### PR TITLE
Remove panics, add --help/-h flag for usage

### DIFF
--- a/app/options/options.go
+++ b/app/options/options.go
@@ -7,6 +7,7 @@ import (
 )
 
 type KubeRouterConfig struct {
+	HelpRequested      bool
 	Kubeconfig         string
 	Master             string
 	ConfigSyncPeriod   time.Duration
@@ -41,6 +42,7 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 }
 
 func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVarP(&s.HelpRequested, "help", "h", false, "Print usage information.")
 	fs.BoolVar(&s.RunServiceProxy, "run-service-proxy", s.RunServiceProxy, "If false, kube-router wont setup IPVS for services proxy. True by default.")
 	fs.BoolVar(&s.RunFirewall, "run-firewall", s.RunFirewall, "If false, kube-router wont setup iptables to provide ingress firewall for pods. True by default.")
 	fs.BoolVar(&s.RunRouter, "run-router", s.RunRouter, "If true each node advertise routes the rest of the nodes and learn the routes for the pods. True by default.")

--- a/kube-router.go
+++ b/kube-router.go
@@ -18,8 +18,13 @@ func main() {
 
 	flag.Set("logtostderr", "true")
 
+	if config.HelpRequested {
+		pflag.Usage()
+		os.Exit(0)
+	}
+
 	if os.Geteuid() != 0 {
-		fmt.Fprintf(os.Stderr, "kube-router need to be run by user with previlages to execute iptables, ipset and configure ipvs\n")
+		fmt.Fprintf(os.Stderr, "kube-router needs to be run with privileges to execute iptables, ipset and configure ipvs\n")
 		os.Exit(1)
 	}
 
@@ -34,7 +39,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = kubeRouter.Run(); err != nil {
+	err = kubeRouter.Run()
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to run kube-router: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Add some extra context to errors for debugging as well.  Tested on my local cluster with quay.io/bzub/kube-router:graceful-cli