### PR TITLE
NetworkServiceController: Add hairpin-mode support

### DIFF
--- a/app/controllers/network_services_controller.go
+++ b/app/controllers/network_services_controller.go
@@ -172,8 +172,9 @@ func (nsc *NetworkServicesController) OnServiceUpdate(serviceUpdate *watchers.Se
 	}
 }
 
-// sync the ipvs service and server details configured to reflect the desired state of services and endpoint
-// as learned from services and endpoints information from the api server
+// sync the ipvs service and server details configured to reflect the desired
+// state of services and endpoint as learned from services and endpoints
+// information from the api server
 func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInfoMap, endpointsInfoMap endpointsInfoMap) {
 
 	start := time.Now()
@@ -195,7 +196,8 @@ func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInf
 			protocol = syscall.IPPROTO_UDP
 		}
 
-		// assign cluster IP of the service to the dummy interface so that its routable from the pod's on the node
+		// assign cluster IP of the service to the dummy interface so that its
+		// routable from the pod's on the node
 		vip := &netlink.Addr{IPNet: &net.IPNet{svc.clusterIP, net.IPv4Mask(255, 255, 255, 255)}, Scope: syscall.RT_SCOPE_LINK}
 		err := netlink.AddrAdd(dummyVipInterface, vip)
 		if err != nil && err.Error() != IFACE_HAS_ADDR {
@@ -234,17 +236,23 @@ func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInf
 				Port:          uint16(endpoint.port),
 				Weight:        1,
 			}
+
 			err := ipvsAddServer(ipvs_cluster_vip_svc, &dst)
 			if err != nil {
 				glog.Errorf(err.Error())
 			}
-			activeServiceEndpointMap[clusterServiceId] = append(activeServiceEndpointMap[clusterServiceId], endpoint.ip)
+
+			activeServiceEndpointMap[clusterServiceId] =
+				append(activeServiceEndpointMap[clusterServiceId], endpoint.ip)
+
 			if svc.nodePort != 0 {
 				err := ipvsAddServer(ipvs_nodeport_svc, &dst)
-				activeServiceEndpointMap[nodeServiceId] = append(activeServiceEndpointMap[clusterServiceId], endpoint.ip)
 				if err != nil {
 					glog.Errorf(err.Error())
 				}
+
+				activeServiceEndpointMap[nodeServiceId] =
+					append(activeServiceEndpointMap[clusterServiceId], endpoint.ip)
 			}
 		}
 	}
@@ -313,6 +321,7 @@ func buildServicesInfo() serviceInfoMap {
 				protocol:  strings.ToLower(string(port.Protocol)),
 				nodePort:  int(port.NodePort),
 			}
+
 			svcInfo.sessionAffinity = (svc.Spec.SessionAffinity == "ClientIP")
 			svcId := generateServiceId(svc.Namespace, svc.Name, port.Name)
 			serviceMap[svcId] = &svcInfo

--- a/app/controllers/network_services_controller.go
+++ b/app/controllers/network_services_controller.go
@@ -502,17 +502,18 @@ func (nsc *NetworkServicesController) syncHairpinIptablesRules() error {
 	return nil
 }
 
-func hairpinRuleFrom(serviceIP string, endpointIP string) (string, []string) {
+func hairpinRuleFrom(serviceIP string, endpointIP string, servicePort int) (string, []string) {
 	// TODO: Factor hairpinChain out
 	hairpinChain := "KUBE-ROUTER-HAIRPIN"
 
 	ruleArgs := []string{"-s", endpointIP + "/32", "-d", endpointIP + "/32",
-		"-m", "ipvs", "--vaddr", serviceIP, "-j", "SNAT", "--to-source", serviceIP}
+		"-m", "ipvs", "--vaddr", serviceIP, "--vport", strconv.Itoa(servicePort),
+		"-j", "SNAT", "--to-source", serviceIP}
 
 	// Trying to ensure this matches iptables.List()
 	ruleString := "-A " + hairpinChain + " -s " + endpointIP + "/32" + " -d " +
-		endpointIP + "/32" + " -m ipvs" + " --vaddr " + serviceIP + " -j SNAT" +
-		" --to-source " + serviceIP
+		endpointIP + "/32" + " -m ipvs" + " --vaddr " + serviceIP + " --vport " +
+		strconv.Itoa(servicePort) + " -j SNAT" + " --to-source " + serviceIP
 
 	return ruleString, ruleArgs
 }

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -25,6 +25,7 @@ type KubeRouterConfig struct {
 	ClusterAsn         string
 	PeerAsn            string
 	FullMeshMode       bool
+	GlobalHairpinMode  bool
 }
 
 func NewKubeRouterConfig() *KubeRouterConfig {
@@ -37,7 +38,8 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		RunFirewall:        true,
 		RunRouter:          true,
 		FullMeshMode:       true,
-		AdvertiseClusterIp: false}
+		AdvertiseClusterIp: false,
+		GlobalHairpinMode:  false}
 }
 
 func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
@@ -59,4 +61,5 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.PeerAsn, "peer-asn", s.PeerAsn, "ASN number of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", s.FullMeshMode, "When enabled each node in the cluster will setup BGP peer with rest of the nodes. True by default")
 	fs.StringVar(&s.HostnameOverride, "hostname-override", s.HostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
+	fs.BoolVar(&s.GlobalHairpinMode, "hairpin-mode", s.GlobalHairpinMode, "Adds iptable rules for every ClusterIP Service Endpoint to support hairpin traffic. False by default")
 }


### PR DESCRIPTION
Tested on my local cluster with quay.io/bzub/kube-router:hairpin-mode

Fixes #9

Test examples:
```
kubectl -n default run alpine --command --image alpine --replicas 2 --port 80 --expose sleep 300d
```

IPs:
```console
$kubectl -n default get pods,services,endpoints -o wide
NAME                         READY     STATUS    RESTARTS   AGE       IP         NODE
po/alpine-4025682865-7r4tw   1/1       Running   0          1h        10.2.0.2   node3-test.zbrbdl
po/alpine-4025682865-pqdfr   1/1       Running   0          1h        10.2.1.8   node2-test.zbrbdl

NAME             CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE       SELECTOR
svc/alpine       10.3.0.64    <none>        80/TCP    1h        run=alpine
svc/kubernetes   10.3.0.1     <none>        443/TCP   1h        <none>

NAME            ENDPOINTS                 AGE
ep/alpine       10.2.0.2:80,10.2.1.8:80   1h
ep/kubernetes   10.10.3.3:443             1h
```

iptables on nodes:
```console
$ for i in node2-test node3-test
$ do
$   echo ${i}
$   ssh ${i} 'sudo iptables -t nat -S|grep -F KUBE-ROUTER'
$   echo
$ done
node2-test
-N KUBE-ROUTER-HAIRPIN
-A POSTROUTING -m ipvs --vdir ORIGINAL -j KUBE-ROUTER-HAIRPIN
-A KUBE-ROUTER-HAIRPIN -s 10.2.0.2/32 -d 10.2.0.2/32 -m ipvs --vaddr 10.3.0.64 -j SNAT --to-source 10.3.0.64
-A KUBE-ROUTER-HAIRPIN -s 10.2.1.8/32 -d 10.2.1.8/32 -m ipvs --vaddr 10.3.0.64 -j SNAT --to-source 10.3.0.64

node3-test
  -N KUBE-ROUTER-HAIRPIN
  -A POSTROUTING -m ipvs --vdir ORIGINAL -j KUBE-ROUTER-HAIRPIN
  -A KUBE-ROUTER-HAIRPIN -s 10.2.0.2/32 -d 10.2.0.2/32 -m ipvs --vaddr 10.3.0.64 -j SNAT --to-source 10.3.0.64
-A KUBE-ROUTER-HAIRPIN -s 10.2.1.8/32 -d 10.2.1.8/32 -m ipvs --vaddr 10.3.0.64 -j SNAT --to-source 10.3.0.64
```

Log into both pods:
```bash
for i in $(kd get pods -l run=alpine --output name)
  do
  kd exec -it $(basename ${i}) sh
done
```

Run httpd server and access it via Service IP:
```console
/ # hostname
alpine-4025682865-7r4tw
alpine-4025682865-pqdfr

/ # nohup httpd -fv &

/ # netstat -lnp                                     
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name    
tcp        0      0 :::80                   :::*                    LISTEN      9/httpd

/ # while true; do wget alpine.default; done
Connecting to alpine.default (10.3.0.64:80)
wget: server returned error: HTTP/1.0 404 Not Found
Connecting to alpine.default (10.3.0.64:80)
wget: server returned error: HTTP/1.0 404 Not Found
Connecting to alpine.default (10.3.0.64:80)
wget: server returned error: HTTP/1.0 404 Not Found
Connecting to alpine.default (10.3.0.64:80)
wget: server returned error: HTTP/1.0 404 Not Found
Connecting to alpine.default (10.3.0.64:80)

/ # tail nohup.out (pod1)
[::ffff:10.2.0.2]:58120: response:404
[::ffff:10.3.0.64]:34658: response:404
[::ffff:10.2.0.2]:58124: response:404
[::ffff:10.3.0.64]:34662: response:404
[::ffff:10.2.0.2]:58128: response:404
[::ffff:10.3.0.64]:34666: response:404
[::ffff:10.2.0.2]:58132: response:404
[::ffff:10.3.0.64]:34670: response:404
[::ffff:10.3.0.64]:34674: response:404
[::ffff:10.2.0.2]:58136: response:404

/ # tail nohup.out (pod2)
[::ffff:10.3.0.64]:58118: response:404
[::ffff:10.2.1.8]:34656: response:404
[::ffff:10.3.0.64]:58122: response:404
[::ffff:10.2.1.8]:34660: response:404
[::ffff:10.3.0.64]:58126: response:404
[::ffff:10.2.1.8]:34664: response:404
[::ffff:10.3.0.64]:58130: response:404
[::ffff:10.2.1.8]:34668: response:404
[::ffff:10.3.0.64]:58134: response:404
[::ffff:10.2.1.8]:34672: response:404
```