### PR TITLE
CI: Automated build/release workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/kube-router

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,18 @@
+builds:
+- goos:
+  - linux
+  goarch:
+  - amd64
+  env:
+  - CGO_ENABLED=0
+archive:
+  format: tar.gz
+  name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
+    .Arm }}{{ end }}'
+  files:
+  - LICENSE*
+  - README*
+  - CHANGELOG*
+  - Documentation*
+snapshot:
+  name_template: SNAPSHOT-{{ .Commit }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,46 @@ services:
   - docker
 
 language: go
-go: 
+go:
   - 1.7.x
 
 env:
-  - REPO=cloudnativelabs/kube-router
-after_success:
-    - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-    - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "master"; else echo $TRAVIS_BRANCH ; fi`
-    - docker build -f Dockerfile -t "$REPO":"$TRAVIS_COMMIT" .
-    - docker tag "$REPO":"$TRAVIS_COMMIT" "$REPO":"$TAG"
-    - if [ ! -z ${TRAVIS_TAG+x} ]; then
-          docker tag "$REPO":"$TRAVIS_COMMIT" "$REPO":"$TRAVIS_TAG";
-          docker tag "$REPO":"$TRAVIS_COMMIT" "$REPO":"latest";
-      fi
-    - docker push "$REPO"
- 
+  global:
+    - IMG_FQDN=quay.io
+    - REPO=cloudnativelabs/kube-router
+    - REPO_PATH=$HOME/gopath/src/github.com/$REPO
+
 script:
- - make all 
+  - make all
+
+after_success:
+  # All successfully built commits get an image placed in the kube-router-git
+  # image repo and tagged with the commit hash.
+  - make push
+
+deploy:
+  # Images from Pull Requests get tagged with the PR number.
+  - provider: script
+    on:
+      condition: $TRAVIS_PULL_REQUEST != "false"
+    skip_cleanup: true
+    script:
+      - make push IMG_PREFIX=PR$TRAVIS_PULL_REQUEST-
+
+  # Images from tagged commits get released.
+  - provider: script
+    on:
+      tags: true
+      # condition: $TRAVIS_PULL_REQUEST == "false"
+    skip_cleanup: true
+    script:
+      - unset IMG_FQDN # Use DockerHub for releases
+      - make release
+
+# This fixes issues when a contributor uses their own Travis CI account to test
+# code/CI changes.
+before_install:
+  - mkdir -p $REPO_PATH
+  - rsync -az ${TRAVIS_BUILD_DIR}/ $REPO_PATH
+  - export TRAVIS_BUILD_DIR=$REPO_PATH
+  - cd $REPO_PATH

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,11 +11,13 @@ Please read [users guide](./Documentation/README.md#user-guide) and [developers 
 
 If you have a question about Kube-router or have a problem using it, please start with contacting us on [community forum](https://gitter.im/kube-router/Lobby) for quick help. If that doesn't answer your questions, or if you think you found a bug, please [file an issue](https://github.com/cloudnativelabs/kube-router/issues).
 
-## Submit PR
+## Contributing Changes
 
 ### Fork the code
 
-Navigate to: [https://github.com/cloudnativelabs/kube-router](https://github.com/cloudnativelabs/kube-router) fork the repository.
+Navigate to:
+[https://github.com/cloudnativelabs/kube-router](https://github.com/cloudnativelabs/kube-router)
+and fork the repository.
 
 Follow these steps to setup a local repository for working on Kube-router:
 
@@ -28,7 +30,7 @@ $ git fetch upstream
 $ git rebase upstream/master
 ```
 
-### Making changes and raising PR
+### Creating A Feature Branch
 
 Create a new branch to make changes on and that branch.
 
@@ -50,6 +52,8 @@ $ git rebase master
 ```
 
 Now your `feature_x` branch is up-to-date with all the code in `upstream/master`, so push to your fork
+
+### Performing A Pull Request
 
 ``` bash
 $ git push origin master

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -176,13 +176,6 @@ To enable hairpin traffic for Service `my-service`:
 kubectl annotate service my-service 'kube-router.io/hairpin-mode='
 ```
 
-## Develope Guide
-
-**Go version 1.7 or above is required to build kube-router**
-
-All the dependencies are vendored already, so just run  *make build* or *go build -o kube-router kube-router.go* to build
-
-Alternatively you can download the prebuilt binary from https://github.com/cloudnativelabs/kube-router/releases
 
 ## BGP configuration
 

--- a/Documentation/developing.md
+++ b/Documentation/developing.md
@@ -1,0 +1,155 @@
+# Developer's Guide
+
+We aim to make local development and testing as straightforward as possible. For
+basic guidelines around contributing, see the [CONTRIBUTING](/CONTRIBUTING.md) document.
+
+There are a number of automation tools available to help with testing and
+building your changes, detailed below.
+
+## Building kube-router
+
+**Go version 1.7 or above is required to build kube-router**
+
+All the dependencies are vendored already, so just run `make` or `go build -o kube-router kube-router.go` to build.
+
+### Building A Docker Image
+
+Running `make container` will compile kube-router (if needed) and build a Docker
+image.  By default the container will be tagged with the last release version,
+and current commit ID.
+
+For example:
+```console
+$ make container
+docker build -t "cloudnativelabs/kube-router-git:0.0.4-22-gd782e89-dirty-build-release"
+Sending build context to Docker daemon  151.5MB
+Step 1/4 : FROM alpine
+ ---> a41a7446062d
+Step 2/4 : RUN apk add --no-cache iptables ipset
+ ---> Using cache
+ ---> 30e25a7640de
+Step 3/4 : COPY kube-router /
+ ---> Using cache
+ ---> c06f78fd02e8
+Step 4/4 : ENTRYPOINT /kube-router
+ ---> Using cache
+ ---> 5cfcfe54623e
+Successfully built 5cfcfe54623e
+Successfully tagged cloudnativelabs/kube-router-git:0.0.4-22-gd782e89-dirty-build-release
+```
+
+The `-dirty` part of the tag means there are uncommitted changes in your local
+git repo.
+
+### Pushing A Docker Image
+
+Running `make push` will push your container image to a Docker registry.  The
+default configuration will use the Docker Hub repository for the official
+kube-router images, cloudnativelabs/kube-router. You can push to a different
+repository by changing a couple settings, as described in [Image Options](#image-options)
+below.
+
+### Makefile Options
+
+There are several variables which can be modified in the Makefile to customize
+your builds. They are specified after your make command like this: `make OPTION=VALUE`.
+These options can also be set in your environment variables.
+For more details beyond the scope of this document, see the
+[Makefile](/Makefile) and run `make help`.
+
+#### Image Options
+
+You can configure the name and tag of the Docker image with a few variables
+passed to `make container` and `make push`.
+
+Example:
+```console
+$ make container IMG_FQDN=quay.io IMG_NAMESPACE=bzub IMAGE_TAG=custom
+docker build -t "quay.io/bzub/kube-router-git:custom" .
+Sending build context to Docker daemon  151.5MB
+Step 1/4 : FROM alpine
+ ---> a41a7446062d
+Step 2/4 : RUN apk add --no-cache iptables ipset
+ ---> Using cache
+ ---> 30e25a7640de
+Step 3/4 : COPY kube-router /
+ ---> Using cache
+ ---> c06f78fd02e8
+Step 4/4 : ENTRYPOINT /kube-router
+ ---> Using cache
+ ---> 5cfcfe54623e
+Successfully built 5cfcfe54623e
+Successfully tagged quay.io/bzub/kube-router-git:custom
+```
+
+- `REGISTRY` is derived from other options. Set this to something else to
+  quickly override the Docker image registry used to tag and push images.
+  - Note: This will override other variables below that make up the image
+    name/tag.
+- `IMG_FQDN` should be set if you are not using Docker Hub for images. In
+  the examples above `IMG_FQDN` is set to `quay.io`.
+- `IMG_NAMESPACE` is the Docker registry user or organization.  It is used in
+  URLs.
+  - Example: quay.io/IMG_NAMESPACE/kube-router
+- `NAME` goes onto the end of the Docker registry URL that will be used.
+  - Example: quay.io/cloudnativelabs/NAME
+- `IMAGE_TAG` is used to override the tag of the Docker image being built.
+- `DEV_SUFFIX` is appended to Docker image names that are not for release.  By
+  default these images get a name ending with `-git` to signify that they are
+  for testing purposes.
+  Example (DEV-SUFFIX=master-latest): quay.io/cloudnativelabs/kube-router-git:master-latest
+
+## Release Workflow
+
+These instructions show how official kube-router releases are performed.
+
+First, you must tag a git commit with the release version.
+This will cause the CI system to:
+- Build kube-router
+- Build a Docker image with ${VERSION} and `latest` tags
+- Push the Docker image to the official registry
+- Submits a draft release to GitHub
+
+Example:
+```
+VERSION=v0.5.0
+git tag -a ${VERSION} -m "Brief release note" && git push origin ${VERSION}
+```
+
+Then the only thing left to do is edit the release notes on the GitHub release
+and publish it.
+
+### Manual Releases
+
+These instructions show how To perform a custom or test release outside of the
+CI system, using a local git commit.
+
+First tag a commit:
+```
+VERSION=v0.5.0_bzub
+git tag -a ${VERSION} -m "Brief release note"
+```
+
+Then you can provide
+[options](#makefile-options) to `make release`.
+
+This does the following:
+- Builds kube-router
+- Builds a Docker image
+- Tags the image with the current git commit's tag
+- Tags the image with `latest`
+- Pushes the image to a docker registry
+
+If you'd like to test the GitHub release functionality as well, you will need to
+pass in the `GITHUB_TOKEN` variable with a value of an API token you've
+[generated](https://github.com/settings/tokens/new). This Access Token must have
+the "repo" OAuth scope enabled.
+
+NOTE: For added security when running a command that contains secure
+credentials, add a space before the entire command to prevent it from being
+added to your shell history file.
+
+Example:
+```console
+$  make release IMG_FQDN=quay.io IMG_NAMESPACE=bzub GITHUB_TOKEN=b1ahbl1ahb1ahba1hahb1ah
+```

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,118 @@
-all: dockerimg
+NAME?=kube-router
+DEV_SUFFIX?=-git
+LOCAL_PACKAGES?=app app/controllers app/options app/watchers
+IMG_NAMESPACE?=cloudnativelabs
+IMG_TAG?=$(shell git describe --tags --dirty)
+GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
+RELEASE_TAG?=$(shell build/get-git-tag.sh)
+REGISTRY?=$(if $(IMG_FQDN),$(IMG_FQDN)/$(IMG_NAMESPACE)/$(NAME),$(IMG_NAMESPACE)/$(NAME))
+REGISTRY_DEV?=$(REGISTRY)$(DEV_SUFFIX)
+IN_DOCKER_GROUP=$(filter docker,$(shell groups))
+IS_ROOT=$(filter 0,$(shell id -u))
+DOCKER=$(if $(or $(IN_DOCKER_GROUP),$(IS_ROOT)),docker,sudo docker)
+MAKEFILE_DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+UPSTREAM_IMPORT_PATH=$(GOPATH)/src/github.com/cloudnativelabs/kube-router/
 
-dockerimg: build
-	sudo docker build -t "cloudnativelabs/kube-router" .
+all: test kube-router container ## Default target. Runs tests, builds binaries and images.
 
-build:
-	go build --ldflags '-extldflags "-static"' -o kube-router kube-router.go
+kube-router: $(shell find . -name \*.go) ## Builds kube-router.
+	CGO_ENABLED=0 go build -o kube-router kube-router.go
 
-clean:
+test: gofmt ## Runs code quality pipelines (gofmt, tests, coverage, lint, etc)
+
+run: kube-router ## Runs "kube-router --help".
+	./kube-router --help
+
+container: kube-router ## Builds a Docker container image.
+	$(DOCKER) build -t "$(REGISTRY_DEV):$(IMG_PREFIX)$(IMG_TAG)" .
+
+docker-login:
+	@if [ -z "$(NO_DOCKER_LOGIN)" ]; then \
+	    $(DOCKER) login -u="$(value DOCKER_USERNAME)" -p="$(value DOCKER_PASSWORD)"; \
+	fi
+
+	@if [ -z "$(NO_QUAY_LOGIN)" ]; then \
+	    $(DOCKER) login -u="$(value QUAY_USERNAME)" -p="$(value QUAY_PASSWORD)" quay.io; \
+	fi
+
+push: container docker-login ## Pushes a Docker container image to a registry.
+	$(DOCKER) tag "$(REGISTRY_DEV):$(IMG_TAG)" "$(REGISTRY_DEV):$(GIT_BRANCH)-latest"
+	$(DOCKER) push "$(REGISTRY_DEV)"
+
+push-release: push
+	@test -n "$(RELEASE_TAG)"
+	$(DOCKER) tag "$(REGISTRY_DEV):$(IMG_TAG)" "$(REGISTRY):$(RELEASE_TAG)"
+	$(DOCKER) tag "$(REGISTRY):$(RELEASE_TAG)" "$(REGISTRY):latest"
+	$(DOCKER) push "$(REGISTRY)"
+
+github-release: kube-router
+	@[ -n "$(value GITHUB_TOKEN)" ] && \
+	  GITHUB_TOKEN=$(value GITHUB_TOKEN); \
+	  curl -sL https://git.io/goreleaser | bash
+
+release: push-release github-release ## Pushes a release to DockerHub and GitHub
+
+clean: ## Removes the kube-router binary and Docker images
 	rm -f kube-router
+	$(DOCKER) rmi $(REGISTRY_DEV)
+	$(DOCKER) rmi $(REGISTRY)
 
-run:
-	./kube-router --kubeconfig=/var/lib/kube-router/kubeconfig
+gofmt: ## Tells you what files need to be gofmt'd.
+	@build/verify-gofmt.sh
+
+gofmt-fix: ## Fixes files that need to be gofmt'd.
+	gofmt -s -w $(LOCAL_PACKAGES)
+
+gopath: ## Warns about issues building from a directory that does not match upstream.
+	@echo 'Checking project path for import issues...'
+	@echo '- Project dir: $(MAKEFILE_DIR)'
+	@echo '- Import dir:  $(UPSTREAM_IMPORT_PATH)'
+	@echo
+ifeq ($(MAKEFILE_DIR),$(UPSTREAM_IMPORT_PATH))
+	@echo 'Looks good!'
+else
+	@echo 'The project directory does not match $(UPSTREAM_IMPORT_PATH)'
+	@echo
+	@echo 'This could cause build issues. Consider moving this project'
+	@echo 'directory to $(UPSTREAM_IMPORT_PATH) and work from there.'
+	@echo 'This could be done for you by running: "make gopath-fix".'
+	@echo
+endif
+
+# This fixes GOPATH issues for contributers using their own Travis-CI account
+# with their forked kube-router repo. It's also useful for contributors testing
+# code and CI changes with their own Travis account.
+gopath-fix: ## Copies this project directory to the upstream import path.
+ifneq ($(wildcard $(UPSTREAM_IMPORT_PATH)/.*),)
+	@echo
+	@echo '$(UPSTREAM_IMPORT_PATH) already exists.'
+	@echo 'Aborting gopath-fix.'
+	@echo
+else
+	@echo
+	@echo 'Copying $(MAKEFILE_DIR) to $(UPSTREAM_IMPORT_PATH)'
+	@echo
+	mkdir -p "$(UPSTREAM_IMPORT_PATH)"
+	cp -ar $(MAKEFILE_DIR)/. "$(UPSTREAM_IMPORT_PATH)"
+	@echo
+	@echo 'Success! Please use $(UPSTREAM_IMPORT_PATH)'
+	@echo
+endif
+
+# http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	  awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+# TODO: Uncomment this target when all deps are version-pinned in glide.yaml
+# update-glide:
+# 	# go get -d -u github.com/Masterminds/glide
+# 	glide update --strip-vendor
+# 	# go get -d -u github.com/sgotti/glide-vc
+# 	glide vc --only-code --no-tests
+
+.PHONY: build clean container run release goreleaser push gofmt gofmt-fix
+.PHONY: update-glide test docker-login push-release github-release help
+.PHONY: gopath gopath-fix
+
+.DEFAULT: all

--- a/app/controllers/network_policy_controller.go
+++ b/app/controllers/network_policy_controller.go
@@ -222,7 +222,7 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains() (map[string]bool, 
 		if destPodIpSet.Flush() != nil {
 			return nil, fmt.Errorf("failed to flush ipset while syncing iptables: %s", err.Error())
 		}
-		for k, _ := range policy.destPods {
+		for k := range policy.destPods {
 			// TODO restrict ipset to ip's of pods running on the node
 			destPodIpSet.Add(k, 0)
 		}

--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -287,7 +287,7 @@ func (nrc *NetworkRoutingController) syncPeers() {
 
 	// find the list of the node removed, from the last known list of active nodes
 	removedNodes := make([]string, 0)
-	for ip, _ := range activeNodes {
+	for ip := range activeNodes {
 		stillActive := false
 		for _, node := range currentNodes {
 			if ip == node {

--- a/app/watchers/node_watcher.go
+++ b/app/watchers/node_watcher.go
@@ -13,7 +13,7 @@ import (
 
 type NodeUpdate struct {
 	Node *api.Node
-	Op  Operation
+	Op   Operation
 }
 
 var (
@@ -21,10 +21,10 @@ var (
 )
 
 type nodeWatcher struct {
-	clientset     *kubernetes.Clientset
+	clientset      *kubernetes.Clientset
 	nodeController cache.Controller
 	nodeLister     cache.Indexer
-	broadcaster   *utils.Broadcaster
+	broadcaster    *utils.Broadcaster
 }
 
 type NodeUpdatesHandler interface {

--- a/build/get-git-tag.sh
+++ b/build/get-git-tag.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+git describe --exact-match || echo -n
+
+# if [ -z "${RELEASE_TAG}" ]; then
+#     echo "Commit is not tagged. Release aborted."
+#     exit 1
+# else
+#     echo "${RELEASE_TAG}"
+# fi

--- a/build/verify-gofmt.sh
+++ b/build/verify-gofmt.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename '*/vendor/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+GOFMT="gofmt -s"
+bad_files=$(find_files | xargs $GOFMT -l)
+if [[ -n "${bad_files}" ]]; then
+  echo "gofmt wants to change the following files: "
+  echo "${bad_files}"
+  echo
+  echo "Run \"make gofmt-fix\"."
+  echo "or"
+  echo "Run \"${GOFMT} -w\" on each file."
+  exit 1
+fi

--- a/utils/node.go
+++ b/utils/node.go
@@ -1,12 +1,12 @@
 package utils
 
 import (
-	"os"
 	"fmt"
+	"os"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetNodeObject(clientset *kubernetes.Clientset, hostnameOverride string) (*apiv1.Node, error) {


### PR DESCRIPTION
WIP. Do not merge.

TODO:
- [x] Just need to modify travis.yml to use the new Makefile features

See the new releasing guide in the CONTRIBUTING doc and the new Makefile for design details.

Also here's an example of a custom release pushing images to a registry: https://quay.io/repository/cloudnativelabs/kube-router?tag=latest&tab=tags

So when the official release workflow is used with Travis-CI, we should see a clean dockerhub repo of released + latest tag.

Here's an example of a kube-router-git repo for per-commit and PR images: https://quay.io/repository/cloudnativelabs/kube-router-git?tag=latest&tab=tags