### PR TITLE
services-controller: Add LoadBalancer Service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ leverages standard Linux technologies **iptables, ipvs/lvs, ipset, iproute2**
 [Kubernetes network services proxy with IPVS/LVS](https://cloudnativelabs.github.io/post/2017-05-10-kube-network-service-proxy/)
 
 Kube-router uses IPVS/LVS technology built in Linux to provide L4 load
-balancing. Each **ClusterIP** and **NodePort** Kubernetes Service type is
-configured as an IPVS virtual service. Each Service Endpoint is configured as
-real server to the virtual service.  The standard **ipvsadm** tool can be used
-to verify the configuration and monitor the active connections.
+balancing. Each **ClusterIP**, **NodePort**, and **LoadBalancer** Kubernetes
+Service type is configured as an IPVS virtual service. Each Service Endpoint is
+configured as real server to the virtual service.  The standard **ipvsadm** tool
+can be used to verify the configuration and monitor the active connections.
 
 Below is example set of Services on Kubernetes:
 

--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -118,7 +118,7 @@ func (nrc *NetworkRoutingController) Run(stopCh <-chan struct{}, wg *sync.WaitGr
 		if nrc.advertiseClusterIp {
 			glog.Infof("Advertising cluster ips")
 			for _, svc := range watchers.ServiceWatcher.List() {
-				if svc.Spec.Type == "ClusterIP" || svc.Spec.Type == "NodePort" {
+				if svc.Spec.Type == "ClusterIP" || svc.Spec.Type == "NodePort" || svc.Spec.Type == "LoadBalancer" {
 
 					// skip headless services
 					if svc.Spec.ClusterIP == "None" || svc.Spec.ClusterIP == "" {

--- a/app/controllers/network_services_controller.go
+++ b/app/controllers/network_services_controller.go
@@ -34,7 +34,7 @@ var (
 )
 
 // Network services controller enables local node as network service proxy through IPVS/LVS.
-// Support only Kuberntes network services of type NodePort, ClusterIP. For each service a
+// Support only Kubernetes network services of type NodePort, ClusterIP, and LoadBalancer. For each service a
 // IPVS service is created and for each service endpoint a server is added to the IPVS service.
 // As services and endpoints are updated, network service controller gets the updates from
 // the kubernetes api server and syncs the ipvs configuration to reflect state of services
@@ -317,7 +317,7 @@ func buildServicesInfo() serviceInfoMap {
 			continue
 		}
 
-		if svc.Spec.Type == "LoadBalancer" || svc.Spec.Type == "ExternalName" {
+		if svc.Spec.Type == "ExternalName" {
 			glog.Infof("Skipping service name:%s namespace:%s due to service Type=%s", svc.Name, svc.Namespace, svc.Spec.Type)
 			continue
 		}

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -63,5 +63,5 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.PeerAsn, "peer-asn", s.PeerAsn, "ASN number of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", s.FullMeshMode, "When enabled each node in the cluster will setup BGP peer with rest of the nodes. True by default")
 	fs.StringVar(&s.HostnameOverride, "hostname-override", s.HostnameOverride, "If non-empty, will use this string as identification instead of the actual hostname.")
-	fs.BoolVar(&s.GlobalHairpinMode, "hairpin-mode", s.GlobalHairpinMode, "Adds iptable rules for every ClusterIP Service Endpoint to support hairpin traffic. False by default")
+	fs.BoolVar(&s.GlobalHairpinMode, "hairpin-mode", s.GlobalHairpinMode, "Adds iptable rules for every Service Endpoint to support hairpin traffic. False by default")
 }


### PR DESCRIPTION
Fixes  #51 

Tested with kops + AWS.

### Testing steps
Start a simple http server deployment:
```console
kubectl -n default run alpine --command --image alpine --replicas 2 --port 80 -- httpd -fv
```
Expose as LB type service:
```console
kubectl -n default expose deployment alpine --port 8888 --target-port 80 --type=LoadBalancer
```

Check Services and EPs:
```
$ kubectl -n default get service,ep -o wide
NAME             CLUSTER-IP      EXTERNAL-IP                                                              PORT(S)          AGE       SELECTOR 
svc/alpine       100.69.95.246   aa5fdbd3a667c11e7b2ff0691ff4e598-286081594.us-west-2.elb.amazonaws.com   8888:32667/TCP   17m       run=alpine                                  
svc/kubernetes   100.64.0.1      <none>                                                                   443/TCP          35m       <none>   

NAME            ENDPOINTS                     AGE                      
ep/alpine       100.96.1.3:80,100.96.2.4:80   17m                      
ep/kubernetes   172.20.43.207:443             35m
```

Hit the external LB IP, got a 404 from the server (OK).
```
curl aa5fdbd3a667c11e7b2ff0691ff4e598-286081594.us-west-2.elb.amazonaws.com:8888
<HTML><HEAD><TITLE>404 Not Found</TITLE></HEAD>
<BODY><H1>404 Not Found</H1>
The requested URL was not found
</BODY></HTML>
```

Check http server logs:
```bash
for i in $(kubectl -n default get pods -l run=alpine --output name)
do
  kubectl -n default logs $(basename ${i})
done
```
output snippet:
```log
[::ffff:172.20.43.207]:10950: response:404                             
[::ffff:172.20.56.29]:10974: response:400                              
[::ffff:100.96.1.1]:31853: response:400                                
[::ffff:172.20.43.207]:57604: response:400                             
[::ffff:172.20.56.29]:10984: response:400                              
[::ffff:100.96.1.1]:31873: response:400                                
[::ffff:172.20.43.207]:57624: response:400                             
[::ffff:172.20.56.29]:11000: response:400                              
[::ffff:100.96.1.1]:31889: response:400                                
```