### PR TITLE
on BGP peer down, advertised route from peer is not cleaned-up in local routing table

### DIFF
--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -223,6 +223,10 @@ func (nrc *NetworkRoutingController) injectRoute(path *table.Path) error {
 		Protocol: 0x11,
 	}
 
+	if path.IsWithdraw {
+		glog.Infof("Removing route: '%s via %s' from peer in the routing table", dst, nexthop)
+		return netlink.RouteDel(route)
+	}
 	glog.Infof("Inject route: '%s via %s' from peer to routing table", dst, nexthop)
 	return netlink.RouteReplace(route)
 }


### PR DESCRIPTION

Fixes #69