### PR TITLE
fix null pointer dereference during kube-router --cleanup-config

### DIFF
--- a/app/controllers/network_services_controller.go
+++ b/app/controllers/network_services_controller.go
@@ -767,7 +767,14 @@ func getKubeDummyInterface() (netlink.Link, error) {
 func (nsc *NetworkServicesController) Cleanup() {
 	// cleanup ipvs rules by flush
 	glog.Infof("Cleaning up IPVS configuration permanently")
-	err := h.Flush()
+
+	handle, err := libipvs.New()
+	if err != nil {
+		glog.Errorf("Failed to cleanup ipvs rules: ", err.Error())
+		return
+	}
+
+	err = handle.Flush()
 	if err != nil {
 		glog.Errorf("Failed to cleanup ipvs rules: ", err.Error())
 		return


### PR DESCRIPTION
Fixes #79