### PR TITLE
Add build-image folder, which allows to build kube-router on mac os

### DIFF
--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,0 +1,18 @@
+from centos:7
+
+RUN yum -y install git make
+
+ENV GO_VERSION 1.8.3
+ENV GO_OS   linux
+ENV GO_ARCH amd64 
+
+RUN curl -O -L https://storage.googleapis.com/golang/go$GO_VERSION.$GO_OS-$GO_ARCH.tar.gz && \
+    tar -C /usr/local -xzf go$GO_VERSION.$GO_OS-$GO_ARCH.tar.gz && \
+    mkdir -p /data/go && \
+    export GOPATH=/data/go
+
+COPY entrypoint.sh /bin/
+
+VOLUME [ "/data/go" ]
+
+ENTRYPOINT [ "entrypoint.sh" ]

--- a/build-image/entrypoint.sh
+++ b/build-image/entrypoint.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+export GOPATH=/data/go
+export PATH=$PATH:/usr/local/go/bin
+cd /data/go/src/github.com/cloudnativelabs/kube-router
+make "$@"

--- a/build-image/make.sh
+++ b/build-image/make.sh
@@ -1,0 +1,4 @@
+NAME=kube-router-build
+docker build -t kube-router-build:latest .
+docker rm -f $NAME
+docker run --name=$NAME -v $GOPATH:/data/go kube-router-build:latest


### PR DESCRIPTION
Because of netlink kube-router can't be built on MacOS.

This adds a folder with a "make.sh" script to build kube router.

Integration into Makefile outstanding.