### PR TITLE
Kube-proxy like behaviour to listen on all ip's for NodePort service.

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -117,6 +117,7 @@ Usage of ./kube-router:
     --run-firewall                    Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
     --run-router                      Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
     --run-service-proxy               Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)
+    --nodeport-bindon-all-ip          For service of NodePort type create IPVS service that listens on all IP's of the node. (default false)
 ```
 
 ### requirements

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -7,27 +7,28 @@ import (
 )
 
 type KubeRouterConfig struct {
-	HelpRequested      bool
-	Kubeconfig         string
-	Master             string
-	ConfigSyncPeriod   time.Duration
-	CleanupConfig      bool
-	IPTablesSyncPeriod time.Duration
-	IpvsSyncPeriod     time.Duration
-	RoutesSyncPeriod   time.Duration
-	RunServiceProxy    bool
-	RunFirewall        bool
-	RunRouter          bool
-	MasqueradeAll      bool
-	ClusterCIDR        string
-	EnablePodEgress    bool
-	HostnameOverride   string
-	AdvertiseClusterIp bool
-	PeerRouter         string
-	ClusterAsn         string
-	PeerAsn            string
-	FullMeshMode       bool
-	GlobalHairpinMode  bool
+	HelpRequested       bool
+	Kubeconfig          string
+	Master              string
+	ConfigSyncPeriod    time.Duration
+	CleanupConfig       bool
+	IPTablesSyncPeriod  time.Duration
+	IpvsSyncPeriod      time.Duration
+	RoutesSyncPeriod    time.Duration
+	RunServiceProxy     bool
+	RunFirewall         bool
+	RunRouter           bool
+	MasqueradeAll       bool
+	ClusterCIDR         string
+	EnablePodEgress     bool
+	HostnameOverride    string
+	AdvertiseClusterIp  bool
+	PeerRouter          string
+	ClusterAsn          string
+	PeerAsn             string
+	FullMeshMode        bool
+	GlobalHairpinMode   bool
+	NodePortBindOnAllIp bool
 }
 
 func NewKubeRouterConfig() *KubeRouterConfig {
@@ -81,4 +82,6 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.")
 	fs.BoolVar(&s.GlobalHairpinMode, "hairpin-mode", false,
 		"Add iptable rules for every Service Endpoint to support hairpin traffic.")
+	fs.BoolVar(&s.NodePortBindOnAllIp, "nodeport-bindon-all-ip", false,
+		"For service of NodePort type create IPVS service that listens on all IP's of the node.")
 }


### PR DESCRIPTION
NodePort service listens on all ip/interfaces in case of kube-proxy. Currently kube-router listens only on node IP. This fix introduces flag `nodeport-bindon-all-ip` with which you can have kube-proxy like behaviour. If not specified only nodeIP will be open for connections.

Fixes #139