### PR TITLE
Dynamic gobgpd listener config, fix leaked listener

### DIFF
--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -69,7 +69,7 @@ const (
 	podSubnetIpSetName   = "kube-router-pod-subnets"
 )
 
-// Run runs forever till until we are notified on stop channel
+// Run runs forever until we are notified on stop channel
 func (nrc *NetworkRoutingController) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 	cidr, err := utils.GetPodCidrFromCniSpec("/etc/cni/net.d/10-kuberouter.conf")
 	if err != nil {


### PR DESCRIPTION
partially addresses #155 

This will automatically detect address families that are supported to avoid errors when ipv4 or ipv6 are disabled.  A followup PR will make the address customizable via CLI flags.