### PR TITLE
Add flag to specify external router's MD5 password

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -97,28 +97,30 @@ Also you can choose to run kube-router as agent running on each cluster node. Al
 
 ```
 Usage of ./kube-router:
-    --advertise-cluster-ip            Add Cluster IP to the RIB and advertise to peers.
-    --cleanup-config                  Cleanup iptables rules, ipvs, ipset configuration and exit.
-    --cluster-asn string              ASN number under which cluster nodes will run iBGP.
-    --config-sync-period duration     The delay between apiserver configuration synchronizations (e.g. '5s', '1m').  Must be greater than 0. (default 1m0s)
-    --enable-pod-egress               SNAT traffic from Pods to destinations outside the cluster. (default true)
-    --enable-overlay                  When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
-    --hairpin-mode                    Add iptable rules for every Service Endpoint to support hairpin traffic.
--h, --help                            Print usage information.
-    --hostname-override string        Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.
-    --iptables-sync-period duration   The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
-    --ipvs-sync-period duration       The delay between ipvs config synchronizations (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 1m0s)
-    --kubeconfig string               Path to kubeconfig file with authorization information (the master location is set by the master flag).
-    --masquerade-all                  SNAT all traffic to cluster IP/node port.
-    --master string                   The address of the Kubernetes API server (overrides any value in kubeconfig).
-    --nodes-full-mesh                 Each node in the cluster will setup BGP peering with rest of the nodes. (default true)
-    --peer-asn string                 ASN number of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr.
-    --peer-router string              Comma sepereated list of ip address of the external routers to which all nodes will peer and advertise the cluster ip and pod cidr's.
-    --routes-sync-period duration     The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 1m0s)
-    --run-firewall                    Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
-    --run-router                      Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
-    --run-service-proxy               Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)
-    --nodeport-bindon-all-ip          For service of NodePort type create IPVS service that listens on all IP's of the node. (default false)
+      --advertise-cluster-ip                Add Cluster IP to the RIB and advertise to peers.
+      --cleanup-config                      Cleanup iptables rules, ipvs, ipset configuration and exit.
+      --cluster-asn uint                    ASN number under which cluster nodes will run iBGP.
+      --cluster-cidr string                 CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.
+      --config-sync-period duration         The delay between apiserver configuration synchronizations (e.g. '5s', '1m').  Must be greater than 0. (default 1m0s)
+      --enable-overlay                      When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
+      --enable-pod-egress                   SNAT traffic from Pods to destinations outside the cluster. (default true)
+      --hairpin-mode                        Add iptable rules for every Service Endpoint to support hairpin traffic.
+  -h, --help                                Print usage information.
+      --hostname-override string            Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.
+      --iptables-sync-period duration       The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
+      --ipvs-sync-period duration           The delay between ipvs config synchronizations (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 1m0s)
+      --kubeconfig string                   Path to kubeconfig file with authorization information (the master location is set by the master flag).
+      --masquerade-all                      SNAT all traffic to cluster IP/node port.
+      --master string                       The address of the Kubernetes API server (overrides any value in kubeconfig).
+      --nodeport-bindon-all-ip              For service of NodePort type create IPVS service that listens on all IP's of the node.
+      --nodes-full-mesh                     Each node in the cluster will setup BGP peering with rest of the nodes. (default true)
+      --peer-router-asns uintSlice          ASN numbers of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr. (default [])
+      --peer-router-ips ipSlice             The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's. (default [])
+      --peer-router-passwords stringSlice   Password for authenticating against the BGP peer defined with "--peer-router-ips".
+      --routes-sync-period duration         The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 1m0s)
+      --run-firewall                        Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
+      --run-router                          Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
+      --run-service-proxy                   Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)```
 ```
 
 ### requirements
@@ -178,7 +180,7 @@ and run kube-proxy with the configuration you have.
 
 Communication from a Pod that is behind a Service to its own ClusterIP:Port is
 not supported by default.  However, It can be enabled per-service by adding the
-`kube-router.io/hairpin-mode=` annotation, or for all Services in a cluster by
+`io.kube-router.net.service.hairpin=` annotation, or for all Services in a cluster by
 passing the flag `--hairpin-mode=true` to kube-router.
 
 Additionally, the `hairpin_mode` sysctl option must be set to `1` for all veth
@@ -207,7 +209,7 @@ Service ClusterIP if it is logging the source IP.
 
 To enable hairpin traffic for Service `my-service`:
 ```
-kubectl annotate service my-service 'kube-router.io/hairpin-mode='
+kubectl annotate service my-service "io.kube-router.net.service.hairpin="
 ```
 
 

--- a/Documentation/bgp.md
+++ b/Documentation/bgp.md
@@ -1,48 +1,101 @@
 ## Configuring BGP Peers
 
 When kube-router is used to provide pod-to-pod networking, BGP is used to exchange routes across the nodes. Kube-router
-provides flexible networking models to support different deployment (public vs private cloud, routable vs non-routable 
-pod IP's, service ip's etc) 
+provides flexible networking models to support different deployments (public vs private cloud, routable vs non-routable
+pod IP's, service ip's etc).
 
 ### Full node-to-node mesh
 
-This is the default mode. All nodes in the clusters form iBGP peering relationship with rest of the nodes forming full 
-node-to-node mesh. Each node advertise the pod CIDR allocated to the nodes with peers (rest of the nodes in the cluster). 
-There is no configuration required in this mode. All the nodes in the cluster are associated with private ASN 64512 
-implicitly (which can be configured with `--cluster-asn` flag). Users are transparent to use of iBGP. This mode is
-suitable in public cloud environments or small cluster deployments. In this mode all the nodes are expected to be L2 adjacent.
+This is the default mode. All nodes in the clusters form iBGP peering
+relationship with rest of the nodes forming full node-to-node mesh. Each node
+advertise the pod CIDR allocated to the nodes with peers (rest of the nodes in
+the cluster).  There is no configuration required in this mode. All the nodes in
+the cluster are associated with private ASN 64512 implicitly (which can be
+configured with `--cluster-asn` flag). Users are transparent to use of iBGP.
+This mode is suitable in public cloud environments or small cluster deployments.
+In this mode all the nodes are expected to be L2 adjacent.
 
 ### Node specific BGP peers
 
-This model support more than a single AS per cluster to allow AS per rack or AS per node models. Nodes in the cluster
-does not form full node-to-node mesh. Users has to explicitly select this mode by specifying `--nodes-full-mesh=false` 
-when launching kube-router. In this mode kube-router expects each node is configured with ASN number to be used for the 
-node from the nodes API object annoations. Kube-router will use the configured value for the key `net.kuberouter.nodeasn`
-in the node object as the ASN number for the node.
+This model support more than a single AS per cluster to allow AS per rack or AS
+per node models. Nodes in the cluster does not form full node-to-node mesh.
+Users has to explicitly select this mode by specifying `--nodes-full-mesh=false`
+when launching kube-router. In this mode kube-router expects each node is
+configured with ASN number to be used for the node from the nodes API object
+annoations. Kube-router will use the configured value for the key
+`io.kube-router.net.node.asn` in the node object as the ASN number for the node.
 
-Users can annotate node object with below command
+Users can annotate node objects with the following command:
 
 ```
-kubectl annotate node <kube-node> "net.kuberouter.nodeasn=64512”"
+kubectl annotate node <kube-node> "io.kube-router.net.node.asn=64512"
 ```
 
-Only nodes with in same ASN form full mesh. Two nodes with different configured ASN never gets peered.
+Only nodes with in same ASN form full mesh. Two nodes with different ASNs never
+gets peered.
 
 ### Global BGP Peer
 
-An optional global BGP peer can be configured by specifying `--peer-asn` and `--peer-router` parameters. When configured
-each node in the cluster forms a peer relationship with specified global peer. Pod cidr, cluster IP's get advertised to
-the global BGP peer. For redundancy you can also configure more than one peer router by specifying comma seperated list
-of BGP peers for `--peer-router` flag, like `--peer-router=192.168.1.99,192.168.1.100`
+An optional global BGP peer can be configured by specifying `--peer-router-asns`
+and `--peer-router-ips` parameters. When configured each node in the cluster
+forms a peer relationship with specified global peer. Pod CIDR and Cluster IP's
+get advertised to the global BGP peer. For redundancy you can also configure
+more than one peer router by specifying a slice of BGP peers.
+
+For example:
+```
+--peer-router-ips="192.168.1.99,192.168.1.100"
+--peer-router-asns="65000,65000"
+```
 
 ### Node specific BGP peer
 
-Alternativley, each node can be configured with one or mode node specific BGP peer. Information regarding node specific BGP peer is
-read from node API object annotations `net.kuberouter.node.bgppeer.address` and `net.kuberouter.node.bgppeer.asn`.
+Alternativley, each node can be configured with one or more node specific BGP
+peers. Information regarding node specific BGP peer is read from node API object
+annotations:
+- `io.kube-router.net.peer.ips`
+- `io.kube-router.net.peer.asns`
 
 
 For e.g users can annotate node object with below commands
 ```
-kubectl annotate node <kube-node> “net.kuberouter.node.bgppeer.address=192.168.1.98,192.168.1.99”
-kubectl annotate node <kube-node> "net.kuberouter.node.bgppeer.asn=64513”"
+kubectl annotate node <kube-node> "io.kube-router.net.peer.ips=192.168.1.98,192.168.1.99"
+kubectl annotate node <kube-node> "io.kube-router.net.peer.asns=64513"
+```
+
+### BGP Peer Password Authentication
+
+The examples above have assumed there is no password authentication with BGP
+peer routers. If you need to use a password for peering, you can use the
+`--peer-router-passwords` CLI flag or the `io.kube-router.net.peer.passwords` node
+annotation.
+
+#### Base64 Encoding Passwords
+
+To ensure passwords are easily parsed, but not easily read by human eyes,
+kube-router requires that they are encoded as base64.
+
+On a Linux or MacOS system you can encode your passwords on the command line:
+```
+$ echo "SecurePassword" | base64
+U2VjdXJlUGFzc3dvcmQK
+```
+
+#### Password Configuration Examples
+
+In this CLI flag example the first router (192.168.1.99) uses a password, while
+the second (192.168.1.100) does not.
+```
+--peer-router-ips="192.168.1.99,192.168.1.100"
+--peer-router-asns="65000,65000"
+--peer-router-passwords="U2VjdXJlUGFzc3dvcmQK,"
+```
+
+Note the comma indicating the end of the first password.
+
+Now here's the same example but configured as node annotations:
+```
+kubectl annotate node <kube-node> "io.kube-router.net.peer.ips=192.168.1.99,192.168.1.100"
+kubectl annotate node <kube-node> "io.kube-router.net.peer.asns=65000,65000"
+kubectl annotate node <kube-node> "io.kube-router.net.peer.passwords=U2VjdXJlUGFzc3dvcmQK,"
 ```

--- a/Documentation/bgp.md
+++ b/Documentation/bgp.md
@@ -1,10 +1,11 @@
-## Configuring BGP Peers
+# Configuring BGP Peers
 
 When kube-router is used to provide pod-to-pod networking, BGP is used to exchange routes across the nodes. Kube-router
 provides flexible networking models to support different deployments (public vs private cloud, routable vs non-routable
 pod IP's, service ip's etc).
 
-### Full node-to-node mesh
+## Peering Within The Cluster
+### Full Node-To-Node Mesh
 
 This is the default mode. All nodes in the clusters form iBGP peering
 relationship with rest of the nodes forming full node-to-node mesh. Each node
@@ -15,15 +16,15 @@ configured with `--cluster-asn` flag). Users are transparent to use of iBGP.
 This mode is suitable in public cloud environments or small cluster deployments.
 In this mode all the nodes are expected to be L2 adjacent.
 
-### Node specific BGP peers
+### Node-To-Node Peering Without Full Mesh
 
 This model support more than a single AS per cluster to allow AS per rack or AS
 per node models. Nodes in the cluster does not form full node-to-node mesh.
 Users has to explicitly select this mode by specifying `--nodes-full-mesh=false`
 when launching kube-router. In this mode kube-router expects each node is
-configured with ASN number to be used for the node from the nodes API object
-annoations. Kube-router will use the configured value for the key
-`io.kube-router.net.node.asn` in the node object as the ASN number for the node.
+configured with an ASN number from the node's API object annoations. Kube-router
+will use the node's `io.kube-router.net.node.asn` annotation value as the ASN
+number for the node.
 
 Users can annotate node objects with the following command:
 
@@ -32,9 +33,10 @@ kubectl annotate node <kube-node> "io.kube-router.net.node.asn=64512"
 ```
 
 Only nodes with in same ASN form full mesh. Two nodes with different ASNs never
-gets peered.
+get peered.
 
-### Global BGP Peer
+## Peering Outside The Cluster
+### Global External BGP Peers
 
 An optional global BGP peer can be configured by specifying `--peer-router-asns`
 and `--peer-router-ips` parameters. When configured each node in the cluster
@@ -48,7 +50,7 @@ For example:
 --peer-router-asns="65000,65000"
 ```
 
-### Node specific BGP peer
+### Node Specific External BGP Peers
 
 Alternativley, each node can be configured with one or more node specific BGP
 peers. Information regarding node specific BGP peer is read from node API object

--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -972,6 +972,10 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 					PeerAs:          peerAsnNo,
 				},
 			}
+			nodeBGPPasswordAnnotation, ok := node.ObjectMeta.Annotations["net.kuberouter.node.bgppeer.password"]
+			if ok {
+				n.Config.AuthPassword = nodeBGPPasswordAnnotation
+			}
 			if err := nrc.bgpServer.AddNeighbor(n); err != nil {
 				nrc.bgpServer.Stop()
 				return errors.New("Failed to peer with node specific BGP peer router: " +

--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -1047,6 +1047,7 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 		ipStrings := stringToSlice(nodeBgpPeersAnnotation, ",")
 		peerIPs, err := stringSliceToIPs(ipStrings)
 		if err != nil {
+			nrc.bgpServer.Stop()
 			return fmt.Errorf("Failed to parse node's Peer Addresses Annotation: %s", err)
 		}
 
@@ -1059,6 +1060,7 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 			passStrings := stringToSlice(nodeBGPPasswordsAnnotation, ",")
 			peerPasswords, err = stringSliceB64Decode(passStrings)
 			if err != nil {
+				nrc.bgpServer.Stop()
 				return fmt.Errorf("Failed to parse node's Peer Passwords Annotation: %s", err)
 			}
 		}
@@ -1066,6 +1068,7 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 		// Create and set Global Peer Router complete configs
 		nrc.globalPeerRouters, err = newGlobalPeers(peerIPs, peerASNs, peerPasswords)
 		if err != nil {
+			nrc.bgpServer.Stop()
 			return fmt.Errorf("Failed to process Global Peer Router configs: %s", err)
 		}
 
@@ -1075,6 +1078,7 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 	if len(nrc.globalPeerRouters) != 0 {
 		err := connectToPeers(nrc.bgpServer, nrc.globalPeerRouters)
 		if err != nil {
+			nrc.bgpServer.Stop()
 			return fmt.Errorf("Failed to peer with Global Peer Router(s): %s",
 				err)
 		}

--- a/app/controllers/network_services_controller.go
+++ b/app/controllers/network_services_controller.go
@@ -426,7 +426,7 @@ func buildServicesInfo() serviceInfoMap {
 			}
 
 			svcInfo.sessionAffinity = (svc.Spec.SessionAffinity == "ClientIP")
-			_, svcInfo.hairpin = svc.ObjectMeta.Annotations["kube-router.io/hairpin-mode"]
+			_, svcInfo.hairpin = svc.ObjectMeta.Annotations["io.kube-router.net.service.hairpin"]
 
 			svcId := generateServiceId(svc.Namespace, svc.Name, port.Name)
 			serviceMap[svcId] = &svcInfo

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -1,6 +1,7 @@
 package options
 
 import (
+	"net"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -23,13 +24,15 @@ type KubeRouterConfig struct {
 	EnablePodEgress     bool
 	HostnameOverride    string
 	AdvertiseClusterIp  bool
-	PeerRouter          string
-	ClusterAsn          string
-	PeerAsn             string
+	PeerRouters         []net.IP
+	PeerASNs            []uint
+	ClusterAsn          uint
 	FullMeshMode        bool
 	GlobalHairpinMode   bool
 	NodePortBindOnAllIp bool
 	EnableOverlay       bool
+	PeerRouterPasswords []string
+	// FullMeshPassword    string
 }
 
 func NewKubeRouterConfig() *KubeRouterConfig {
@@ -72,12 +75,12 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0.")
 	fs.BoolVar(&s.AdvertiseClusterIp, "advertise-cluster-ip", false,
 		"Add Cluster IP to the RIB and advertise to peers.")
-	fs.StringVar(&s.PeerRouter, "peer-router", s.PeerRouter,
+	fs.IPSliceVar(&s.PeerRouters, "peer-router", s.PeerRouters,
 		"The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's.")
-	fs.StringVar(&s.ClusterAsn, "cluster-asn", s.ClusterAsn,
+	fs.UintVar(&s.ClusterAsn, "cluster-asn", s.ClusterAsn,
 		"ASN number under which cluster nodes will run iBGP.")
-	fs.StringVar(&s.PeerAsn, "peer-asn", s.PeerAsn,
-		"ASN number of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr.")
+	fs.UintSliceVar(&s.PeerASNs, "peer-asn", s.PeerASNs,
+		"ASN numbers of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr.")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", true,
 		"Each node in the cluster will setup BGP peering with rest of the nodes.")
 	fs.StringVar(&s.HostnameOverride, "hostname-override", s.HostnameOverride,
@@ -89,4 +92,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableOverlay, "enable-overlay", true,
 		"When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. "+
 			"When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets")
+	fs.StringSliceVar(&s.PeerRouterPasswords, "peer-router-password", s.PeerRouterPasswords,
+		"Password for authenticating against the BGP peer defined with \"--peer-router\".")
+	// fs.StringVar(&s.FullMeshPassword, "nodes-full-mesh-password", s.FullMeshPassword,
+	// 	"Password that cluster-node BGP servers will use to authenticate one another when \"--nodes-full-mesh\" is set.")
 }

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -31,7 +31,7 @@ type KubeRouterConfig struct {
 	GlobalHairpinMode   bool
 	NodePortBindOnAllIp bool
 	EnableOverlay       bool
-	PeerRouterPasswords []string
+	PeerPasswords       []string
 	// FullMeshPassword    string
 }
 
@@ -75,11 +75,11 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0.")
 	fs.BoolVar(&s.AdvertiseClusterIp, "advertise-cluster-ip", false,
 		"Add Cluster IP to the RIB and advertise to peers.")
-	fs.IPSliceVar(&s.PeerRouters, "peer-router", s.PeerRouters,
+	fs.IPSliceVar(&s.PeerRouters, "peer-router-ips", s.PeerRouters,
 		"The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's.")
 	fs.UintVar(&s.ClusterAsn, "cluster-asn", s.ClusterAsn,
 		"ASN number under which cluster nodes will run iBGP.")
-	fs.UintSliceVar(&s.PeerASNs, "peer-asn", s.PeerASNs,
+	fs.UintSliceVar(&s.PeerASNs, "peer-router-asns", s.PeerASNs,
 		"ASN numbers of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr.")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", true,
 		"Each node in the cluster will setup BGP peering with rest of the nodes.")
@@ -92,8 +92,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableOverlay, "enable-overlay", true,
 		"When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. "+
 			"When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets")
-	fs.StringSliceVar(&s.PeerRouterPasswords, "peer-router-password", s.PeerRouterPasswords,
-		"Password for authenticating against the BGP peer defined with \"--peer-router\".")
+	fs.StringSliceVar(&s.PeerPasswords, "peer-router-passwords", s.PeerPasswords,
+		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
 	// fs.StringVar(&s.FullMeshPassword, "nodes-full-mesh-password", s.FullMeshPassword,
 	// 	"Password that cluster-node BGP servers will use to authenticate one another when \"--nodes-full-mesh\" is set.")
 }

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -23,8 +23,8 @@ spec:
           - "--kubeconfig=/var/lib/kube-router/kubeconfig"
           - "--advertise-cluster-ip=true"
           - "--cluster-asn=64512"
-          - "--peer-router=192.168.1.99"
-          - "--peer-asn=64513"
+          - "--peer-router-ips=192.168.1.99"
+          - "--peer-router-asns=64513"
         securityContext:
           privileged: true
         imagePullPolicy: Always


### PR DESCRIPTION
Addresses the following item for #163
- Add flag to specify external router's MD5 password

### Other changes, please review.
- **BREAKING**: `--peer-router` and `--peer-asn` flags now take a slice rather than a comma separated string. In hindsight the previous type (comma separated string) may be easier to maintain consistency with annotations.
- Consolidated NRC peer fields into a []config.NeighborConfig
  to store address, asn, and password for each peer.
- Use net.IP type directly in flags. pflags library will validate the input so we don't have to.