### PR TITLE
Update DaemonSet manifests

### DIFF
--- a/contrib/bootkube/kube-router.yaml
+++ b/contrib/bootkube/kube-router.yaml
@@ -14,23 +14,6 @@ spec:
         tier: node
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-                "name": "install-cni",
-                "image": "busybox",
-                "command": [ "/bin/sh", "-c", "set -e -x; if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then TMP=/etc/cni/net.d/.tmp-kuberouter-cfg; cp /etc/kube-router/cni-conf.json ${TMP}; mv ${TMP} /etc/cni/net.d/10-kuberouter.conf; fi" ],
-                "volumeMounts": [
-                    {
-                        "name": "cni",
-                        "mountPath": "/etc/cni/net.d"
-                    },
-                    {
-                        "name": "kube-router-cfg",
-                        "mountPath": "/etc/kube-router"
-                    }
-                ]
-            }
-        ]'
     spec:
       containers:
       - name: kube-router
@@ -52,11 +35,29 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
           readOnly: true
-        - name: cni
+        - name: cni-conf-dir
           mountPath: /etc/cni/net.d
         - name: kubeconfig
           mountPath: /etc/kubernetes/kubeconfig
           readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly
@@ -65,15 +66,15 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
-      - hostPath:
-          path: /lib/modules
-        name: lib-modules
-      - hostPath:
-          path: /etc/kubernetes/cni/net.d
-        name: cni
-      - name: kubeconfig
+      - name: lib-modules
         hostPath:
-          path: /etc/kubernetes/kubeconfig
+          path: /lib/modules
+      - name: cni-conf-dir
+        hostPath:
+          path: /etc/kubernetes/cni/net.d
       - name: kube-router-cfg
         configMap:
           name: kube-router-cfg
+      - name: kubeconfig
+        hostPath:
+          path: /etc/kubernetes/kubeconfig

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -1,3 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-router-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    k8s-app: kube-router
+data:
+  cni-conf.json: |
+    {
+      "name":"kubernetes",
+      "type":"bridge",
+      "bridge":"kube-bridge",
+      "isDefaultGateway":true,
+      "ipam": {
+        "type":"host-local"
+      }
+    }
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -29,18 +49,37 @@ spec:
           privileged: true
         imagePullPolicy: Always
         env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
-          - mountPath: /lib/modules
-            name: lib-modules
-            readOnly: true
-          - mountPath: /etc/cni/net.d/10-kuberouter.conf
-            name: cni-conf-dir
-          - mountPath: /var/lib/kube-router/kubeconfig
-            name: kubeconfig
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kubeconfig
+          mountPath: /var/lib/kube-router/kubeconfig
+          readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly
@@ -49,12 +88,15 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
-        - name: lib-modules
-          hostPath:
-              path: /lib/modules
-        - name: cni-conf-dir
-          hostPath:
-              path: /etc/cni/net.d/10-kuberouter.conf
-        - name: kubeconfig
-          hostPath:
-              path: /var/lib/kube-router/kubeconfig
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: cni-conf-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: kube-router-cfg
+        configMap:
+          name: kube-router-cfg
+      - name: kubeconfig
+        hostPath:
+          path: /var/lib/kube-router/kubeconfig

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -1,3 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-router-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    k8s-app: kube-router
+data:
+  cni-conf.json: |
+    {
+      "name":"kubernetes",
+      "type":"bridge",
+      "bridge":"kube-bridge",
+      "isDefaultGateway":true,
+      "ipam": {
+        "type":"host-local"
+      }
+    }
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -21,18 +41,37 @@ spec:
           privileged: true
         imagePullPolicy: Always
         env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
-          - mountPath: /lib/modules
-            name: lib-modules
-            readOnly: true
-          - mountPath: /etc/cni/net.d/10-kuberouter.conf
-            name: cni-conf-dir
-          - mountPath: /var/lib/kube-router/kubeconfig
-            name: kubeconfig
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kubeconfig
+          mountPath: /var/lib/kube-router/kubeconfig
+          readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly
@@ -41,12 +80,15 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
-        - name: lib-modules
-          hostPath:
-              path: /lib/modules
-        - name: cni-conf-dir
-          hostPath:
-              path: /etc/cni/net.d/10-kuberouter.conf
-        - name: kubeconfig
-          hostPath:
-              path: /var/lib/kube-router/kubeconfig
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: cni-conf-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: kube-router-cfg
+        configMap:
+          name: kube-router-cfg
+      - name: kubeconfig
+        hostPath:
+          path: /var/lib/kube-router/kubeconfig

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -1,3 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-router-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    k8s-app: kube-router
+data:
+  cni-conf.json: |
+    {
+      "name":"kubernetes",
+      "type":"bridge",
+      "bridge":"kube-bridge",
+      "isDefaultGateway":true,
+      "ipam": {
+        "type":"host-local"
+      }
+    }
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -21,18 +41,37 @@ spec:
           privileged: true
         imagePullPolicy: Always
         env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
-          - mountPath: /lib/modules
-            name: lib-modules
-            readOnly: true
-          - mountPath: /etc/cni/net.d/10-kuberouter.conf
-            name: cni-conf-dir
-          - mountPath: /var/lib/kube-router/kubeconfig
-            name: kubeconfig
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kubeconfig
+          mountPath: /var/lib/kube-router/kubeconfig
+          readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly
@@ -41,12 +80,15 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
-        - name: lib-modules
-          hostPath:
-              path: /lib/modules
-        - name: cni-conf-dir
-          hostPath:
-              path: /etc/cni/net.d/10-kuberouter.conf
-        - name: kubeconfig
-          hostPath:
-              path: /var/lib/kube-router/kubeconfig
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: cni-conf-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: kube-router-cfg
+        configMap:
+          name: kube-router-cfg
+      - name: kubeconfig
+        hostPath:
+          path: /var/lib/kube-router/kubeconfig

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -1,3 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-router-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    k8s-app: kube-router
+data:
+  cni-conf.json: |
+    {
+      "name":"kubernetes",
+      "type":"bridge",
+      "bridge":"kube-bridge",
+      "isDefaultGateway":true,
+      "ipam": {
+        "type":"host-local"
+      }
+    }
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -21,18 +41,37 @@ spec:
           privileged: true
         imagePullPolicy: Always
         env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
-          - mountPath: /lib/modules
-            name: lib-modules
-            readOnly: true
-          - mountPath: /etc/cni/net.d/10-kuberouter.conf
-            name: cni-conf-dir
-          - mountPath: /var/lib/kube-router/kubeconfig
-            name: kubeconfig
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kubeconfig
+          mountPath: /var/lib/kube-router/kubeconfig
+          readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly
@@ -41,12 +80,15 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
-        - name: lib-modules
-          hostPath:
-              path: /lib/modules
-        - name: cni-conf-dir
-          hostPath:
-              path: /etc/cni/net.d/10-kuberouter.conf
-        - name: kubeconfig
-          hostPath:
-              path: /var/lib/kube-router/kubeconfig
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: cni-conf-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: kube-router-cfg
+        configMap:
+          name: kube-router-cfg
+      - name: kubeconfig
+        hostPath:
+          path: /var/lib/kube-router/kubeconfig

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -34,31 +34,8 @@ spec:
         tier: node
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-                "name": "install-cni",
-                "image": "busybox",
-                "command": [ "/bin/sh", "-c", "set -e -x; if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then TMP=/etc/cni/net.d/.tmp-kuberouter-cfg; cp /etc/kube-router/cni-conf.json ${TMP}; mv ${TMP} /etc/cni/net.d/10-kuberouter.conf; fi" ],
-                "volumeMounts": [
-                    {
-                        "name": "cni",
-                        "mountPath": "/etc/cni/net.d"
-                    },
-                    {
-                        "name": "kube-router-cfg",
-                        "mountPath": "/etc/kube-router"
-                    }
-                ],
-                "volumes": {
-                     "name": "cni",
-                     "hostPath": {
-                          "path": "/etc/cni/net.d"
-                     }
-                }
-            }
-        ]'
     spec:
-      serviceAccountName: kube-router 
+      serviceAccountName: kube-router
       serviceAccount: kube-router
       containers:
       - name: kube-router
@@ -84,11 +61,29 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
           readOnly: true
-        - name: cni
+        - name: cni-conf-dir
           mountPath: /etc/cni/net.d
         - name: kubeconfig
           mountPath: /var/lib/kube-router
           readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly
@@ -97,26 +92,26 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
-      - hostPath:
+      - name: lib-modules
+        hostPath:
           path: /lib/modules
-        name: lib-modules
-      - hostPath:
+      - name: cni-conf-dir
+        hostPath:
           path: /etc/cni/net.d
-        name: cni
+      - name: kube-router-cfg
+        configMap:
+          name: kube-router-cfg
       - name: kubeconfig
         configMap:
           name: kube-proxy
           items:
           - key: kubeconfig.conf
             path: kubeconfig
-      - name: kube-router-cfg
-        configMap:
-          name: kube-router-cfg
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kube-router 
+  name: kube-router
   namespace: kube-system
 ---
 kind: ClusterRole

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -34,31 +34,8 @@ spec:
         tier: node
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        pod.beta.kubernetes.io/init-containers: '[
-            {
-                "name": "install-cni",
-                "image": "busybox",
-                "command": [ "/bin/sh", "-c", "set -e -x; if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then TMP=/etc/cni/net.d/.tmp-kuberouter-cfg; cp /etc/kube-router/cni-conf.json ${TMP}; mv ${TMP} /etc/cni/net.d/10-kuberouter.conf; fi" ],
-                "volumeMounts": [
-                    {
-                        "name": "cni",
-                        "mountPath": "/etc/cni/net.d"
-                    },
-                    {
-                        "name": "kube-router-cfg",
-                        "mountPath": "/etc/kube-router"
-                    }
-                ],
-                "volumes": {
-                     "name": "cni",
-                     "hostPath": {
-                          "path": "/etc/cni/net.d"
-                     }
-                }
-            }
-        ]'
     spec:
-      serviceAccountName: kube-router 
+      serviceAccountName: kube-router
       serviceAccount: kube-router
       containers:
       - name: kube-router
@@ -83,11 +60,29 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
           readOnly: true
-        - name: cni
+        - name: cni-conf-dir
           mountPath: /etc/cni/net.d
         - name: kubeconfig
           mountPath: /var/lib/kube-router/kubeconfig
           readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - mountPath: /etc/cni/net.d
+          name: cni-conf-dir
+        - mountPath: /etc/kube-router
+          name: kube-router-cfg
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly
@@ -96,23 +91,23 @@ spec:
         key: node-role.kubernetes.io/master
         operator: Exists
       volumes:
-      - hostPath:
-          path: /lib/modules
-        name: lib-modules
-      - hostPath:
-          path: /etc/cni/net.d
-        name: cni
-      - name: kubeconfig
+      - name: lib-modules
         hostPath:
-          path: /var/lib/kube-router/kubeconfig
+          path: /lib/modules
+      - name: cni-conf-dir
+        hostPath:
+          path: /etc/cni/net.d
       - name: kube-router-cfg
         configMap:
           name: kube-router-cfg
+      - name: kubeconfig
+        hostPath:
+          path: /var/lib/kube-router/kubeconfig
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kube-router 
+  name: kube-router
   namespace: kube-system
 ---
 kind: ClusterRole

--- a/hack/vagrant-up.sh
+++ b/hack/vagrant-up.sh
@@ -59,7 +59,7 @@ do
     echo "Modifying image attribute in ${KR_MANIFEST_PATH}"
     sed -i -e "s/image: cloudnativelabs\/kube-router/image: ${KR_IMAGE_TAG}/" \
       "${KR_MANIFEST_PATH}"
-    sed -i -e "s/imagePullPolicy: Always/imagePullPolicy: Never/" "${KR_MANIFEST_PATH}"
+    sed -i -e "s/imagePullPolicy: Always/imagePullPolicy: IfNotPresent/" "${KR_MANIFEST_PATH}"
     echo "Verify modification:"
     grep -F "image: " "${KR_MANIFEST_PATH}"
     grep -F "imagePullPolicy: " "${KR_MANIFEST_PATH}"


### PR DESCRIPTION
Testing these now. Should make things work better on k8s 1.8 which dropped support for the old way of defining InitContainers via annotation/JSON.

- Remove beta annotation versions of init containers
- Add YAML InitContainers spec to all manifests
- Add CNI config ConfigMap to all manifests
- Make indentation, volume names, etc consistent
- Set all kubeconfig volumes to readonly