### PR TITLE
Support BGP Graceful Restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ UPSTREAM_IMPORT_PATH=$(GOPATH)/src/github.com/cloudnativelabs/kube-router/
 
 all: test kube-router container ## Default target. Runs tests, builds binaries and images.
 
-kube-router: $(shell find . -name \*.go) ## Builds kube-router.
+kube-router:
 	@echo Starting kube-router binary build.
 	CGO_ENABLED=0 go build -o kube-router kube-router.go
 	@echo Finished kube-router binary build.

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -29,6 +29,7 @@ type KubeRouterConfig struct {
 	PeerASNs            []uint
 	ClusterAsn          uint
 	FullMeshMode        bool
+	BGPGracefulRestart  bool
 	GlobalHairpinMode   bool
 	NodePortBindOnAllIp bool
 	EnableOverlay       bool
@@ -86,6 +87,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"ASN numbers of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr.")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", true,
 		"Each node in the cluster will setup BGP peering with rest of the nodes.")
+	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
+		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
 	fs.StringVar(&s.HostnameOverride, "hostname-override", s.HostnameOverride,
 		"Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.")
 	fs.BoolVar(&s.GlobalHairpinMode, "hairpin-mode", false,

--- a/build-image/make.sh
+++ b/build-image/make.sh
@@ -1,4 +1,4 @@
 NAME=kube-router-build
 docker build -t kube-router-build:latest .
 docker rm -f $NAME
-docker run --name=$NAME -v $GOPATH:/data/go kube-router-build:latest
+docker run --name=$NAME -v $GOPATH:/data/go kube-router-build:latest "$@"


### PR DESCRIPTION
As per: https://github.com/cloudnativelabs/kube-router/issues/219. Adds support for BGP graceful restart

```
--bgp-graceful-restart
```
Will enable BGP graceful restarts as per https://tools.ietf.org/pdf/rfc4724.pdf, which _should_ preserve routes and forwarding state of the node. The restart time will default to the hold time, happy to add a flag to set the restart time if we think that's necessary. 

Also does some cleanup in scripts and makefile, happy to move these changes in another PR :). 

cc @murali-reddy 