### PR TITLE
add --enable-ibgp flag

### DIFF
--- a/app/options/options.go
+++ b/app/options/options.go
@@ -30,6 +30,7 @@ type KubeRouterConfig struct {
 	ClusterAsn          uint
 	FullMeshMode        bool
 	BGPGracefulRestart  bool
+	EnableiBGP          bool
 	GlobalHairpinMode   bool
 	NodePortBindOnAllIp bool
 	EnableOverlay       bool
@@ -89,6 +90,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Each node in the cluster will setup BGP peering with rest of the nodes.")
 	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
+	fs.BoolVar(&s.EnableiBGP, "enable-ibgp", true,
+		"Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers")
 	fs.StringVar(&s.HostnameOverride, "hostname-override", s.HostnameOverride,
 		"Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.")
 	fs.BoolVar(&s.GlobalHairpinMode, "hairpin-mode", false,


### PR DESCRIPTION
Adds a flag to enable/disable iBGP peering. Useful when you only want nodes peering with a global peer. 

cc @murali-reddy 