### PR TITLE
tunnel interface names cannot be longer than 15 characters

### DIFF
--- a/app/controllers/network_routes_controller_test.go
+++ b/app/controllers/network_routes_controller_test.go
@@ -884,6 +884,36 @@ func Test_OnNodeUpdate(t *testing.T) {
 	}
 }
 
+func Test_generateTunnelName(t *testing.T) {
+	testcases := []struct {
+		name       string
+		nodeIP     string
+		tunnelName string
+	}{
+		{
+			"IP less than 12 characters after removing '.'",
+			"10.0.0.1",
+			"tun-10001",
+		},
+		{
+			"IP has 12 characters after removing '.'",
+			"100.200.300.400",
+			"tun100200300400",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			tunnelName := generateTunnelName(testcase.nodeIP)
+			if tunnelName != testcase.tunnelName {
+				t.Logf("actual tunnel interface name: %s", tunnelName)
+				t.Logf("expected tunnel interface name: %s", testcase.tunnelName)
+				t.Error("did not get expected tunnel interface name")
+			}
+		})
+	}
+}
+
 func createServices(clientset kubernetes.Interface, svcs []*v1core.Service) error {
 	for _, svc := range svcs {
 		_, err := clientset.CoreV1().Services("default").Create(svc)


### PR DESCRIPTION
Ran into some strange behaviour as reported [here](https://github.com/cloudnativelabs/kube-router/issues/273). Turns out it was because linux interface names cannot be more than 15 characters. Removing the `-` in the interface name ensures that we will always have at most 15 characters for IPv4. However, I do have concerns around backwards compatibility and some more work may have to be done here so that the transition is smoother. @murali-reddy would love your thoughts here. 