### PR TITLE
Healthchecks

### DIFF
--- a/Documentation/health.md
+++ b/Documentation/health.md
@@ -1,9 +1,10 @@
 # Health checking kube-router
 
-kube-router currently has basic health checking in form of heartbeats sent from each controller to the health manager each time the main loop completes successfully.
+kube-router currently has basic health checking in form of heartbeats sent from each controller to the healthcontroller each time the main loop completes successfully.
 
-The healthz port is by default 20244 but can be changed with the startup option
-    
+The health port is by default 20244 but can be changed with the startup option.
+The health path is `/healthz`
+
     --health-port=<port number>
 
 If port is set to 0 (zero) no HTTP endpoint will be made availible but the health controller will still run and print out any missed heartbeats to STDERR of kube-router

--- a/Documentation/health.md
+++ b/Documentation/health.md
@@ -21,4 +21,4 @@ kube-router is started with
     --run-firewall=true
     --run-service-proxy=true
 
-If the route controller or service controller exits it's main loop and does not publish a heartbeat the /healthz endpoint will return a error 500 signaling that kube-router is not healthy
+If the route controller, policy controller or service controller exits it's main loop and does not publish a heartbeat the /healthz endpoint will return a error 500 signaling that kube-router is not healthy.

--- a/Documentation/healthz.md
+++ b/Documentation/healthz.md
@@ -1,0 +1,23 @@
+# Health checking kube-router
+
+kube-router currently has basic health checking in form of heartbeats sent from each controller to the health manager each time the main loop completes successfully.
+
+The healthz port is by default 20244 but can be changed with the startup option
+    
+    --health-port=<port number>
+
+If port is set to 0 (zero) no HTTP endpoint will be made availible but the health controller will still run and print out any missed heartbeats to STDERR of kube-router
+
+If a controller does not send a heartbeat within controllersynctime + 5 seconds the component will be flagged as unhealthy.
+
+If any of the running components is failing the whole kube-router state will be marked as failed in the /healthz endpoint
+
+E.g
+
+kube-router is started with
+
+    --run-router=true
+    --run-firewall=true
+    --run-service-proxy=true
+
+If the route controller or service controller exits it's main loop and does not publish a heartbeat the /healthz endpoint will return a error 500 signaling that kube-router is not healthy

--- a/app/controllers/health_controller.go
+++ b/app/controllers/health_controller.go
@@ -129,8 +129,9 @@ func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <
 	srv := &http.Server{Addr: ":" + strconv.Itoa(int(hc.HealthPort)), Handler: http.DefaultServeMux}
 
 	http.HandleFunc("/healthz", hc.Handler)
+
 	if (hc.Config.HealthPort > 0) && (hc.Config.HealthPort <= 65535) {
-		hc.HTTPenabled = false
+		hc.HTTPenabled = true
 		go func() {
 			if err := srv.ListenAndServe(); err != nil {
 				// cannot panic, because this probably is an intentional close
@@ -140,8 +141,9 @@ func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <
 	} else if hc.Config.MetricsPort > 65535 {
 		glog.Errorf("Metrics port must be over 0 and under 65535, given port: %d", hc.Config.MetricsPort)
 	} else {
-		hc.HTTPenabled = true
+		hc.HTTPenabled = false
 	}
+
 	for {
 		//Give the controllers a few seconds to start before checking health
 		if time.Since(Started) > 5*time.Second {

--- a/app/controllers/health_controller.go
+++ b/app/controllers/health_controller.go
@@ -27,6 +27,7 @@ type HealthController struct {
 
 //HealthStats is holds the latest heartbeats
 type HealthStats struct {
+	sync.Mutex
 	Healthy                        bool
 	MetricsControllerAlive         time.Time
 	NetworkPolicyControllerAlive   time.Time
@@ -68,6 +69,9 @@ func (hc *HealthController) Handler(w http.ResponseWriter, req *http.Request) {
 //HandleHeartbeat handles recevied heartbeats onthe health channel
 func (hc *HealthController) HandleHeartbeat(beat *ControllerHeartbeat) {
 	glog.V(3).Infof("Received heartbeat from %s", beat.Component)
+
+	hc.Status.Lock()
+	defer hc.Status.Unlock()
 
 	switch component := beat.Component; component {
 	case "NSC":

--- a/app/controllers/health_controller.go
+++ b/app/controllers/health_controller.go
@@ -84,7 +84,7 @@ func (hc *HealthController) CheckHealth() bool {
 }
 
 func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) error {
-	t := time.NewTicker(3 * time.Second)
+	t := time.NewTicker(1.5 * time.Second)
 	defer wg.Done()
 	glog.Info("Starting health controller")
 
@@ -114,7 +114,7 @@ func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <
 		case heartbeat := <-healthChan:
 			hc.HandleHeartbeat(heartbeat)
 		case <-t.C:
-			glog.Info("Health controller tick")
+			glog.V(4).Info("Health controller tick")
 		}
 	}
 

--- a/app/controllers/health_controller.go
+++ b/app/controllers/health_controller.go
@@ -84,7 +84,7 @@ func (hc *HealthController) CheckHealth() bool {
 }
 
 func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) error {
-	t := time.NewTicker(1.5 * time.Second)
+	t := time.NewTicker(1 * time.Second)
 	defer wg.Done()
 	glog.Info("Starting health controller")
 

--- a/app/controllers/health_controller.go
+++ b/app/controllers/health_controller.go
@@ -1,0 +1,75 @@
+package controllers
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cloudnativelabs/kube-router/app/options"
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+)
+
+type ControllerHeartbeat struct {
+	Component     string
+	Lastheartbeat time.Time
+}
+
+//HealthController reports the health of the controller loops as a http endpoint
+type HealthController struct {
+	HealthPort uint16
+}
+
+func sendHeartBeat(channel chan<- *ControllerHeartbeat, controller string) {
+	heartbeat := ControllerHeartbeat{
+		Component:     controller,
+		Lastheartbeat: time.Now(),
+	}
+	channel <- &heartbeat
+}
+
+func (hc *HealthController) Handler(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("These aren't the droids you're looking for"))
+}
+
+func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) error {
+	t := time.NewTicker(3 * time.Second)
+	defer wg.Done()
+	glog.Info("Starting health controller")
+
+	srv := &http.Server{Addr: ":" + strconv.Itoa(int(hc.HealthPort)), Handler: http.DefaultServeMux}
+
+	// add prometheus handler on metrics path
+	http.HandleFunc("/healthz", hc.Handler)
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil {
+			// cannot panic, because this probably is an intentional close
+			glog.Errorf("Health controller error: %s", err)
+		}
+	}()
+
+	for {
+		select {
+		case <-stopCh:
+			glog.Infof("Shutting down health controller")
+			if err := srv.Shutdown(context.Background()); err != nil {
+				glog.Errorf("could not shutdown: %v", err)
+			}
+			return nil
+		case heartbeat := <-healthChan:
+			glog.V(3).Infof("Received heartbeat from %s", heartbeat.Component)
+		case <-t.C:
+		}
+	}
+
+}
+
+func NewHealthController(config *options.KubeRouterConfig) (*HealthController, error) {
+	hc := HealthController{
+		HealthPort: config.HealthPort,
+	}
+	return &hc, nil
+}

--- a/app/controllers/health_controller.go
+++ b/app/controllers/health_controller.go
@@ -22,6 +22,7 @@ type HealthController struct {
 }
 
 func sendHeartBeat(channel chan<- *ControllerHeartbeat, controller string) {
+	glog.Infof("Send Heartbeat from %s", controller)
 	heartbeat := ControllerHeartbeat{
 		Component:     controller,
 		Lastheartbeat: time.Now(),
@@ -31,7 +32,7 @@ func sendHeartBeat(channel chan<- *ControllerHeartbeat, controller string) {
 
 func (hc *HealthController) Handler(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("These aren't the droids you're looking for"))
+	w.Write([]byte("These aren't the droids you're looking for\n"))
 }
 
 func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) error {
@@ -60,8 +61,9 @@ func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <
 			}
 			return nil
 		case heartbeat := <-healthChan:
-			glog.V(3).Infof("Received heartbeat from %s", heartbeat.Component)
+			glog.Infof("Received heartbeat from %s", heartbeat.Component)
 		case <-t.C:
+			glog.Infof("Health controller tick")
 		}
 	}
 

--- a/app/controllers/health_controller.go
+++ b/app/controllers/health_controller.go
@@ -19,10 +19,19 @@ type ControllerHeartbeat struct {
 //HealthController reports the health of the controller loops as a http endpoint
 type HealthController struct {
 	HealthPort uint16
+	Status     HealthStats
+	Config     *options.KubeRouterConfig
+}
+
+type HealthStats struct {
+	Healthy                        bool
+	MetricsControllerAlive         time.Time
+	NetworkPolicyControllerAlive   time.Time
+	NetworkRoutingControllerAlive  time.Time
+	NetworkServicesControllerAlive time.Time
 }
 
 func sendHeartBeat(channel chan<- *ControllerHeartbeat, controller string) {
-	glog.Infof("Send Heartbeat from %s", controller)
 	heartbeat := ControllerHeartbeat{
 		Component:     controller,
 		Lastheartbeat: time.Now(),
@@ -31,8 +40,47 @@ func sendHeartBeat(channel chan<- *ControllerHeartbeat, controller string) {
 }
 
 func (hc *HealthController) Handler(w http.ResponseWriter, req *http.Request) {
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("These aren't the droids you're looking for\n"))
+	if hc.Status.Healthy {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("These aren't the droids you're looking for\n"))
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("These are the droids you're looking for\n"))
+	}
+}
+
+func (hc *HealthController) HandleHeartbeat(beat *ControllerHeartbeat) {
+	glog.Infof("Received heartbeat from %s", beat.Component)
+	switch component := beat.Component; component {
+	case "NSC":
+		hc.Status.NetworkServicesControllerAlive = time.Now()
+	case "NRC":
+		hc.Status.NetworkRoutingControllerAlive = time.Now()
+	case "NPC":
+		hc.Status.NetworkPolicyControllerAlive = time.Now()
+	case "MC":
+		hc.Status.MetricsControllerAlive = time.Now()
+	}
+}
+
+func (hc *HealthController) CheckHealth() bool {
+	glog.V(4).Info("Checking components")
+	health := true
+	if time.Since(hc.Status.NetworkPolicyControllerAlive) > hc.Config.IPTablesSyncPeriod+3*time.Second {
+		glog.Error("Network Policy Controller heartbeat timeout")
+		health = false
+	}
+
+	if time.Since(hc.Status.NetworkRoutingControllerAlive) > hc.Config.RoutesSyncPeriod+3*time.Second {
+		glog.Error("Network Routing Controller heartbeat timeout")
+		health = false
+	}
+
+	if time.Since(hc.Status.NetworkServicesControllerAlive) > hc.Config.IpvsSyncPeriod+3*time.Second {
+		glog.Error("NetworkService Controller heartbeat timeout")
+		health = false
+	}
+	return health
 }
 
 func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) error {
@@ -53,6 +101,9 @@ func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <
 	}()
 
 	for {
+
+		hc.Status.Healthy = hc.CheckHealth()
+
 		select {
 		case <-stopCh:
 			glog.Infof("Shutting down health controller")
@@ -61,9 +112,9 @@ func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <
 			}
 			return nil
 		case heartbeat := <-healthChan:
-			glog.Infof("Received heartbeat from %s", heartbeat.Component)
+			hc.HandleHeartbeat(heartbeat)
 		case <-t.C:
-			glog.Infof("Health controller tick")
+			glog.Info("Health controller tick")
 		}
 	}
 
@@ -71,6 +122,7 @@ func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <
 
 func NewHealthController(config *options.KubeRouterConfig) (*HealthController, error) {
 	hc := HealthController{
+		Config:     config,
 		HealthPort: config.HealthPort,
 	}
 	return &hc, nil

--- a/app/controllers/metrics_controller.go
+++ b/app/controllers/metrics_controller.go
@@ -149,10 +149,8 @@ func (mc *MetricsController) Run(healthChan chan<- *ControllerHeartbeat, stopCh 
 			return nil
 		case <-t.C:
 			glog.V(4).Info("Metrics controller tick")
+		}
 	}
-	
-
-
 }
 
 // NewMetricsController returns new MetricController object

--- a/app/controllers/metrics_controller.go
+++ b/app/controllers/metrics_controller.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/cloudnativelabs/kube-router/app/options"
 	"github.com/golang/glog"
@@ -119,6 +120,7 @@ type MetricsController struct {
 
 // Run prometheus metrics controller
 func (mc *MetricsController) Run(healthChan chan<- *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) error {
+	t := time.NewTicker(3 * time.Second)
 	defer wg.Done()
 	glog.Info("Starting metrics controller")
 
@@ -136,15 +138,21 @@ func (mc *MetricsController) Run(healthChan chan<- *ControllerHeartbeat, stopCh 
 			glog.Errorf("Metrics controller error: %s", err)
 		}
 	}()
-
-	sendHeartBeat(healthChan, "MC")
-
-	<-stopCh
-	glog.Infof("Shutting down metrics controller")
-	if err := srv.Shutdown(context.Background()); err != nil {
-		glog.Errorf("could not shutdown: %v", err)
+	for {
+		sendHeartBeat(healthChan, "MC")
+		select {
+		case <-stopCh:
+			glog.Infof("Shutting down metrics controller")
+			if err := srv.Shutdown(context.Background()); err != nil {
+				glog.Errorf("could not shutdown: %v", err)
+			}
+			return nil
+		case <-t.C:
+			glog.V(4).Info("Metrics controller tick")
 	}
-	return nil
+	
+
+
 }
 
 // NewMetricsController returns new MetricController object

--- a/app/controllers/metrics_controller.go
+++ b/app/controllers/metrics_controller.go
@@ -118,7 +118,7 @@ type MetricsController struct {
 }
 
 // Run prometheus metrics controller
-func (mc *MetricsController) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) error {
+func (mc *MetricsController) Run(healthChan chan<- *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) error {
 	defer wg.Done()
 	glog.Info("Starting metrics controller")
 
@@ -136,6 +136,8 @@ func (mc *MetricsController) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) err
 			glog.Errorf("Metrics controller error: %s", err)
 		}
 	}()
+
+	sendHeartBeat(healthChan, "MC")
 
 	<-stopCh
 	glog.Infof("Shutting down metrics controller")

--- a/app/controllers/network_policy_controller.go
+++ b/app/controllers/network_policy_controller.go
@@ -121,12 +121,12 @@ func (npc *NetworkPolicyController) Run(healthChan chan<- *ControllerHeartbeat, 
 			err := npc.Sync()
 			if err != nil {
 				glog.Errorf("Error during periodic sync: " + err.Error())
+			} else {
+				sendHeartBeat(healthChan, "NPC")
 			}
 		} else {
 			continue
 		}
-
-		sendHeartBeat(healthChan, "NPC")
 
 		select {
 		case <-stopCh:

--- a/app/controllers/network_policy_controller.go
+++ b/app/controllers/network_policy_controller.go
@@ -100,7 +100,7 @@ type protocolAndPort struct {
 }
 
 // Run runs forver till we receive notification on stopCh
-func (npc *NetworkPolicyController) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
+func (npc *NetworkPolicyController) Run(healthChan chan<- *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) {
 	t := time.NewTicker(npc.syncPeriod)
 	defer t.Stop()
 	defer wg.Done()
@@ -125,6 +125,8 @@ func (npc *NetworkPolicyController) Run(stopCh <-chan struct{}, wg *sync.WaitGro
 		} else {
 			continue
 		}
+
+		sendHeartBeat(healthChan, "NPC")
 
 		select {
 		case <-stopCh:

--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -82,7 +82,7 @@ const (
 )
 
 // Run runs forever until we are notified on stop channel
-func (nrc *NetworkRoutingController) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
+func (nrc *NetworkRoutingController) Run(healthChan chan<- *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) {
 	cidr, err := utils.GetPodCidrFromCniSpec("/etc/cni/net.d/10-kuberouter.conf")
 	if err != nil {
 		glog.Errorf("Failed to get pod CIDR from CNI conf file: %s", err.Error())
@@ -253,6 +253,8 @@ func (nrc *NetworkRoutingController) Run(stopCh <-chan struct{}, wg *sync.WaitGr
 		if nrc.bgpEnableInternal {
 			nrc.syncInternalPeers()
 		}
+
+		sendHeartBeat(healthChan, "NRC")
 
 		select {
 		case <-stopCh:

--- a/app/controllers/network_services_controller.go
+++ b/app/controllers/network_services_controller.go
@@ -99,7 +99,7 @@ type endpointsInfo struct {
 type endpointsInfoMap map[string][]endpointsInfo
 
 // Run periodically sync ipvs configuration to reflect desired state of services and endpoints
-func (nsc *NetworkServicesController) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) error {
+func (nsc *NetworkServicesController) Run(healthChan chan<- *ControllerHeartbeat, stopCh <-chan struct{}, wg *sync.WaitGroup) error {
 
 	t := time.NewTicker(nsc.syncPeriod)
 	defer t.Stop()
@@ -134,6 +134,8 @@ func (nsc *NetworkServicesController) Run(stopCh <-chan struct{}, wg *sync.WaitG
 		} else {
 			continue
 		}
+
+		sendHeartBeat(healthChan, "NSC")
 
 		select {
 		case <-stopCh:

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -119,6 +119,6 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	// fs.StringVar(&s.FullMeshPassword, "nodes-full-mesh-password", s.FullMeshPassword,
 	// 	"Password that cluster-node BGP servers will use to authenticate one another when \"--nodes-full-mesh\" is set.")
 	fs.StringVarP(&s.VLevel, "v", "v", "0", "log level for V logs")
-	fs.Uint16Var(&s.MetricsPort, "health-port", 0, "Health check port, 0 = Disabled")
+	fs.Uint16Var(&s.HealthPort, "health-port", 0, "Health check port, 0 = Disabled")
 
 }

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -41,6 +41,7 @@ type KubeRouterConfig struct {
 	MetricsPort         uint16
 	MetricsPath         string
 	VLevel              string
+	HealthPort          uint16
 	// FullMeshPassword    string
 }
 
@@ -118,5 +119,6 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	// fs.StringVar(&s.FullMeshPassword, "nodes-full-mesh-password", s.FullMeshPassword,
 	// 	"Password that cluster-node BGP servers will use to authenticate one another when \"--nodes-full-mesh\" is set.")
 	fs.StringVarP(&s.VLevel, "v", "v", "0", "log level for V logs")
+	fs.Uint16Var(&s.MetricsPort, "health-port", 0, "Health check port, 0 = Disabled")
 
 }

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -114,7 +114,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
 	fs.BoolVar(&s.EnablePprof, "enable-pprof", false,
 		"Enables pprof for debugging performance and memory leak issues.")
-	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, 0 = Disabled")
+	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, (Default 0, Disabled)")
 	fs.StringVar(&s.MetricsPath, "metrics-path", "/metrics", "Prometheus metrics path")
 	// fs.StringVar(&s.FullMeshPassword, "nodes-full-mesh-password", s.FullMeshPassword,
 	// 	"Password that cluster-node BGP servers will use to authenticate one another when \"--nodes-full-mesh\" is set.")

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -119,6 +119,6 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	// fs.StringVar(&s.FullMeshPassword, "nodes-full-mesh-password", s.FullMeshPassword,
 	// 	"Password that cluster-node BGP servers will use to authenticate one another when \"--nodes-full-mesh\" is set.")
 	fs.StringVarP(&s.VLevel, "v", "v", "0", "log level for V logs")
-	fs.Uint16Var(&s.HealthPort, "health-port", 0, "Health check port, 0 = Disabled")
+	fs.Uint16Var(&s.HealthPort, "health-port", 20244, "Health check port, 0 = Disabled")
 
 }

--- a/app/server.go
+++ b/app/server.go
@@ -111,7 +111,9 @@ func (kr *KubeRouter) stopApiWatchers() {
 func (kr *KubeRouter) Run() error {
 	var err error
 	var wg sync.WaitGroup
+
 	healthChan := make(chan *controllers.ControllerHeartbeat, 10)
+	defer close(healthChan)
 
 	stopCh := make(chan struct{})
 

--- a/app/server.go
+++ b/app/server.go
@@ -127,14 +127,12 @@ func (kr *KubeRouter) Run() error {
 		os.Exit(0)
 	}
 
-	if (kr.Config.HealthPort > 0) && (kr.Config.HealthPort <= 65535) {
-		hc, err := controllers.NewHealthController(kr.Config)
-		if err != nil {
-			return errors.New("Failed to create health controller: " + err.Error())
-		}
-		wg.Add(1)
-		go hc.Run(healthChan, stopCh, &wg)
+	hc, err := controllers.NewHealthController(kr.Config)
+	if err != nil {
+		return errors.New("Failed to create health controller: " + err.Error())
 	}
+	wg.Add(1)
+	go hc.Run(healthChan, stopCh, &wg)
 
 	if (kr.Config.MetricsPort > 0) && (kr.Config.MetricsPort <= 65535) {
 		kr.Config.MetricsEnabled = true

--- a/app/server.go
+++ b/app/server.go
@@ -141,7 +141,7 @@ func (kr *KubeRouter) Run() error {
 			return errors.New("Failed to create metrics controller: " + err.Error())
 		}
 		wg.Add(1)
-		go mc.Run(stopCh, &wg)
+		go mc.Run(healthChan, stopCh, &wg)
 
 	} else if kr.Config.MetricsPort > 65535 {
 		glog.Errorf("Metrics port must be over 0 and under 65535, given port: %d", kr.Config.MetricsPort)

--- a/app/server.go
+++ b/app/server.go
@@ -109,9 +109,9 @@ func (kr *KubeRouter) stopApiWatchers() {
 
 // Run starts the controllers and waits forever till we get SIGINT or SIGTERM
 func (kr *KubeRouter) Run() error {
-
 	var err error
 	var wg sync.WaitGroup
+	healthChan := make(chan *controllers.ControllerHeartbeat, 10)
 
 	stopCh := make(chan struct{})
 
@@ -125,6 +125,15 @@ func (kr *KubeRouter) Run() error {
 		os.Exit(0)
 	}
 
+	//if (kr.Config.HealthPort > 0) && (kr.Config.HealthPort <= 65535) {
+	hc, err := controllers.NewHealthController(kr.Config)
+	if err != nil {
+		return errors.New("Failed to create health controller: " + err.Error())
+	}
+	wg.Add(1)
+	go hc.Run(healthChan, stopCh, &wg)
+	//}
+
 	if (kr.Config.MetricsPort > 0) && (kr.Config.MetricsPort <= 65535) {
 		kr.Config.MetricsEnabled = true
 		mc, err := controllers.NewMetricsController(kr.Client, kr.Config)
@@ -133,6 +142,7 @@ func (kr *KubeRouter) Run() error {
 		}
 		wg.Add(1)
 		go mc.Run(stopCh, &wg)
+
 	} else if kr.Config.MetricsPort > 65535 {
 		glog.Errorf("Metrics port must be over 0 and under 65535, given port: %d", kr.Config.MetricsPort)
 		kr.Config.MetricsEnabled = false
@@ -167,7 +177,7 @@ func (kr *KubeRouter) Run() error {
 		}
 
 		wg.Add(1)
-		go nsc.Run(stopCh, &wg)
+		go nsc.Run(healthChan, stopCh, &wg)
 	}
 
 	// Handle SIGINT and SIGTERM

--- a/app/server.go
+++ b/app/server.go
@@ -125,14 +125,14 @@ func (kr *KubeRouter) Run() error {
 		os.Exit(0)
 	}
 
-	//if (kr.Config.HealthPort > 0) && (kr.Config.HealthPort <= 65535) {
-	hc, err := controllers.NewHealthController(kr.Config)
-	if err != nil {
-		return errors.New("Failed to create health controller: " + err.Error())
+	if (kr.Config.HealthPort > 0) && (kr.Config.HealthPort <= 65535) {
+		hc, err := controllers.NewHealthController(kr.Config)
+		if err != nil {
+			return errors.New("Failed to create health controller: " + err.Error())
+		}
+		wg.Add(1)
+		go hc.Run(healthChan, stopCh, &wg)
 	}
-	wg.Add(1)
-	go hc.Run(healthChan, stopCh, &wg)
-	//}
 
 	if (kr.Config.MetricsPort > 0) && (kr.Config.MetricsPort <= 65535) {
 		kr.Config.MetricsEnabled = true
@@ -157,7 +157,7 @@ func (kr *KubeRouter) Run() error {
 		}
 
 		wg.Add(1)
-		go npc.Run(stopCh, &wg)
+		go npc.Run(healthChan, stopCh, &wg)
 	}
 
 	if kr.Config.RunRouter {
@@ -167,7 +167,7 @@ func (kr *KubeRouter) Run() error {
 		}
 
 		wg.Add(1)
-		go nrc.Run(stopCh, &wg)
+		go nrc.Run(healthChan, stopCh, &wg)
 	}
 
 	if kr.Config.RunServiceProxy {

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -74,6 +74,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -50,7 +50,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -69,6 +69,12 @@ spec:
         - "--peer-router-asns=64512"
         - "--cluster-asn=64512"
         - "--advertise-cluster-ip=true"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         env:
         - name: NODE_NAME
           valueFrom:

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -69,12 +69,6 @@ spec:
         - "--peer-router-asns=64512"
         - "--cluster-asn=64512"
         - "--advertise-cluster-ip=true"
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 20244
-          initialDelaySeconds: 10
-          periodSeconds: 3
         env:
         - name: NODE_NAME
           valueFrom:

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -47,6 +47,10 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -50,7 +50,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -65,6 +65,12 @@ spec:
         - "--run-firewall=true"
         - "--run-service-proxy=true"
         - "--kubeconfig=/var/lib/kube-router/kubeconfig"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         env:
         - name: NODE_NAME
           valueFrom:

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -47,6 +47,10 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -65,17 +65,17 @@ spec:
         - "--run-firewall=true"
         - "--run-service-proxy=true"
         - "--kubeconfig=/var/lib/kube-router/kubeconfig"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
           initialDelaySeconds: 10
           periodSeconds: 3
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         resources:
           requests:
             cpu: 250m

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -45,17 +45,17 @@ spec:
         - "--run-router=true"
         - "--run-firewall=true"
         - "--run-service-proxy=false"
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
           initialDelaySeconds: 10
           periodSeconds: 3
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         resources:
           requests:
             cpu: 250m

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -31,7 +31,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -45,17 +45,17 @@ spec:
         - "--run-router=true"
         - "--run-firewall=true"
         - "--run-service-proxy=false"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
           initialDelaySeconds: 10
           periodSeconds: 3
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         resources:
           requests:
             cpu: 250m

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -50,6 +50,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -28,6 +28,10 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -45,6 +45,12 @@ spec:
           - "--cluster-asn=64512"
           - "--peer-router-ips=192.168.1.99"
           - "--peer-router-asns=64513"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         securityContext:
           privileged: true
         imagePullPolicy: Always

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -29,7 +29,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -45,12 +45,6 @@ spec:
           - "--cluster-asn=64512"
           - "--peer-router-ips=192.168.1.99"
           - "--peer-router-asns=64513"
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 20244
-          initialDelaySeconds: 10
-          periodSeconds: 3
         securityContext:
           privileged: true
         imagePullPolicy: Always
@@ -59,6 +53,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -26,6 +26,10 @@ metadata:
   labels:
     k8s-app: kube-router
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -37,6 +37,12 @@ spec:
       - name: kube-router
         image: cloudnativelabs/kube-router
         args: ["--run-router=true", "--run-firewall=true", "--run-service-proxy=true", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         securityContext:
           privileged: true
         imagePullPolicy: Always

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -26,6 +26,10 @@ metadata:
   labels:
     k8s-app: kube-router
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -37,12 +37,6 @@ spec:
       - name: kube-router
         image: cloudnativelabs/kube-router
         args: ["--run-router=true", "--run-firewall=true", "--run-service-proxy=true", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 20244
-          initialDelaySeconds: 10
-          periodSeconds: 3
         securityContext:
           privileged: true
         imagePullPolicy: Always
@@ -51,6 +45,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -37,12 +37,6 @@ spec:
       - name: kube-router
         image: cloudnativelabs/kube-router
         args: ["--run-router=false", "--run-firewall=true", "--run-service-proxy=false", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 20244
-          initialDelaySeconds: 10
-          periodSeconds: 3
         securityContext:
           privileged: true
         imagePullPolicy: Always
@@ -51,6 +45,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -37,6 +37,12 @@ spec:
       - name: kube-router
         image: cloudnativelabs/kube-router
         args: ["--run-router=false", "--run-firewall=true", "--run-service-proxy=false", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         securityContext:
           privileged: true
         imagePullPolicy: Always

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -26,6 +26,10 @@ metadata:
   labels:
     k8s-app: kube-router
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -37,12 +37,6 @@ spec:
       - name: kube-router
         image: cloudnativelabs/kube-router
         args: ["--run-router=false", "--run-firewall=false", "--run-service-proxy=true", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 20244
-          initialDelaySeconds: 10
-          periodSeconds: 3
         securityContext:
           privileged: true
         imagePullPolicy: Always
@@ -51,6 +45,12 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -37,6 +37,12 @@ spec:
       - name: kube-router
         image: cloudnativelabs/kube-router
         args: ["--run-router=false", "--run-firewall=false", "--run-service-proxy=true", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         securityContext:
           privileged: true
         imagePullPolicy: Always

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -29,7 +29,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -26,6 +26,10 @@ metadata:
   labels:
     k8s-app: kube-router
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -46,6 +46,12 @@ spec:
         - --run-firewall=true
         - --run-service-proxy=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         env:
         - name: NODE_NAME
           valueFrom:

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -46,17 +46,17 @@ spec:
         - --run-firewall=true
         - --run-service-proxy=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
           initialDelaySeconds: 10
           periodSeconds: 3
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         resources:
           requests:
             cpu: 250m

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -27,6 +27,10 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -30,7 +30,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -46,6 +46,12 @@ spec:
         - --run-firewall=true
         - --run-service-proxy=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         env:
         - name: NODE_NAME
           valueFrom:

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -46,17 +46,17 @@ spec:
         - --run-firewall=true
         - --run-service-proxy=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
           initialDelaySeconds: 10
           periodSeconds: 3
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         resources:
           requests:
             cpu: 250m

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -27,6 +27,10 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -30,7 +30,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -45,6 +45,12 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=false
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
         env:
         - name: NODE_NAME
           valueFrom:

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -27,6 +27,10 @@ metadata:
   name: kube-router
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 2
   template:
     metadata:
       labels:

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -30,7 +30,7 @@ spec:
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 2
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -45,17 +45,17 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=false
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
           initialDelaySeconds: 10
           periodSeconds: 3
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
         resources:
           requests:
             cpu: 250m


### PR DESCRIPTION
Running this PR in my test env over day. Please review but do not merge until I have test results.

Fixes: https://github.com/cloudnativelabs/kube-router/issues/80 and https://github.com/cloudnativelabs/kube-router/issues/171

* Added roling update strategy to all daemonsets. Max 2 unavail
* Added liveness check in daemonsets to use default health port of 20244 on /healthz
* Added health controller

Description: 

Added health controller that uses syncinterval of controllers + 5 seconds. If a controller isn't reporting in with a heartbeat within the interval it kube-router will be flagged as unhealthy on the /healthz endpoint

Docs are in health.md

