### PR TITLE
[WIP] support for Hostport

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -264,6 +264,41 @@ For destination hashing scheduling use:
 kubectl annotate service my-service "kube-router.io/service.scheduler=dh"
 ```
 
+### HostPort support
+
+If you would like to use `HostPort` functionality below changes are required in the manifest.
+
+- By default kube-router assumes CNI conf file to be `/etc/cni/net.d/10-kuberouter.conf`. Add an environment variable `KUBE_ROUTER_CNI_CONF_FILE` to kube-router manifest and set it to `/etc/cni/net.d/10-kuberouter.conflist`
+- Modify `kube-router-cfg` ConfigMap with CNI config that supports `portmap` as additional plug-in
+```
+    {
+       "cniVersion":"0.3.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          },
+          {
+             "type":"portmap",
+             "capabilities":{
+                "snat":true,
+                "portMappings":true
+             }
+          }
+       ]
+    }
+```
+- Update init container command to create `/etc/cni/net.d/10-kuberouter.conflist` file
+- Restart the container runtime
+
+For an e.g manifest please look at [manifest](../daemonset/kubeadm-kuberouter-all-features-hostport.yaml) with necessary changes required for `HostPort` functionality.
+
 ## BGP configuration
 
 [Configuring BGP Peers](bgp.md)

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -1,0 +1,184 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-router-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    k8s-app: kube-router
+data:
+  cni-conf.json: |
+    {
+       "cniVersion":"0.3.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          },
+          {
+             "type":"portmap",
+             "capabilities":{
+                "snat":true,
+                "portMappings":true
+             }
+          }
+       ]
+    }
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: kube-router
+    tier: node
+  name: kube-router
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-router
+        tier: node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      serviceAccountName: kube-router
+      serviceAccount: kube-router
+      containers:
+      - name: kube-router
+        image: cloudnativelabs/kube-router
+        imagePullPolicy: Always
+        args:
+        - --run-router=true
+        - --run-firewall=true
+        - --run-service-proxy=true
+        - --kubeconfig=/var/lib/kube-router/kubeconfig
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          initialDelaySeconds: 10
+          periodSeconds: 3
+        resources:
+          requests:
+            cpu: 250m
+            memory: 250Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kubeconfig
+          mountPath: /var/lib/kube-router
+          readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json ${TMP};
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
+      hostNetwork: true
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      volumes:
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: cni-conf-dir
+        hostPath:
+          path: /etc/cni/net.d
+      - name: kube-router-cfg
+        configMap:
+          name: kube-router-cfg
+      - name: kubeconfig
+        configMap:
+          name: kube-proxy
+          items:
+          - key: kubeconfig.conf
+            path: kubeconfig
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-router
+  namespace: kube-system
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - namespaces
+      - pods
+      - services
+      - nodes
+      - endpoints
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+    - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+    - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router
+subjects:
+- kind: ServiceAccount
+  name: kube-router
+  namespace: kube-system

--- a/utils/pod_cidr.go
+++ b/utils/pod_cidr.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"reflect"
+	"strings"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/plugins/ipam/host-local/backend/allocator"
@@ -15,22 +16,39 @@ import (
 
 // GetPodCidrFromCniSpec gets pod CIDR allocated to the node from CNI spec file and returns it
 func GetPodCidrFromCniSpec(cniConfFilePath string) (net.IPNet, error) {
-	netconfig, err := libcni.ConfFromFile(cniConfFilePath)
-	if err != nil {
-		return net.IPNet{}, fmt.Errorf("Failed to load CNI conf file: %s", err.Error())
-	}
-
+	var podCidr net.IPNet
+	var err error
 	var ipamConfig *allocator.IPAMConfig
-	ipamConfig, _, err = allocator.LoadIPAMConfig(netconfig.Bytes, "")
-	if err != nil {
-		return net.IPNet{}, fmt.Errorf("Failed to get IPAM details from the CNI conf file: %s", err.Error())
-	}
 
-	podCidr := net.IPNet(ipamConfig.Subnet)
+	if strings.HasSuffix(cniConfFilePath, ".conflist") {
+		var confList *libcni.NetworkConfigList
+		confList, err = libcni.ConfListFromFile(cniConfFilePath)
+		if err != nil {
+			return net.IPNet{}, fmt.Errorf("Failed to load CNI config list file: %s", err.Error())
+		}
+		for _, conf := range confList.Plugins {
+			if conf.Network.IPAM.Type != "" {
+				ipamConfig, _, err = allocator.LoadIPAMConfig(conf.Bytes, "")
+				if err != nil {
+					return net.IPNet{}, fmt.Errorf("Failed to get IPAM details from the CNI conf file: %s", err.Error())
+				}
+				break
+			}
+		}
+	} else {
+		netconfig, err := libcni.ConfFromFile(cniConfFilePath)
+		if err != nil {
+			return net.IPNet{}, fmt.Errorf("Failed to load CNI conf file: %s", err.Error())
+		}
+		ipamConfig, _, err = allocator.LoadIPAMConfig(netconfig.Bytes, "")
+		if err != nil {
+			return net.IPNet{}, fmt.Errorf("Failed to get IPAM details from the CNI conf file: %s", err.Error())
+		}
+	}
+	podCidr = net.IPNet(ipamConfig.Subnet)
 	if reflect.DeepEqual(podCidr, net.IPNet{}) {
 		return net.IPNet{}, errors.New("subnet missing from CNI IPAM")
 	}
-
 	return podCidr, nil
 }
 
@@ -41,15 +59,46 @@ func InsertPodCidrInCniSpec(cniConfFilePath string, cidr string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to load CNI conf file: %s", err.Error())
 	}
-	config := make(map[string]interface{})
-	err = json.Unmarshal(file, &config)
-	if err != nil {
-		return fmt.Errorf("Failed to parse JSON from CNI conf file: %s", err.Error())
-	}
+	var config interface{}
+	if strings.HasSuffix(cniConfFilePath, ".conflist") {
+		err = json.Unmarshal(file, &config)
+		if err != nil {
+			return fmt.Errorf("Failed to parse JSON from CNI conf file: %s", err.Error())
+		}
+		updatedCidr := false
+		configMap := config.(map[string]interface{})
+		for key := range configMap {
+			if key != "plugins" {
+				continue
+			}
+			// .conflist file has array of plug-in config. Find the one with ipam key
+			// and insert the CIDR for the node
+			pluginConfigs := configMap["plugins"].([]interface{})
+			for _, pluginConfig := range pluginConfigs {
+				pluginConfigMap := pluginConfig.(map[string]interface{})
+				if val, ok := pluginConfigMap["ipam"]; ok {
+					valObj := val.(map[string]interface{})
+					valObj["subnet"] = cidr
+					updatedCidr = true
+					break
+				}
+			}
+		}
 
-	config["ipam"].(map[string]interface{})["subnet"] = cidr
-	configJson, _ := json.Marshal(config)
-	err = ioutil.WriteFile(cniConfFilePath, configJson, 0644)
+		if !updatedCidr {
+			return fmt.Errorf("Failed to insert subnet cidr into CNI conf file: %s as CNI file is invalid.", cniConfFilePath)
+		}
+
+	} else {
+		err = json.Unmarshal(file, &config)
+		if err != nil {
+			return fmt.Errorf("Failed to parse JSON from CNI conf file: %s", err.Error())
+		}
+		pluginConfig := config.(map[string]interface{})
+		pluginConfig["ipam"].(map[string]interface{})["subnet"] = cidr
+	}
+	configJSON, _ := json.Marshal(config)
+	err = ioutil.WriteFile(cniConfFilePath, configJSON, 0644)
 	if err != nil {
 		return fmt.Errorf("Failed to insert subnet cidr into CNI conf file: %s", err.Error())
 	}


### PR DESCRIPTION
This PR addes support for hostport.

- CNI conf file to be used is moved to env variable. If env var is not present falls back to previous hard coded value i.e) `/etc/cni/net.d/10-kuberouter.conf`
- support for `.conflist` is added so you can specify multiple plug-ins
- sample [daemonset](https://github.com/murali-reddy/kube-router/blob/hostport/daemonset/kubeadm-kuberouter-all-features-hostport.yaml) is added with 
-- env variable set to `/etc/cni/net.d/10-kuberouter.conflist`
-- configmap with cni conf json with portmap plugin config
-- init container changes to add `.conflist` file
   

Image `cloudnativelabs/kube-router-git:hostport` has the changes in this PR.


