### PR TITLE
Dockefile: use ADD instead of COPY and rearrange

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 FROM alpine:3.7
 
-COPY kube-router gobgp /usr/local/bin/
-COPY build/image-assets/bashrc /root/.bashrc
-COPY build/image-assets/profile /root/.profile
-COPY build/image-assets/vimrc /root/.vimrc
-COPY build/image-assets/motd-kube-router.sh /etc/motd-kube-router.sh
-
 RUN apk add --no-cache \
       iptables \
       ipset \
@@ -17,8 +11,14 @@ RUN apk add --no-cache \
     mkdir -p /var/lib/gobgp && \
     mkdir -p /usr/local/share/bash-completion && \
     curl -L -o /usr/local/share/bash-completion/bash-completion \
-        https://raw.githubusercontent.com/scop/bash-completion/master/bash_completion && \
-    cd && \
+        https://raw.githubusercontent.com/scop/bash-completion/master/bash_completion
+
+ADD build/image-assets/bashrc /root/.bashrc
+ADD build/image-assets/profile /root/.profile
+ADD build/image-assets/vimrc /root/.vimrc
+ADD build/image-assets/motd-kube-router.sh /etc/motd-kube-router.sh
+ADD kube-router gobgp /usr/local/bin/
+RUN cd && \
     /usr/local/bin/gobgp --gen-cmpl --bash-cmpl-file /var/lib/gobgp/gobgp-completion.bash
 
 WORKDIR "/root"


### PR DESCRIPTION
Couple changes to improve local development, building, etc.

* use ADD instead of COPY to force cache invalidation
* rearrange to cache more expensive network downloads (apk, etc),
  ADDing locally built binaries at last