### PR TITLE
ipvs: add --ipvs-ignore-key for manually configured services

### DIFF
--- a/app/controllers/network_services_controller.go
+++ b/app/controllers/network_services_controller.go
@@ -58,6 +58,7 @@ var (
 type NetworkServicesController struct {
 	nodeIP              net.IP
 	nodeHostName        string
+	ipvsIgnoreKey       []string
 	syncPeriod          time.Duration
 	mu                  sync.Mutex
 	serviceMap          serviceInfoMap
@@ -583,6 +584,17 @@ func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInf
 		} else if ipvsSvc.FWMark != 0 {
 			key = fmt.Sprint(ipvsSvc.FWMark)
 		} else {
+			continue
+		}
+
+		ignoreSvc := false
+		for _, iKey := range nsc.ipvsIgnoreKey {
+			if key == iKey {
+				ignoreSvc = true
+				break
+			}
+		}
+		if ignoreSvc {
 			continue
 		}
 
@@ -1644,6 +1656,7 @@ func NewNetworkServicesController(clientset *kubernetes.Clientset, config *optio
 		nsc.MetricsEnabled = true
 	}
 
+	nsc.ipvsIgnoreKey = config.IpvsIgnoreKey
 	nsc.syncPeriod = config.IpvsSyncPeriod
 	nsc.globalHairpin = config.GlobalHairpinMode
 

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -25,6 +25,7 @@ type KubeRouterConfig struct {
 	HelpRequested       bool
 	HostnameOverride    string
 	IPTablesSyncPeriod  time.Duration
+	IpvsIgnoreKey       []string
 	IpvsSyncPeriod      time.Duration
 	Kubeconfig          string
 	MasqueradeAll       bool
@@ -82,6 +83,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"The delay between apiserver configuration synchronizations (e.g. '5s', '1m').  Must be greater than 0.")
 	fs.DurationVar(&s.IPTablesSyncPeriod, "iptables-sync-period", s.IPTablesSyncPeriod,
 		"The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0.")
+	fs.StringSliceVar(&s.IpvsIgnoreKey, "ipvs-ignore-key", s.IpvsIgnoreKey,
+		"A ipvs key to ignore when syncing (string '<ip>-<tcp|udp>-<port>' ie '192.168.1.1-tcp-80' or '<fwmark>' ie '1'). Multiple same options accepted.")
 	fs.DurationVar(&s.IpvsSyncPeriod, "ipvs-sync-period", s.IpvsSyncPeriod,
 		"The delay between ipvs config synchronizations (e.g. '5s', '1m', '2h22m'). Must be greater than 0.")
 	fs.DurationVar(&s.RoutesSyncPeriod, "routes-sync-period", s.RoutesSyncPeriod,


### PR DESCRIPTION
This is simply an escape hatch to tell kube-router not to touch specific
ipvs service's that have been manually configured outside the scope of
kube-router.