### PR TITLE
allow pod CIDR to be set using node annotations

### DIFF
--- a/utils/node.go
+++ b/utils/node.go
@@ -13,7 +13,6 @@ import (
 
 // GetNodeObject returns the node API object for the node
 func GetNodeObject(clientset kubernetes.Interface, hostnameOverride string) (*apiv1.Node, error) {
-
 	// assuming kube-router is running as pod, first check env NODE_NAME
 	nodeName := os.Getenv("NODE_NAME")
 	if nodeName != "" {

--- a/utils/pod_cidr_test.go
+++ b/utils/pod_cidr_test.go
@@ -8,6 +8,10 @@ import (
 	"os"
 	"reflect"
 	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_GetPodCidrFromCniSpec(t *testing.T) {
@@ -113,6 +117,82 @@ func Test_InsertPodCidrInCniSpec(t *testing.T) {
 				t.Logf("actual CNI config: %v", newContent)
 				t.Logf("expected CNI config: %v", testcase.newCni)
 				t.Error("did not get expected CNI config content")
+			}
+		})
+	}
+}
+
+func Test_GetPodCidrFromNodeSpec(t *testing.T) {
+	testcases := []struct {
+		name             string
+		hostnameOverride string
+		existingNode     *apiv1.Node
+		podCIDR          string
+		err              error
+	}{
+		{
+			"node with node.Spec.PoodCIDR",
+			"test-node",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Spec: apiv1.NodeSpec{
+					PodCIDR: "172.17.0.0/24",
+				},
+			},
+			"172.17.0.0/24",
+			nil,
+		},
+		{
+			"node with node.Annotations['kube-router.io/pod-cidr']",
+			"test-node",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						podCIDRAnnotation: "172.17.0.0/24",
+					},
+				},
+			},
+			"172.17.0.0/24",
+			nil,
+		},
+		{
+			"node with invalid pod cidr in node.Annotations['kube-router.io/pod-cidr']",
+			"test-node",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						podCIDRAnnotation: "172.17.0.0",
+					},
+				},
+			},
+			"",
+			errors.New("error parsing pod CIDR in node annotation: invalid CIDR address: 172.17.0.0"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			_, err := clientset.Core().Nodes().Create(testcase.existingNode)
+			if err != nil {
+				t.Fatalf("failed to create existing nodes for test: %v", err)
+			}
+
+			podCIDR, err := GetPodCidrFromNodeSpec(clientset, testcase.hostnameOverride)
+			if !reflect.DeepEqual(err, testcase.err) {
+				t.Logf("actual error: %v", err)
+				t.Logf("expected error: %v", testcase.err)
+				t.Error("did not get expected error")
+			}
+
+			if podCIDR != testcase.podCIDR {
+				t.Logf("actual podCIDR: %q", podCIDR)
+				t.Logf("expected podCIDR: %q", testcase.podCIDR)
+				t.Error("did not get expected podCIDR")
 			}
 		})
 	}


### PR DESCRIPTION
This allows you to set pod CIDR on a node by setting the annotation `kube-router.io/pod-cidr`. The pod CIDR in the annotation takes precedence over `node.Spec.PodCIDR`. Generally people should still rely on `node.Spec.PodCIDR` (set by the control plane), but this is a nice feature to have in case you need to migrate your cluster into a new IP space. 