### PR TITLE
withdraw ClusterIP bgp route for externalTrafficPolicy=Local when there are no local endpoints

### DIFF
--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -684,12 +684,13 @@ func (nrc *NetworkRoutingController) AdvertiseClusterIp(clusterIp string) error 
 		bgp.NewPathAttributeOrigin(0),
 		bgp.NewPathAttributeNextHop(nrc.nodeIP.String()),
 	}
+
 	glog.V(2).Infof("Advertising route: '%s/%s via %s' to peers", clusterIp, strconv.Itoa(32), nrc.nodeIP.String())
-	if _, err := nrc.bgpServer.AddPath("", []*table.Path{table.NewPath(nil, bgp.NewIPAddrPrefix(uint8(32),
-		clusterIp), false, attrs, time.Now(), false)}); err != nil {
-		return fmt.Errorf(err.Error())
-	}
-	return nil
+
+	_, err := nrc.bgpServer.AddPath("", []*table.Path{table.NewPath(nil, bgp.NewIPAddrPrefix(uint8(32),
+		clusterIp), false, attrs, time.Now(), false)})
+
+	return err
 }
 
 // UnadvertiseClusterIP  unadvertises the service cluster ip
@@ -701,11 +702,7 @@ func (nrc *NetworkRoutingController) UnadvertiseClusterIp(clusterIp string) erro
 
 	err := nrc.bgpServer.DeletePath([]byte(nil), 0, "", pathList)
 
-	if err != nil {
-		return fmt.Errorf(err.Error())
-	}
-
-	return nil
+	return err
 }
 
 

--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -705,7 +705,6 @@ func (nrc *NetworkRoutingController) UnadvertiseClusterIp(clusterIp string) erro
 	return err
 }
 
-
 // Each node advertises its pod CIDR to the nodes with same ASN (iBGP peers) and to the global BGP peer
 // or per node BGP peer. Each node ends up advertising not only pod CIDR assigned to the self but other
 // learned routes to the node pod CIDR's as well to global BGP peer or per node BGP peers. external BGP

--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -696,13 +696,8 @@ func (nrc *NetworkRoutingController) AdvertiseClusterIp(clusterIp string) error 
 func (nrc *NetworkRoutingController) UnadvertiseClusterIp(clusterIp string) error {
 	glog.V(2).Infof("Unadvertising route: '%s/%s via %s' to peers", clusterIp, strconv.Itoa(32), nrc.nodeIP.String())
 
-	attrs := []bgp.PathAttributeInterface{
-		bgp.NewPathAttributeOrigin(0),
-		bgp.NewPathAttributeNextHop(nrc.nodeIP.String()),
-	}
-
 	pathList := []*table.Path{table.NewPath(nil, bgp.NewIPAddrPrefix(uint8(32),
-		clusterIp), true, attrs, time.Now(), false)}
+		clusterIp), true, nil, time.Now(), false)}
 
 	err := nrc.bgpServer.DeletePath([]byte(nil), 0, "", pathList)
 


### PR DESCRIPTION
Hi guys,

I noticed that when using a Service object with type: Loadbalancer and externalTrafficPolicy: Local, the routes are not withdrawn. On my external BGP peer I could still see the route which caused for dropped packets when that route was used.

This pull request withdraws routes for this externalTrafficPolicy when there are no endpoints.