### PR TITLE
add 1s deley between ec2 API calls, and check if node has ec2 IAM

### DIFF
--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -94,6 +94,7 @@ type NetworkRoutingController struct {
 	bgpClusterId         uint32
 	cniConfFile          string
 	initSrcDstCheckDone  bool
+	ec2IamAuthorized     bool
 }
 
 // Run runs forever until we are notified on stop channel
@@ -1011,6 +1012,7 @@ func (nrc *NetworkRoutingController) disableSourceDestinationCheck() {
 		if err != nil {
 			awserr := err.(awserr.Error)
 			if awserr.Code() == "UnauthorizedOperation" {
+				nrc.ec2IamAuthorized = false
 				glog.Errorf("Node does not have necessary IAM creds to modify instance attribute. So skipping disabling src-dst check.")
 				return
 			}
@@ -1020,7 +1022,7 @@ func (nrc *NetworkRoutingController) disableSourceDestinationCheck() {
 		}
 
 		// to prevent EC2 rejecting API call due to API throttling give a delay between the calls
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1000 * time.Millisecond)
 	}
 }
 
@@ -1375,7 +1377,7 @@ func (nrc *NetworkRoutingController) OnNodeUpdate(nodeUpdate *watchers.NodeUpdat
 
 	// skip if first round of disableSourceDestinationCheck() is not done yet, this is to prevent
 	// all the nodes for all the node add update trying to perfrom disableSourceDestinationCheck
-	if nrc.initSrcDstCheckDone {
+	if nrc.initSrcDstCheckDone && nrc.ec2IamAuthorized {
 		nrc.disableSourceDestinationCheck()
 	}
 }
@@ -1603,6 +1605,9 @@ func NewNetworkRoutingController(clientset *kubernetes.Clientset,
 	nrc.bgpRRServer = false
 	nrc.bgpServerStarted = false
 	nrc.initSrcDstCheckDone = false
+
+	// lets start with assumption we hace necessary IAM creds to access EC2 api
+	nrc.ec2IamAuthorized = true
 
 	nrc.cniConfFile = os.Getenv("KUBE_ROUTER_CNI_CONF_FILE")
 	if nrc.cniConfFile == "" {


### PR DESCRIPTION

- Adding 1s delay between ec2 API calls
- node performs disable src-dst check ONLY if it has necessary IAM