### PR TITLE
[jjo] support advertising status.loadBalancer.ingress IPs via flag

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -264,6 +264,25 @@ For destination hashing scheduling use:
 kubectl annotate service my-service "kube-router.io/service.scheduler=dh"
 ```
 
+### LoadBalancer IPs
+
+If you want to also advertise loadbalancer set IPs
+(`status.loadBalancer.ingress` IPs), e.g. when using it with MetalLb,
+add the `--advertise-loadbalancer-ip` flag (`false` by default).
+
+To selectively disable this behaviour per-service, you can use
+the `kube-router.io/service.skiplbips` annotation as e.g.:
+`$ kubectl annotate service my-external-service "kube-router.io/service.skiplbips=true"`
+
+In concrete, unless the Service is annotated as per above, the
+`--advertise-loadbalancer-ip` flag will make Service's Ingress IP(s)
+set by the LoadBalancer to:
+* be locally added to nodes' `kube-dummy-if` network interface
+* be advertised to BGP peers
+
+FYI Above has been successfully tested together with
+[MetalLB](https://github.com/google/metallb) in ARP mode.
+
 ### HostPort support
 
 If you would like to use `HostPort` functionality below changes are required in the manifest.

--- a/app/controllers/network_routes_controller_test.go
+++ b/app/controllers/network_routes_controller_test.go
@@ -185,7 +185,12 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			}
 
 			waitForListerWithTimeout(time.Second*10, t)
-			testcase.nrc.advertiseClusterIPs()
+			// ClusterIPs
+			testcase.nrc.advertiseClusterIp = true
+			testcase.nrc.advertiseExternalIp = false
+			testcase.nrc.advertiseLoadBalancerIp = false
+			toAdvertise, toUnAdvertise, _ := testcase.nrc.getIpsToAdvertise(false)
+			testcase.nrc.advertiseIPs(toAdvertise, toUnAdvertise)
 
 			watchEvents := waitForBGPWatchEventWithTimeout(time.Second*10, len(testcase.watchEvents), w, t)
 			for _, watchEvent := range watchEvents {
@@ -348,6 +353,101 @@ func Test_advertiseExternalIPs(t *testing.T) {
 				"1.1.1.1/32": true,
 			},
 		},
+		{
+			"add bgp path to loadbalancerIP for service with LoadBalancer IP",
+			&NetworkRoutingController{
+				bgpServer: gobgp.NewBgpServer(),
+			},
+			[]*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "svc-1",
+						Annotations: map[string]string{
+							"kube-router.io/service.uselbips": "true",
+						},
+					},
+					Spec: v1core.ServiceSpec{
+						Type:      "LoadBalancer",
+						ClusterIP: "10.0.0.1",
+					},
+					Status: v1core.ServiceStatus{
+						LoadBalancer: v1core.LoadBalancerStatus{
+							Ingress: []v1core.LoadBalancerIngress{
+								{
+									IP: "10.0.255.1",
+								},
+								{
+									IP: "10.0.255.2",
+								},
+							},
+						},
+					},
+				},
+			},
+			map[string]bool{
+				"10.0.255.1/32": true,
+				"10.0.255.2/32": true,
+			},
+		},
+		{
+			"no bgp path to nil loadbalancerIPs for service with LoadBalancer",
+			&NetworkRoutingController{
+				bgpServer: gobgp.NewBgpServer(),
+			},
+			[]*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "svc-1",
+						Annotations: map[string]string{
+							"kube-router.io/service.uselbips": "true",
+						},
+					},
+					Spec: v1core.ServiceSpec{
+						Type:      "LoadBalancer",
+						ClusterIP: "10.0.0.1",
+					},
+					Status: v1core.ServiceStatus{
+						LoadBalancer: v1core.LoadBalancerStatus{
+							Ingress: []v1core.LoadBalancerIngress{},
+						},
+					},
+				},
+			},
+			map[string]bool{},
+		},
+		{
+			"no bgp path to loadbalancerIPs for service with LoadBalancer and skiplbips annotation",
+			&NetworkRoutingController{
+				bgpServer: gobgp.NewBgpServer(),
+			},
+			[]*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "svc-1",
+						Annotations: map[string]string{
+							"kube-router.io/service.skiplbips": "true",
+						},
+					},
+					Spec: v1core.ServiceSpec{
+						Type:      "LoadBalancer",
+						ClusterIP: "10.0.0.1",
+					},
+					Status: v1core.ServiceStatus{
+						LoadBalancer: v1core.LoadBalancerStatus{
+							Ingress: []v1core.LoadBalancerIngress{
+								{
+									IP: "10.0.255.1",
+								},
+								{
+									IP: "10.0.255.2",
+								},
+							},
+						},
+					},
+				},
+			},
+			map[string]bool{},
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -379,7 +479,12 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			}
 
 			waitForListerWithTimeout(time.Second*10, t)
-			testcase.nrc.advertiseExternalIPs()
+			// ExternalIPs
+			testcase.nrc.advertiseClusterIp = false
+			testcase.nrc.advertiseExternalIp = true
+			testcase.nrc.advertiseLoadBalancerIp = true
+			toAdvertise, toUnAdvertise, _ := testcase.nrc.getIpsToAdvertise(false)
+			testcase.nrc.advertiseIPs(toAdvertise, toUnAdvertise)
 
 			watchEvents := waitForBGPWatchEventWithTimeout(time.Second*10, len(testcase.watchEvents), w, t)
 			for _, watchEvent := range watchEvents {
@@ -1290,6 +1395,10 @@ func Test_addExportPolicies(t *testing.T) {
 				t.Errorf("failed to create existing nodes: %v", err)
 			}
 
+			// ClusterIPs and ExternalIPs
+			testcase.nrc.advertiseClusterIp = true
+			testcase.nrc.advertiseExternalIp = true
+			testcase.nrc.advertiseLoadBalancerIp = false
 			err = testcase.nrc.addExportPolicies()
 			if !reflect.DeepEqual(err, testcase.err) {
 				t.Logf("expected err %v", testcase.err)

--- a/app/controllers/network_routes_controller_test.go
+++ b/app/controllers/network_routes_controller_test.go
@@ -362,9 +362,6 @@ func Test_advertiseExternalIPs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "svc-1",
-						Annotations: map[string]string{
-							"kube-router.io/service.uselbips": "true",
-						},
 					},
 					Spec: v1core.ServiceSpec{
 						Type:      "LoadBalancer",
@@ -398,9 +395,6 @@ func Test_advertiseExternalIPs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "svc-1",
-						Annotations: map[string]string{
-							"kube-router.io/service.uselbips": "true",
-						},
 					},
 					Spec: v1core.ServiceSpec{
 						Type:      "LoadBalancer",

--- a/app/controllers/network_services_controller.go
+++ b/app/controllers/network_services_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/vishvananda/netns"
 	"golang.org/x/net/context"
 	api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -46,6 +47,7 @@ const (
 	svcSchedulerAnnotation = "kube-router.io/service.scheduler"
 	svcHairpinAnnotation   = "kube-router.io/service.hairpin"
 	svcLocalAnnotation     = "kube-router.io/service.local"
+	svcUseLbIpsAnnotation  = "kube-router.io/service.uselbips"
 )
 
 var (
@@ -88,7 +90,9 @@ type serviceInfo struct {
 	scheduler                string
 	directServerReturnMethod string
 	hairpin                  bool
+	uselbips                 bool
 	externalIPs              []string
+	loadBalancerIPs          []string
 	local                    bool
 }
 
@@ -427,7 +431,13 @@ func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInf
 		// based on FWMARK to enable Direct server return functionality. DSR requires a director
 		// without a VIP http://www.austintek.com/LVS/LVS-HOWTO/HOWTO/LVS-HOWTO.routing_to_VIP-less_director.html
 		// to avoid martian packets
-		for _, externalIP := range svc.externalIPs {
+		extIPSet := sets.NewString(svc.externalIPs...)
+		if svc.uselbips {
+			extIPSet = extIPSet.Union(sets.NewString(svc.loadBalancerIPs...))
+		}
+		glog.V(2).Infof("Service \"%s\" using extIPSet: %v", svc.name, extIPSet.List())
+
+		for _, externalIP := range extIPSet.List() {
 			var externalIpServiceId string
 			if svc.directServerReturn && svc.directServerReturnMethod == "tunnel" {
 				ipvsExternalIPSvc, err := ipvsAddFWMarkService(net.ParseIP(externalIP), protocol, uint16(svc.port), svc.sessionAffinity, svc.scheduler)
@@ -871,9 +881,13 @@ func buildServicesInfo() serviceInfoMap {
 				}
 			}
 			copy(svcInfo.externalIPs, svc.Spec.ExternalIPs)
+			for _, lbIngress := range svc.Status.LoadBalancer.Ingress {
+				svcInfo.loadBalancerIPs = append(svcInfo.loadBalancerIPs, lbIngress.IP)
+			}
 			svcInfo.sessionAffinity = svc.Spec.SessionAffinity == "ClientIP"
 			_, svcInfo.hairpin = svc.ObjectMeta.Annotations[svcHairpinAnnotation]
 			_, svcInfo.local = svc.ObjectMeta.Annotations[svcLocalAnnotation]
+			_, svcInfo.uselbips = svc.ObjectMeta.Annotations[svcUseLbIpsAnnotation]
 			if svc.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyTypeLocal {
 				svcInfo.local = true
 			}

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -8,41 +8,42 @@ import (
 )
 
 type KubeRouterConfig struct {
-	AdvertiseClusterIp  bool
-	AdvertiseExternalIp bool
-	BGPGracefulRestart  bool
-	CleanupConfig       bool
-	ClusterAsn          uint
-	ClusterCIDR         string
-	ConfigSyncPeriod    time.Duration
-	EnableiBGP          bool
-	EnableOverlay       bool
-	EnablePodEgress     bool
-	EnablePprof         bool
-	FullMeshMode        bool
-	GlobalHairpinMode   bool
-	HealthPort          uint16
-	HelpRequested       bool
-	HostnameOverride    string
-	IPTablesSyncPeriod  time.Duration
-	IpvsSyncPeriod      time.Duration
-	Kubeconfig          string
-	MasqueradeAll       bool
-	Master              string
-	MetricsEnabled      bool
-	MetricsPath         string
-	MetricsPort         uint16
-	NodePortBindOnAllIp bool
-	PeerASNs            []uint
-	PeerMultihopTtl     uint8
-	PeerPasswords       []string
-	PeerRouters         []net.IP
-	RoutesSyncPeriod    time.Duration
-	RunFirewall         bool
-	RunRouter           bool
-	RunServiceProxy     bool
-	Version             bool
-	VLevel              string
+	AdvertiseClusterIp      bool
+	AdvertiseExternalIp     bool
+	AdvertiseLoadBalancerIp bool
+	BGPGracefulRestart      bool
+	CleanupConfig           bool
+	ClusterAsn              uint
+	ClusterCIDR             string
+	ConfigSyncPeriod        time.Duration
+	EnableiBGP              bool
+	EnableOverlay           bool
+	EnablePodEgress         bool
+	EnablePprof             bool
+	FullMeshMode            bool
+	GlobalHairpinMode       bool
+	HealthPort              uint16
+	HelpRequested           bool
+	HostnameOverride        string
+	IPTablesSyncPeriod      time.Duration
+	IpvsSyncPeriod          time.Duration
+	Kubeconfig              string
+	MasqueradeAll           bool
+	Master                  string
+	MetricsEnabled          bool
+	MetricsPath             string
+	MetricsPort             uint16
+	NodePortBindOnAllIp     bool
+	PeerASNs                []uint
+	PeerMultihopTtl         uint8
+	PeerPasswords           []string
+	PeerRouters             []net.IP
+	RoutesSyncPeriod        time.Duration
+	RunFirewall             bool
+	RunRouter               bool
+	RunServiceProxy         bool
+	Version                 bool
+	VLevel                  string
 	// FullMeshPassword    string
 }
 
@@ -90,6 +91,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Add Cluster IP of the service to the RIB so that it gets advertises to the BGP peers.")
 	fs.BoolVar(&s.AdvertiseExternalIp, "advertise-external-ip", false,
 		"Add External IP of service to the RIB so that it gets advertised to the BGP peers.")
+	fs.BoolVar(&s.AdvertiseLoadBalancerIp, "advertise-loadbalancer-ip", false,
+		"Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.")
 	fs.IPSliceVar(&s.PeerRouters, "peer-router-ips", s.PeerRouters,
 		"The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's.")
 	fs.UintVar(&s.ClusterAsn, "cluster-asn", s.ClusterAsn,


### PR DESCRIPTION
* add `--advertise-loadbalancer-ip` flag, which will make Service's
  Ingress IP(s)set by the LoadBalancer to:
  - be locally added to nodes' `kube-dummy-if` network interface
  - be advertised to BGP peers

* support "kube-router.io/service.skiplbips=true" per Service
  annotation to selectively skip above

* refactor several functions with dupped code to streamline logic as:
  - `getIpsToAdvertise()` which calls ->
    - `getClusterIPs()`
    - `getExternalIPs()`
    - `getLoadBalancerIPs()`
    and contains nodeHasEndpoints logic, returns:
      (ipsToAdvertise, ipsToUnAdvertise)
  - advertiseIPs() which is essentially previous advertiseClusterIPs()
    (which was previously used to advertise _any_ IP actually, ie misnamed),
    with logic to un/advertise based on both passed arguments:
      (ipsToAdvertise, ipsToUnAdvertise)

This is cleanup / rebase from PR #339, find there previous discussion
with @SEJeff @murali-reddy @andrewsykim re: usage and implementation.