### PR TITLE
fix bug where default ASN is used for iBGP peering

### DIFF
--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -1131,7 +1131,7 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 		n := &config.Neighbor{
 			Config: config.NeighborConfig{
 				NeighborAddress: nodeIP.String(),
-				PeerAs:          nrc.defaultNodeAsnNumber,
+				PeerAs:          nrc.nodeAsnNumber,
 			},
 		}
 


### PR DESCRIPTION
Fixes a bug where the default ASN was used (64512) even though the annotation `kube-router.io/node.asn` was set. 