### PR TITLE
Fixed the /var/run/docker.sock permissions in the DSR example

### DIFF
--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -74,6 +74,7 @@ spec:
           readOnly: true
         - name: run
           mountPath: /var/run/docker.sock
+          readOnly: true
       initContainers:
       - name: install-cni
         image: busybox

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -71,9 +71,9 @@ spec:
           mountPath: /etc/cni/net.d
         - name: kubeconfig
           mountPath: /var/lib/kube-router
+          readOnly: true
         - name: run
           mountPath: /var/run/docker.sock
-          readOnly: true
       initContainers:
       - name: install-cni
         image: busybox


### PR DESCRIPTION
I guess the example config was copied wrong. https://github.com/cloudnativelabs/kube-router/blob/master/daemonset/kubeadm-kuberouter-all-features.yaml has `kubeconfig` set to RO but I think you need RW access to talk to docker?

Alternatively both need to be RO