### PR TITLE
trim end newline in byte[] base64.StdEncoding.DecodeString

### DIFF
--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -562,11 +562,12 @@ func stringSliceB64Decode(s []string) ([]string, error) {
 	ss := make([]string, 0)
 	for _, b64String := range s {
 		decoded, err := base64.StdEncoding.DecodeString(b64String)
+		decodedStr := strings.TrimSuffix(string(decoded), "\n")
 		if err != nil {
 			return nil, fmt.Errorf("Could not parse \"%s\" as a base64 encoded string",
 				b64String)
 		}
-		ss = append(ss, string(decoded))
+		ss = append(ss, decodedStr)
 	}
 	return ss, nil
 }


### PR DESCRIPTION

For BGP kube-router takes base64 encoded string as passoword as described in

https://github.com/cloudnativelabs/kube-router/blob/master/Documentation/bgp.md#base64-encoding-passwords

While decoding to plain text, a newline was part of byte array casuing problems. Fix trims the end new line. 