### PR TITLE
always generate IPIP tunnels regardless of node subnets

### DIFF
--- a/app/controllers/network_routes_controller.go
+++ b/app/controllers/network_routes_controller.go
@@ -856,80 +856,67 @@ func (nrc *NetworkRoutingController) injectRoute(path *table.Path) error {
 	dst, _ := netlink.ParseIPNet(nlri.String())
 	var route *netlink.Route
 
-	// check if the neighbour is in same subnet
-	if !nrc.nodeSubnet.Contains(nexthop) {
-		tunnelName := generateTunnelName(nexthop.String())
-		glog.Infof("Found node: " + nexthop.String() + " to be in different subnet.")
+	tunnelName := generateTunnelName(nexthop.String())
 
-		// if overlay is not enabled then skip creating tunnels and adding route
-		if !nrc.enableOverlays {
-			glog.Infof("Found node: " + nexthop.String() + " to be in different subnet but overlays are " +
-				"disabled so not creating any tunnel and injecting route for the node's pod CIDR.")
-			glog.Infof("Cleaning up if there is any existing tunnel interface for the node")
-			link, err := netlink.LinkByName(tunnelName)
-			if err != nil {
-				return nil
-			}
-			err = netlink.LinkDel(link)
-			if err != nil {
-				glog.Errorf("Failed to delete tunnel link for the node due to " + err.Error())
-			}
+	// if overlay is not enabled then skip creating tunnels and adding route
+	if !nrc.enableOverlays {
+		glog.Infof("Cleaning up if there is any existing tunnel interface for the node")
+		link, err := netlink.LinkByName(tunnelName)
+		if err != nil {
 			return nil
 		}
+		err = netlink.LinkDel(link)
+		if err != nil {
+			glog.Errorf("Failed to delete tunnel link for the node due to " + err.Error())
+		}
+		return nil
+	}
 
-		// create ip-in-ip tunnel and inject route as overlay is enabled
-		var link netlink.Link
-		var err error
+	// create ip-in-ip tunnel and inject route as overlay is enabled
+	var link netlink.Link
+	var err error
+	link, err = netlink.LinkByName(tunnelName)
+	if err != nil {
+		out, err := exec.Command("ip", "tunnel", "add", tunnelName, "mode", "ipip", "local", nrc.nodeIP.String(),
+			"remote", nexthop.String(), "dev", nrc.nodeInterface).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Route not injected for the route advertised by the node %s "+
+				"Failed to create tunnel interface %s. error: %s, output: %s",
+				nexthop.String(), tunnelName, err, string(out))
+		}
+
 		link, err = netlink.LinkByName(tunnelName)
 		if err != nil {
-			glog.Infof("Found node: " + nexthop.String() + " to be in different subnet. Creating tunnel: " + tunnelName)
-			out, err := exec.Command("ip", "tunnel", "add", tunnelName, "mode", "ipip", "local", nrc.nodeIP.String(),
-				"remote", nexthop.String(), "dev", nrc.nodeInterface).CombinedOutput()
-			if err != nil {
-				return fmt.Errorf("Route not injected for the route advertised by the node %s "+
-					"Failed to create tunnel interface %s. error: %s, output: %s",
-					nexthop.String(), tunnelName, err, string(out))
-			}
-
-			link, err = netlink.LinkByName(tunnelName)
-			if err != nil {
-				return fmt.Errorf("Route not injected for the route advertised by the node %s "+
-					"Failed to get tunnel interface by name error: %s", tunnelName, err)
-			}
-			if err := netlink.LinkSetUp(link); err != nil {
-				return errors.New("Failed to bring tunnel interface " + tunnelName + " up due to: " + err.Error())
-			}
-			// reduce the MTU by 20 bytes to accommodate ipip tunnel overhead
-			if err := netlink.LinkSetMTU(link, link.Attrs().MTU-20); err != nil {
-				return errors.New("Failed to set MTU of tunnel interface " + tunnelName + " up due to: " + err.Error())
-			}
-		} else {
-			glog.Infof("Tunnel interface: " + tunnelName + " for the node " + nexthop.String() + " already exists.")
+			return fmt.Errorf("Route not injected for the route advertised by the node %s "+
+				"Failed to get tunnel interface by name error: %s", tunnelName, err)
 		}
-
-		out, err := exec.Command("ip", "route", "list", "table", customRouteTableID).CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("Failed to verify if route already exists in %s table: %s",
-				customRouteTableName, err.Error())
+		if err := netlink.LinkSetUp(link); err != nil {
+			return errors.New("Failed to bring tunnel interface " + tunnelName + " up due to: " + err.Error())
 		}
-		if !strings.Contains(string(out), tunnelName) {
-			if out, err = exec.Command("ip", "route", "add", nexthop.String(), "dev", tunnelName, "table",
-				customRouteTableID).CombinedOutput(); err != nil {
-				return fmt.Errorf("failed to add route in custom route table, err: %s, output: %s", err, string(out))
-			}
-		}
-
-		route = &netlink.Route{
-			LinkIndex: link.Attrs().Index,
-			Dst:       dst,
-			Protocol:  0x11,
+		// reduce the MTU by 20 bytes to accommodate ipip tunnel overhead
+		if err := netlink.LinkSetMTU(link, link.Attrs().MTU-20); err != nil {
+			return errors.New("Failed to set MTU of tunnel interface " + tunnelName + " up due to: " + err.Error())
 		}
 	} else {
-		route = &netlink.Route{
-			Dst:      dst,
-			Gw:       nexthop,
-			Protocol: 0x11,
+		glog.Infof("Tunnel interface: " + tunnelName + " for the node " + nexthop.String() + " already exists.")
+	}
+
+	out, err := exec.Command("ip", "route", "list", "table", customRouteTableID).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to verify if route already exists in %s table: %s",
+			customRouteTableName, err.Error())
+	}
+	if !strings.Contains(string(out), tunnelName) {
+		if out, err = exec.Command("ip", "route", "add", nexthop.String(), "dev", tunnelName, "table",
+			customRouteTableID).CombinedOutput(); err != nil {
+			return fmt.Errorf("failed to add route in custom route table, err: %s, output: %s", err, string(out))
 		}
+	}
+
+	route = &netlink.Route{
+		LinkIndex: link.Attrs().Index,
+		Dst:       dst,
+		Protocol:  0x11,
 	}
 
 	if path.IsWithdraw {


### PR DESCRIPTION
I'm not sure how graceful this change will be for existing clusters that have the previous routes (no IPIP tunnel). At one point we'll want to account for clusters that are upgrading from a previous version. I think for now it's okay :) 