### PR TITLE
Initial kube-router E2E framework on DigitalOcean

### DIFF
--- a/e2e/bgp.go
+++ b/e2e/bgp.go
@@ -1,0 +1,54 @@
+package e2e
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1core "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var _ = Describe("BGP E2E", func() {
+
+	Context("BGP config", func() {
+		var clientset kubernetes.Interface
+		var nodes *v1core.NodeList
+		var err error
+
+		BeforeEach(func() {
+			clientset, err = clientFromKubeConfig()
+			if err != nil {
+				Fail(fmt.Sprintf("failed to setup clientset from kubeconfig: %s", err))
+			}
+
+			nodes, err = clientset.CoreV1().Nodes().List(meta_v1.ListOptions{})
+			if err != nil {
+				Fail(fmt.Sprintf("failed to get cluster nodes: %v", err))
+			}
+		})
+
+		It("should have the correct number of neighbours", func() {
+			expectedNeighbours := len(nodes.Items) - 1
+			for _, node := range nodes.Items {
+				ip, err := getNodePublicIP(node)
+				if err != nil {
+					Fail(fmt.Sprintf("could not find public IP for node %s, err: %s", ip, err))
+				}
+
+				bgpClient, err := newBGPClient(ip)
+				if err != nil {
+					Fail(fmt.Sprintf("failed to setup bgp client: %s", err))
+				}
+				defer bgpClient.Close()
+
+				neighbors, err := bgpClient.ListNeighbor()
+				Expect(neighbors).To(HaveLen(expectedNeighbours))
+				Expect(err).To(Succeed())
+			}
+		})
+
+	})
+})

--- a/e2e/e2e.sh
+++ b/e2e/e2e.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function destroy_cluster {
+  $SCRIPT_DIR/scripts/destroy_cluster.sh
+}
+
+$SCRIPT_DIR/scripts/setup_cluster.sh
+trap destroy_cluster EXIT
+
+echo "==> running kube-router E2E tests..."
+go test github.com/cloudnativelabs/kube-router/e2e/... 

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -1,0 +1,111 @@
+package e2e
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	bgpclient "github.com/osrg/gobgp/client"
+
+	v1core "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "E2E Suite")
+}
+
+func getNodePublicIP(node v1core.Node) (string, error) {
+	for _, address := range node.Status.Addresses {
+		if address.Type == v1core.NodeExternalIP {
+			return address.Address, nil
+		}
+	}
+
+	return "", errors.New("node did not have an external IP set")
+}
+
+func newBGPClient(nodeIP string) (*bgpclient.Client, error) {
+	return bgpclient.New(nodeIP + ":50051")
+}
+
+func clientFromKubeConfig() (kubernetes.Interface, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		return nil, errors.New("KUBECONFIG is required")
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientset, nil
+}
+
+func executeSSHCmd(command string, hostIP string, config *ssh.ClientConfig) (string, error) {
+	conn, err := ssh.Dial("tcp", fmt.Sprintf("%s:22", hostIP), config)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	session, err := conn.NewSession()
+	if err != nil {
+		return "", err
+	}
+	defer session.Close()
+
+	var stdoutBuf bytes.Buffer
+	session.Stdout = &stdoutBuf
+	session.Run(command)
+
+	return stdoutBuf.String(), nil
+}
+
+func newSSHClientConfig() (*ssh.ClientConfig, error) {
+	keyFile := os.Getenv("SSHKEY_FILE")
+	if keyFile == "" {
+		return nil, errors.New("SSHKEY_FILE is required")
+	}
+
+	key, err := sshKeyAuth(keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ssh.ClientConfig{
+		User: "core",
+		Auth: []ssh.AuthMethod{
+			key,
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}, nil
+}
+
+func sshKeyAuth(file string) (ssh.AuthMethod, error) {
+	buffer, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := ssh.ParsePrivateKey(buffer)
+	if err != nil {
+		return nil, err
+	}
+	return ssh.PublicKeys(key), nil
+}

--- a/e2e/ipvs.go
+++ b/e2e/ipvs.go
@@ -1,0 +1,265 @@
+package e2e
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"golang.org/x/crypto/ssh"
+
+	apps_v1beta2 "k8s.io/api/apps/v1beta2"
+	v1core "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+var _ = Describe("IPVS E2E", func() {
+	var clientset kubernetes.Interface
+	var nodes *v1core.NodeList
+	var appName string
+	var testsvc *v1core.Service
+	var testdeploy *apps_v1beta2.Deployment
+	var sshConfig *ssh.ClientConfig
+	var err error
+
+	BeforeEach(func() {
+		clientset, err = clientFromKubeConfig()
+		if err != nil {
+			Fail(fmt.Sprintf("failed to setup clientset from kubeconfig: %s", err))
+		}
+
+		nodes, err = clientset.CoreV1().Nodes().List(meta_v1.ListOptions{})
+		if err != nil {
+			Fail(fmt.Sprintf("failed to get cluster nodes: %v", err))
+		}
+
+		sshConfig, err = newSSHClientConfig()
+		if err != nil {
+			Fail(fmt.Sprintf("failed to create ssh client config: %s", err))
+		}
+	})
+	Context("IPVS with no backends", func() {
+		BeforeEach(func() {
+			appName = "test-" + randStringRunes(5)
+
+			testsvc = generateSvc(appName)
+			testsvc, err = clientset.CoreV1().Services(meta_v1.NamespaceDefault).Create(testsvc)
+			if err != nil {
+				Fail(fmt.Sprintf("failed to create test service: %v", err))
+			}
+		})
+		It("should have the correct IPVS", func() {
+			defer func() {
+				clientset.CoreV1().Services(meta_v1.NamespaceDefault).Delete(testsvc.Name, &meta_v1.DeleteOptions{})
+			}()
+
+			for _, node := range nodes.Items {
+				nodeIP, err := getNodePublicIP(node)
+				if err != nil {
+					Fail(fmt.Sprintf("failed to get node public IP: %s", err))
+				}
+
+				expectedOutput := fmt.Sprintf("TCP  %s:80 rr", testsvc.Spec.ClusterIP)
+
+				ipvsOutput, err := executeSSHCmd("sudo ipvsadm --list --numeric", nodeIP, sshConfig)
+				Expect(err).To(Succeed())
+
+				if !strings.Contains(strings.TrimSpace(ipvsOutput), expectedOutput) {
+					fmt.Fprintf(GinkgoWriter, fmt.Sprintf("expected IPVS output to contain: \n%s\n", expectedOutput))
+					fmt.Fprintf(GinkgoWriter, fmt.Sprintf("actual IPVS output: \n%s\n", ipvsOutput))
+					Fail("unexpected IPVS output")
+				}
+			}
+		})
+
+	})
+	Context("IPVS with backends", func() {
+		BeforeEach(func() {
+			appName = "test-" + randStringRunes(5)
+
+			testsvc = generateSvc(appName)
+			testsvc, err = clientset.CoreV1().Services(meta_v1.NamespaceDefault).Create(testsvc)
+			if err != nil {
+				Fail(fmt.Sprintf("failed to create test service: %v", err))
+			}
+
+			testdeploy = generateDeploy(appName)
+			testdeploy, err = clientset.AppsV1beta2().Deployments(meta_v1.NamespaceDefault).Create(testdeploy)
+			if err != nil {
+				Fail(fmt.Sprintf("failed to create test deployment: %v", err))
+			}
+			if err := waitForDeploymentWithTimeout(clientset, appName, 2*time.Minute); err != nil {
+				Fail(fmt.Sprintf("failed waiting for deployment to finish: %v", err))
+			}
+		})
+
+		It("should have the correct IPVS", func() {
+			defer func() {
+				clientset.CoreV1().Services(meta_v1.NamespaceDefault).Delete(testsvc.Name, &meta_v1.DeleteOptions{})
+				clientset.AppsV1beta2().Deployments(meta_v1.NamespaceDefault).Delete(testdeploy.Name, &meta_v1.DeleteOptions{})
+			}()
+
+			for _, node := range nodes.Items {
+				nodeIP, err := getNodePublicIP(node)
+				if err != nil {
+					Fail(fmt.Sprintf("failed to get node public IP: %s", err))
+				}
+
+				podIPs, err := getPodsIPsForApp(clientset, appName)
+				if err != nil {
+					Fail(fmt.Sprintf("failed to get pods for app %s, err: %s", appName, err))
+				}
+
+				expectedOutput := fmt.Sprintf("TCP  %s:80 rr", testsvc.Spec.ClusterIP)
+				for _, podIP := range podIPs {
+					expectedOutput += fmt.Sprintf("\n  -> %s:80                Masq    1      0          0         ", podIP)
+				}
+
+				ipvsOutput, err := executeSSHCmd("sudo ipvsadm --list --numeric", nodeIP, sshConfig)
+				Expect(err).To(Succeed())
+
+				if !strings.Contains(ipvsOutput, expectedOutput) {
+					fmt.Fprintf(GinkgoWriter, fmt.Sprintf("expected IPVS output to contain: \n%s\n", expectedOutput))
+					fmt.Fprintf(GinkgoWriter, fmt.Sprintf("actual IPVS output: \n%s\n", ipvsOutput))
+					Fail("unexpected IPVS output")
+				}
+			}
+		})
+
+	})
+})
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
+
+func generateSvc(name string) *v1core.Service {
+	return &v1core.Service{
+		TypeMeta: meta_v1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      name,
+			Namespace: meta_v1.NamespaceDefault,
+		},
+		Spec: v1core.ServiceSpec{
+			Ports: []v1core.ServicePort{
+				{
+					Name:       "80-tcp",
+					Port:       int32(80),
+					TargetPort: intstr.FromInt(80),
+					Protocol:   "TCP",
+				},
+			},
+			Selector: map[string]string{
+				"app": name,
+			},
+		},
+	}
+}
+
+func generateDeploy(name string) *apps_v1beta2.Deployment {
+	return &apps_v1beta2.Deployment{
+		TypeMeta: meta_v1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"app": name,
+			},
+			Namespace: meta_v1.NamespaceDefault,
+		},
+		Spec: apps_v1beta2.DeploymentSpec{
+			Replicas: int32Ptr(2),
+			Selector: &meta_v1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
+			Template: v1core.PodTemplateSpec{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: name,
+					Labels: map[string]string{
+						"app": name,
+					},
+				},
+				Spec: v1core.PodSpec{
+					Containers: []v1core.Container{
+						{
+							Name:  name,
+							Image: "nginx:1.7.9",
+							Ports: []v1core.ContainerPort{
+								{
+									ContainerPort: int32(80),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func getPodsIPsForApp(clientset kubernetes.Interface, appName string) ([]string, error) {
+	pods, err := clientset.CoreV1().Pods(meta_v1.NamespaceDefault).List(meta_v1.ListOptions{
+		LabelSelector: fmt.Sprintf("app=%s", appName),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error listing pods: %s", err)
+	}
+
+	var ips []string
+	for _, pod := range pods.Items {
+		if pod.Status.PodIP == "" {
+			return nil, fmt.Errorf("pod %s did not have an IP", pod.Name)
+		}
+		ips = append(ips, pod.Status.PodIP)
+	}
+
+	sort.Strings(ips)
+	return ips, nil
+}
+
+func waitForDeploymentWithTimeout(clientset kubernetes.Interface, deployment string, timeout time.Duration) error {
+	tick := time.Tick(1 * time.Second)
+	timeoutCh := time.After(timeout)
+	for {
+		select {
+		case <-timeoutCh:
+			return fmt.Errorf("timed out waiting for deployment %s to finish", deployment)
+		case <-tick:
+			deploy, err := clientset.AppsV1beta2().Deployments(meta_v1.NamespaceDefault).Get(deployment, meta_v1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to check deployment status: %s", err)
+			}
+
+			if deploy.Status.Replicas == deploy.Status.ReadyReplicas {
+				return nil
+			}
+		}
+	}
+}
+
+func int32Ptr(val int32) *int32 {
+	return &val
+}
+
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}

--- a/e2e/scripts/destroy_cluster.sh
+++ b/e2e/scripts/destroy_cluster.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -z $KOPS_CLUSTER_NAME ]; then
+  echo "KOPS_CLUSTER_NAME is required for e2e tests"
+fi
+
+kops delete cluster --name $KOPS_CLUSTER_NAME --yes
+

--- a/e2e/scripts/setup_cluster.sh
+++ b/e2e/scripts/setup_cluster.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source $SCRIPT_DIR/utils.sh
+
+if [[ -z $KOPS_CLUSTER_NAME ]]; then
+  echo "KOPS_CLUSTER_NAME is required for e2e tests"
+  exit 1
+fi
+
+if [[ -z $KUBE_ROUTER_DOCKER_IMAGE ]]; then
+  echo "KUBE_ROUTER_DOCKER_IMAGE is required for e2e tests"
+  exit 1
+fi
+
+SSH_PUBLIC_KEYFILE="${SSH_PUBLIC_KEYFILE:-~/.ssh/id_rsa.pub}"
+KOPS_REGION="${KOPS_REGION:-tor1}"
+
+install_kubectl
+get_kops
+create_template $version
+
+cd $GOPATH/src/k8s.io/kops
+make clean && make kops && cp $GOPATH/src/k8s.io/kops/.build/local/kops $GOPATH/bin/
+
+export PATH=$PATH:$GOPATH/bin/
+
+kops create cluster --cloud=digitalocean \
+  --name=$KOPS_CLUSTER_NAME \
+  --zones=$KOPS_REGION \
+  --ssh-public-key=$SSH_PUBLIC_KEYFILE \
+  --networking=kube-router \
+  --yes
+
+echo "==> waiting until kubernetes cluster is ready..."
+
+n=0
+until [ $n -ge 300 ]
+do
+  if [[ $(kubectl -n kube-system get po | grep kube-router | grep Running | wc -l) -eq 3 ]]; then
+    echo "==> kubernetes cluster is ready"
+    exit 0
+  fi
+
+  n=$[$n+1]
+  sleep 5
+done
+
+echo "==> timed out waiting for kubernetes cluster to be ready"
+exit 1

--- a/e2e/scripts/utils.sh
+++ b/e2e/scripts/utils.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+
+function get_kops {
+  echo "==> fetching the latest kops codebase"
+  go get -u k8s.io/kops
+}
+
+function install_kubectl {
+  if ! kubectl version --client=true > /dev/null; then	
+    echo "==> installing kubectl"
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+    chmod +x ./kubectl
+    sudo mv ./kubectl /usr/local/bin/kubectl
+  fi
+}
+
+function create_template {
+  local version=$1
+
+  cat > $GOPATH/src/k8s.io/kops/upup/models/cloudup/resources/addons/networking.kuberouter/k8s-1.6.yaml.template <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-router-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    k8s-app: kube-router
+data:
+  cni-conf.json: |
+    {
+      "name":"kubernetes",
+      "type":"bridge",
+      "bridge":"kube-bridge",
+      "isDefaultGateway":true,
+      "ipam": {
+        "type":"host-local"
+      }
+    }
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: kube-router
+    tier: node
+  name: kube-router
+  namespace: kube-system
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-router
+        tier: node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      containers:
+      - name: kube-router
+        image: $KUBE_ROUTER_DOCKER_IMAGE
+        args:
+        - --run-router=true
+        - --run-firewall=true
+        - --run-service-proxy=true
+        - --advertise-cluster-ip=true
+        - --advertise-external-ip=true
+        - --kubeconfig=/var/lib/kube-router/kubeconfig
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        resources:
+          requests:
+            cpu: 100m
+            memory: 250Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kubeconfig
+          mountPath: /var/lib/kube-router/kubeconfig
+          readOnly: true
+      initContainers:
+      - name: install-cni
+        image: busybox
+        command:
+        - /bin/sh
+        - -c
+        - set -e -x;
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+            cp /etc/kube-router/cni-conf.json \${TMP};
+            mv \${TMP} /etc/cni/net.d/10-kuberouter.conf;
+          fi
+        volumeMounts:
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
+      hostNetwork: true
+      serviceAccountName: kube-router
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /lib/modules
+        name: lib-modules
+      - hostPath:
+          path: /etc/cni/net.d
+        name: cni-conf-dir
+      - name: kubeconfig
+        hostPath:
+          path: /var/lib/kube-router/kubeconfig
+      - name: kube-router-cfg
+        configMap:
+          name: kube-router-cfg
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router
+  namespace: kube-system
+---
+# Kube-router roles
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-router
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+      - services
+      - nodes
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: ["extensions"]
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: kube-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router
+subjects:
+- kind: ServiceAccount
+  name: kube-router
+  namespace: kube-system
+- kind: User
+  name: system:kube-router
+EOF
+}


### PR DESCRIPTION
Uses kops to stand up a Kubernetes cluster on DigitalOcean with kube-router. 

Some notes:
* kops support on DigitalOcean is *very alpha* so I have to build kops from master for the time being
* I think there's a lot more test coverage we can add with the E2E tests but wanted to get the initial framework done and go from there
* I still need to figure out how we should configure travis CI to run E2E tests but it should be relatively easy to setup. 

related: https://github.com/kubernetes/kops/issues/2150