### PR TITLE
Enable GoBGP logging from kube-router

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -108,6 +108,7 @@ Usage of kube-router:
       --cluster-asn uint                 ASN number under which cluster nodes will run iBGP.
       --cluster-cidr string              CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.
       --config-sync-period duration      The delay between apiserver configuration synchronizations (e.g. '5s', '1m').  Must be greater than 0. (default 1m0s)
+      --enable-gobgp-logging             Set --enable-gobgp-logging=true to print GoBGP logs
       --enable-ibgp                      Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)
       --enable-overlay                   When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
       --enable-pod-egress                SNAT traffic from Pods to destinations outside the cluster. (default true)

--- a/app/options/options.go
+++ b/app/options/options.go
@@ -17,6 +17,7 @@ type KubeRouterConfig struct {
 	ClusterCIDR             string
 	ConfigSyncPeriod        time.Duration
 	EnableiBGP              bool
+	EnableGoBGPLogging      bool
 	EnableOverlay           bool
 	EnablePodEgress         bool
 	EnablePprof             bool
@@ -126,4 +127,5 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	// 	"Password that cluster-node BGP servers will use to authenticate one another when \"--nodes-full-mesh\" is set.")
 	fs.StringVarP(&s.VLevel, "v", "v", "0", "log level for V logs")
 	fs.Uint16Var(&s.HealthPort, "health-port", 20244, "Health check port, 0 = Disabled")
+	fs.BoolVar(&s.EnableGoBGPLogging, "enable-gobgp-logging", s.EnableGoBGPLogging, "Set --enable-gobgp-logging=true to print GoBGP logs")
 }

--- a/app/server.go
+++ b/app/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cloudnativelabs/kube-router/app/options"
 	"github.com/golang/glog"
 
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -134,6 +135,14 @@ func (kr *KubeRouter) Run() error {
 	}
 
 	if kr.Config.RunRouter {
+
+		// enable GoBGP debug log
+		if kr.Config.EnableGoBGPLogging {
+			log.SetLevel(log.DebugLevel)
+		} else {
+			log.SetLevel(log.WarnLevel)
+		}
+
 		nrc, err := controllers.NewNetworkRoutingController(kr.Client, kr.Config, nodeInformer, svcInformer, epInformer)
 		if err != nil {
 			return errors.New("Failed to create network routing controller: " + err.Error())


### PR DESCRIPTION
Fixes #363

its not pretty due to mix of different loggers, but would be useful

```
I0414 00:34:33.968640       1 server.go:191] Running /usr/local/bin/kube-router version v0.2.0-beta.2-dirty, built on 2018-04-14T06:00:04+0530, go1.8
I0414 00:34:33.971037       1 health_controller.go:127] Starting health controller
I0414 00:34:34.026174       1 network_policy_controller.go:122] Starting network policy controller
I0414 00:34:34.059874       1 network_services_controller.go:219] Starting network services controller
I0414 00:34:34.646592       1 network_routes_controller.go:1072] Disabled source destination check for the instance: i-0ac8abfa3b687feec
I0414 00:34:35.844095       1 network_routes_controller.go:1072] Disabled source destination check for the instance: i-0bab4ad49982bb1a5
I0414 00:34:37.023625       1 network_routes_controller.go:1072] Disabled source destination check for the instance: i-05cf066329ccc4abe
I0414 00:34:38.035102       1 network_routes_controller.go:217] Starting network route controller
I0414 00:34:38.038113       1 network_routes_controller.go:1596] Could not find BGP peer info for the node in the node annotations so skipping configuring peer.
time="2018-04-14T00:34:38Z" level=debug msg="create Destination" Key=100.96.0.0/24 Topic=Table
time="2018-04-14T00:34:38Z" level=debug msg="Processing destination" Key=100.96.0.0/24 Topic=table
time="2018-04-14T00:34:38Z" level=debug msg="computeKnownBestPath known pathlist: 1" Topic=Table
time="2018-04-14T00:34:38Z" level=info msg="Add a peer configuration for:172.20.46.210" Topic=Peer
time="2018-04-14T00:34:38Z" level=info msg="Add a peer configuration for:172.20.72.207" Topic=Peer
time="2018-04-14T00:34:38Z" level=debug msg="IdleHoldTimer expired" Duration=0 Key=172.20.46.210 Topic=Peer
time="2018-04-14T00:34:38Z" level=debug msg="IdleHoldTimer expired" Duration=0 Key=172.20.72.207 Topic=Peer
time="2018-04-14T00:34:38Z" level=debug msg="state changed" Key=172.20.46.210 Topic=Peer new=BGP_FSM_ACTIVE old=BGP_FSM_IDLE reason=idle-hold-timer-expired
time="2018-04-14T00:34:38Z" level=debug msg="state changed" Key=172.20.72.207 Topic=Peer new=BGP_FSM_ACTIVE old=BGP_FSM_IDLE reason=idle-hold-timer-expired
time="2018-04-14T00:34:52Z" level=debug msg="failed to connect: getsockopt: connection refused" Key=172.20.72.207 Topic=Peer
time="2018-04-14T00:34:55Z" level=debug msg="state changed" Key=172.20.46.210 Topic=Peer new=BGP_FSM_OPENSENT old=BGP_FSM_ACTIVE reason=new-connection
time="2018-04-14T00:34:55Z" level=info msg="skiped asn negotiation: peer-as: 64512, peer-type: internal" Key=172.20.46.210 State=BGP_FSM_OPENSENT Topic=Peer
time="2018-04-14T00:34:55Z" level=debug msg="state changed" Key=172.20.46.210 Topic=Peer new=BGP_FSM_OPENCONFIRM old=BGP_FSM_OPENSENT reason=open-msg-received
time="2018-04-14T00:34:55Z" level=info msg="Peer Up" Key=172.20.46.210 State=BGP_FSM_OPENCONFIRM Topic=Peer
time="2018-04-14T00:34:55Z" level=debug msg="state changed" Key=172.20.46.210 Topic=Peer new=BGP_FSM_ESTABLISHED old=BGP_FSM_OPENCONFIRM reason=open-msg-negotiated
```