### PR TITLE
minimize sync() done by the controllers

### DIFF
--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -115,7 +115,7 @@ func (kr *KubeRouter) Run() error {
 	nsInformer := informerFactory.Core().V1().Namespaces().Informer()
 	npInformer := informerFactory.Networking().V1().NetworkPolicies().Informer()
 
-	go informerFactory.Start(stopCh)
+	informerFactory.Start(stopCh)
 	informerFactory.WaitForCacheSync(stopCh)
 
 	if kr.Config.RunFirewall {

--- a/pkg/controllers/network_policy_controller.go
+++ b/pkg/controllers/network_policy_controller.go
@@ -160,6 +160,8 @@ func (npc *NetworkPolicyController) OnPodUpdate(obj interface{}) {
 
 // OnNetworkPolicyUpdate handles updates to network policy from the kubernetes api server
 func (npc *NetworkPolicyController) OnNetworkPolicyUpdate(obj interface{}) {
+	netpol := obj.(*networking.NetworkPolicy)
+	glog.V(2).Infof("Received network policy update namespace:%s netpol name:%s", netpol.Namespace, netpol.Name)
 	err := npc.Sync()
 	if err != nil {
 		glog.Errorf("Error syncing on network policy update: %s", err)
@@ -168,12 +170,12 @@ func (npc *NetworkPolicyController) OnNetworkPolicyUpdate(obj interface{}) {
 
 // OnNamespaceUpdate handles updates to namespace from kubernetes api server
 func (npc *NetworkPolicyController) OnNamespaceUpdate(obj interface{}) {
+	namespace := obj.(*api.Namespace)
+	glog.V(2).Infof("Received namespece: %v update", namespace.Name)
 	// namespace (and annotations on it) has no significance in GA ver of network policy
 	if npc.v1NetworkPolicy {
 		return
 	}
-
-	namespace := obj.(*api.Namespace)
 	glog.V(2).Infof("Received update for namespace: %s", namespace.Name)
 
 	err := npc.Sync()

--- a/pkg/controllers/network_routes_controller.go
+++ b/pkg/controllers/network_routes_controller.go
@@ -261,10 +261,11 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *ControllerHeartbeat,
 			glog.Errorf("failed to get routes to advertise/withdraw %s", err)
 		}
 
+		glog.V(1).Infof("Performing periodic sync of service VIP routes")
 		nrc.advertiseVIPs(toAdvertise)
 		nrc.withdrawVIPs(toWithdraw)
 
-		glog.V(1).Info("Performing periodic sync of the routes")
+		glog.V(1).Info("Performing periodic sync of pod CIDR routes")
 		err = nrc.advertisePodRoute()
 		if err != nil {
 			glog.Errorf("Error advertising route: %s", err.Error())
@@ -1438,6 +1439,7 @@ func (nrc *NetworkRoutingController) OnServiceUpdate(obj interface{}) {
 		return
 	}
 
+	glog.V(1).Infof("Received update to service Name: %v in Namespace %v from watch API", svc.Name, svc.Namespace)
 	toAdvertise, toWithdraw, err := nrc.getVIPsForService(svc, true)
 	if err != nil {
 		glog.Errorf("error getting routes for service: %s, err: %s", svc.Name, err)
@@ -1464,6 +1466,7 @@ func (nrc *NetworkRoutingController) OnServiceDelete(obj interface{}) {
 		return
 	}
 
+	glog.V(1).Infof("Received event to delete service Name: %v in Namespace %v from watch API", svc.Name, svc.Namespace)
 	toAdvertise, toWithdraw, err := nrc.getVIPsForService(svc, true)
 	if err != nil {
 		glog.Errorf("failed to get clean up routes for deleted service %s", svc.Name)

--- a/pkg/controllers/network_services_controller.go
+++ b/pkg/controllers/network_services_controller.go
@@ -353,8 +353,6 @@ func (nsc *NetworkServicesController) OnEndpointsUpdate(obj interface{}) {
 	nsc.mu.Lock()
 	defer nsc.mu.Unlock()
 
-	glog.V(1).Info("Received endpoints update from watch API")
-
 	ep, ok := obj.(*api.Endpoints)
 	if !ok {
 		glog.Error("could not convert endpoints update object to *v1.Endpoints")
@@ -365,14 +363,19 @@ func (nsc *NetworkServicesController) OnEndpointsUpdate(obj interface{}) {
 		return
 	}
 
-	// build new endpoints map to reflect the change
+	glog.V(1).Infof("Received update to endpoints Name: %v in Namespace %v from watch API", ep.Name, ep.Namespace)
+
+	// build new service and endpoints map to reflect the change
+	newServiceMap := nsc.buildServicesInfo()
 	newEndpointsMap := nsc.buildEndpointsInfo()
 
 	if len(newEndpointsMap) != len(nsc.endpointsMap) || !reflect.DeepEqual(newEndpointsMap, nsc.endpointsMap) {
 		nsc.endpointsMap = newEndpointsMap
+		nsc.serviceMap = newServiceMap
+		glog.V(1).Infof("Syncing IPVS services sync on endpoint Name: %v in Namespace %v update.", ep.Name, ep.Namespace)
 		nsc.syncIpvsServices(nsc.serviceMap, nsc.endpointsMap)
 	} else {
-		glog.V(1).Info("Skipping ipvs server sync on endpoints because nothing changed")
+		glog.V(1).Infof("Skipping IPVS services sync on endpoint Name: %v in Namespace %v update as nothing changed", ep.Name, ep.Namespace)
 	}
 }
 
@@ -381,16 +384,25 @@ func (nsc *NetworkServicesController) OnServiceUpdate(obj interface{}) {
 	nsc.mu.Lock()
 	defer nsc.mu.Unlock()
 
-	glog.V(1).Info("Received service update from watch API")
+	svc, ok := obj.(*api.Service)
+	if !ok {
+		glog.Error("could not convert service update object to *v1.Service")
+		return
+	}
 
-	// build new services map to reflect the change
+	glog.V(1).Infof("Received update to service Name: %v in Namespace %v from watch API", svc.Name, svc.Namespace)
+
+	// build new service and endpoints map to reflect the change
 	newServiceMap := nsc.buildServicesInfo()
+	newEndpointsMap := nsc.buildEndpointsInfo()
 
 	if len(newServiceMap) != len(nsc.serviceMap) || !reflect.DeepEqual(newServiceMap, nsc.serviceMap) {
+		nsc.endpointsMap = newEndpointsMap
 		nsc.serviceMap = newServiceMap
+		glog.V(1).Infof("Syncing IPVS services sync on update to service Name: %v in Namespace %v update.", svc.Name, svc.Namespace)
 		nsc.syncIpvsServices(nsc.serviceMap, nsc.endpointsMap)
 	} else {
-		glog.V(1).Info("Skipping ipvs server sync on service update because nothing changed")
+		glog.V(1).Infof("Skipping syncing IPVS services on service Name: %v in Namespace %v update as nothing changed", svc.Name, svc.Namespace)
 	}
 }
 
@@ -532,7 +544,6 @@ func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInf
 		if !svc.skipLbIps {
 			extIPSet = extIPSet.Union(sets.NewString(svc.loadBalancerIPs...))
 		}
-		glog.V(2).Infof("Service \"%s\" using extIPSet: %v", svc.name, extIPSet.List())
 
 		for _, externalIP := range extIPSet.List() {
 			var externalIpServiceId string

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -48,10 +48,10 @@ type KubeRouterConfig struct {
 }
 
 func NewKubeRouterConfig() *KubeRouterConfig {
-	return &KubeRouterConfig{ConfigSyncPeriod: 1 * time.Minute,
-		IpvsSyncPeriod:     1 * time.Minute,
-		IPTablesSyncPeriod: 1 * time.Minute,
-		RoutesSyncPeriod:   1 * time.Minute,
+	return &KubeRouterConfig{ConfigSyncPeriod: 0 * time.Minute,
+		IpvsSyncPeriod:     5 * time.Minute,
+		IPTablesSyncPeriod: 5 * time.Minute,
+		RoutesSyncPeriod:   5 * time.Minute,
 		EnableOverlay:      true,
 	}
 }


### PR DESCRIPTION
Following changes are done

- use resync period as 0 when creating SharedInformerFactory, this sync wil actually replay all the cached objects, resulting sync() in each controller for each object

- regular full sync will ber performed periodically. Increased defualt value to 5 min.

I will submit a new PR, where work queue will be used to reque the object so that a retry can be performed in case of error. So that full sync interval can be even pushed further.