### PR TITLE
add kube-router.io/bgp.max.paths annotation

### DIFF
--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -160,12 +160,20 @@ rules:
     resources:
       - namespaces
       - pods
-      - services
       - nodes
       - endpoints
     verbs:
       - list
       - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - get
+      - update
       - watch
   - apiGroups:
     - "networking.k8s.io"

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -156,12 +156,20 @@ rules:
     resources:
       - namespaces
       - pods
-      - services
       - nodes
       - endpoints
     verbs:
       - list
       - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - get
+      - update
       - watch
   - apiGroups:
     - "networking.k8s.io"

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -123,12 +123,20 @@ rules:
     resources:
       - namespaces
       - pods
-      - services
       - nodes
       - endpoints
     verbs:
       - list
       - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - get
+      - update
       - watch
   - apiGroups:
     - "networking.k8s.io"

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -139,12 +139,20 @@ rules:
     resources:
       - namespaces
       - pods
-      - services
       - nodes
       - endpoints
     verbs:
       - list
       - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - get
+      - update
       - watch
   - apiGroups:
     - "networking.k8s.io"

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -146,12 +146,20 @@ rules:
     resources:
       - namespaces
       - pods
-      - services
       - nodes
       - endpoints
     verbs:
       - list
       - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - get
+      - update
       - watch
   - apiGroups:
     - "networking.k8s.io"

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -131,12 +131,20 @@ rules:
     resources:
       - namespaces
       - pods
-      - services
       - nodes
       - endpoints
     verbs:
       - list
       - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - get
+      - update
       - watch
   - apiGroups:
     - "networking.k8s.io"

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -127,12 +127,20 @@ rules:
     resources:
       - namespaces
       - pods
-      - services
       - nodes
       - endpoints
     verbs:
       - list
       - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - list
+      - get
+      - update
       - watch
   - apiGroups:
     - "networking.k8s.io"

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -39,6 +39,8 @@ const (
 	podSubnetsIPSetName  = "kube-router-pod-subnets"
 	nodeAddrsIPSetName   = "kube-router-node-ips"
 
+	bgpMaxPathsAnnotation             = "kube-router.io/bgp.max.paths"
+	bgpMaxPathsStateAnnotation        = "kube-router.io/bgp.state.max.paths"
 	nodeASNAnnotation                 = "kube-router.io/node.asn"
 	peerASNAnnotation                 = "kube-router.io/peer.asns"
 	peerIPAnnotation                  = "kube-router.io/peer.ips"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -41,3 +41,12 @@ func (b *Broadcaster) Notify(instance interface{}) {
 		go listener.OnUpdate(instance)
 	}
 }
+
+func ArrayHasString(a []string, search string) bool {
+	for _, item := range a {
+		if item == search {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/k8s.io/client-go/util/retry/OWNERS
+++ b/vendor/k8s.io/client-go/util/retry/OWNERS
@@ -1,0 +1,2 @@
+reviewers:
+- caesarxuchao

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// DefaultBackoff is the recommended backoff for a conflict where a client
+// may be attempting to make an unrelated modification to a resource under
+// active management by one or more controllers.
+var DefaultBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Millisecond,
+	Factor:   5.0,
+	Jitter:   0.1,
+}
+
+// RetryConflict executes the provided function repeatedly, retrying if the server returns a conflicting
+// write. Callers should preserve previous executions if they wish to retry changes. It performs an
+// exponential backoff.
+//
+//     var pod *api.Pod
+//     err := RetryOnConflict(DefaultBackoff, func() (err error) {
+//       pod, err = c.Pods("mynamespace").UpdateStatus(podStatus)
+//       return
+//     })
+//     if err != nil {
+//       // may be conflict if max retries were hit
+//       return err
+//     }
+//     ...
+//
+// TODO: Make Backoff an interface?
+func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
+	var lastConflictErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.IsConflict(err):
+			lastConflictErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastConflictErr
+	}
+	return err
+}

--- a/vendor/k8s.io/client-go/util/retry/util_test.go
+++ b/vendor/k8s.io/client-go/util/retry/util_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func TestRetryOnConflict(t *testing.T) {
+	opts := wait.Backoff{Factor: 1.0, Steps: 3}
+	conflictErr := errors.NewConflict(schema.GroupResource{Resource: "test"}, "other", nil)
+
+	// never returns
+	err := RetryOnConflict(opts, func() error {
+		return conflictErr
+	})
+	if err != conflictErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// returns immediately
+	i := 0
+	err = RetryOnConflict(opts, func() error {
+		i++
+		return nil
+	})
+	if err != nil || i != 1 {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// returns immediately on error
+	testErr := fmt.Errorf("some other error")
+	err = RetryOnConflict(opts, func() error {
+		return testErr
+	})
+	if err != testErr {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// keeps retrying
+	i = 0
+	err = RetryOnConflict(opts, func() error {
+		if i < 2 {
+			i++
+			return errors.NewConflict(schema.GroupResource{Resource: "test"}, "other", nil)
+		}
+		return nil
+	})
+	if err != nil || i != 2 {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Add the ability to define a max number of paths out of the cluster.
This is useful for debugging on-premises environments where upstream
routers may have issues with asynchronous routing (due to ECMP VIP).

The state of which nodes have selected themselves to be in the available
paths is available in the kube-router.io/bgp.state.paths annotation.
You should be able to steer which nodes are the L4 director by setting
this as well.

At this time, there is no controller watching for nodes to be deleted or
become NotReady and update the annotation.

Also: wasn't sure how to add in the new vendor'd dependencies so I just copied them in.