### PR TITLE
update clusteripprefixset so that BGP export policies allow advertising the service VIP

### DIFF
--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -93,6 +93,11 @@ func (nrc *NetworkRoutingController) OnServiceUpdate(obj interface{}) {
 		return
 	}
 
+	err = nrc.addExportPolicies()
+	if err != nil {
+		glog.Errorf("Error adding BGP export policies: %s", err.Error())
+	}
+
 	if len(toAdvertise) > 0 {
 		nrc.advertiseVIPs(toAdvertise)
 	}


### PR DESCRIPTION
Fixes #426 

With out the fix athough service VIP gets added to the gobgp RIB, then wont get advertised to peers.
During periodic sync export policies are reevaluated which will result in the VIP's getting advertised.

Thanks to @phemmer for cathing this latent issue.