### PR TITLE
perform clean-up of external ip from custom route table for external ip only if the table is not empty

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1686,17 +1686,19 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 		}
 	}
 
-	// clean up stale external IPs
-	for _, line := range strings.Split(strings.Trim(outStr, "\n"), "\n") {
-		route := strings.Split(strings.Trim(line, " "), " ")
-		ip := route[0]
-
-		if !activeExternalIPs[ip] {
-			args := []string{"route", "del", "table", externalIPRouteTableId}
-			args = append(args, route...)
-			if err = exec.Command("ip", args...).Run(); err != nil {
-				glog.Errorf("Failed to del route for %v in custom route table for external IP's due to: %s", ip, err)
-				continue
+	// check if there are any pbr in externalIPRouteTableId for external IP's
+	if len(outStr) > 0 {
+		// clean up stale external IPs
+		for _, line := range strings.Split(strings.Trim(outStr, "\n"), "\n") {
+			route := strings.Split(strings.Trim(line, " "), " ")
+			ip := route[0]
+			if !activeExternalIPs[ip] {
+				args := []string{"route", "del", "table", externalIPRouteTableId}
+				args = append(args, route...)
+				if err = exec.Command("ip", args...).Run(); err != nil {
+					glog.Errorf("Failed to del route for %v in custom route table for external IP's due to: %s", ip, err)
+					continue
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fix prevents unnecessary performing of clean up of external ip from PBR custom table resulting in

`E0513 06:22:31.383773       1 network_services_controller.go:1698] Failed to del route for  in custom route table for external IP's due to: exit status 255`