### PR TITLE
Print output of `ip route` command as string.

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -115,10 +115,10 @@ func (ln *linuxNetworking) ipAddrAdd(iface netlink.Link, ip string) error {
 
 	// TODO: netlink.RouteReplace which is replacement for below command is not working as expected. Call succeeds but
 	// route is not replaced. For now do it with command.
-	out, err := exec.Command("ip", "route", "replace", "local", ip, "dev", "kube-dummy-if", "table", "local", "proto", "kernel", "scope", "host", "src",
+	out, err := exec.Command("ip", "route", "replace", "local", ip, "dev", KUBE_DUMMY_IF, "table", "local", "proto", "kernel", "scope", "host", "src",
 		NodeIP.String(), "table", "local").CombinedOutput()
 	if err != nil {
-		glog.Errorf("Failed to replace route to service VIP %s configured on kube-dummy-if. Error: %v, Output: %v", ip, err, out)
+		glog.Errorf("Failed to replace route to service VIP %s configured on %s. Error: %v, Output: %s", ip, KUBE_DUMMY_IF, err, out)
 	}
 	return nil
 }


### PR DESCRIPTION
`Cmd.CombinedOutput()` returns `[]byte` for the command output which, at least for `ip` commands should be a printable string. The output is now printed as string.

Furthermore the constant `KUBE_DUMMY_IF` is used for the interface name to reduce multiple definitions of the interface name.

Signed-off-by: Mathias Kaufmann <me@stei.gr>