### PR TITLE
adds explicit check for existing tunnel to avoid partial matches

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -391,7 +391,7 @@ func (nrc *NetworkRoutingController) injectRoute(path *table.Path) error {
 			return fmt.Errorf("Failed to verify if route already exists in %s table: %s",
 				customRouteTableName, err.Error())
 		}
-		if !strings.Contains(string(out), tunnelName) {
+		if !strings.Contains(string(out), "dev "+tunnelName+" scope") {
 			if out, err = exec.Command("ip", "route", "add", nexthop.String(), "dev", tunnelName, "table",
 				customRouteTableID).CombinedOutput(); err != nil {
 				return fmt.Errorf("failed to add route in custom route table, err: %s, output: %s", err, string(out))


### PR DESCRIPTION
The current stings.Contains passes checks when there is are similar IPs

Ex: 
the two ips exist `10.1.73.7` &  `10.1.73.72` where in the latter the tunnel will pass the condition for the former. This issue was encountered multiple times when there are similar IPs with the last octets sharing values. This has fixed the issue in our current environment.   
