### PR TITLE
fix race condition issues with health checks

### DIFF
--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -87,13 +87,6 @@ func (kr *KubeRouter) Run() error {
 		os.Exit(0)
 	}
 
-	hc, err := healthcheck.NewHealthController(kr.Config)
-	if err != nil {
-		return errors.New("Failed to create health controller: " + err.Error())
-	}
-	wg.Add(1)
-	go hc.Run(healthChan, stopCh, &wg)
-
 	if (kr.Config.MetricsPort > 0) && (kr.Config.MetricsPort <= 65535) {
 		kr.Config.MetricsEnabled = true
 		mc, err := metrics.NewMetricsController(kr.Client, kr.Config)
@@ -164,6 +157,13 @@ func (kr *KubeRouter) Run() error {
 		wg.Add(1)
 		go nsc.Run(healthChan, stopCh, &wg)
 	}
+
+	hc, err := healthcheck.NewHealthController(kr.Config)
+	if err != nil {
+		return errors.New("Failed to create health controller: " + err.Error())
+	}
+	wg.Add(1)
+	go hc.Run(healthChan, stopCh, &wg)
 
 	// Handle SIGINT and SIGTERM
 	ch := make(chan os.Signal)

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -136,7 +136,8 @@ func (npc *NetworkPolicyController) Run(healthChan chan<- *healthcheck.Controlle
 		glog.V(1).Info("Performing periodic sync of iptables to reflect network policies")
 		err := npc.Sync()
 		if err != nil {
-			glog.Errorf("Error during periodic sync: " + err.Error())
+			glog.Errorf("Error during periodic sync of network policies in network policy controller. Error: " + err.Error())
+			glog.Errorf("Skipping sending heartbeat from network policy controller as periodic sync failed.")
 		} else {
 			healthcheck.SendHeartBeat(healthChan, "NPC")
 		}

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -265,7 +265,8 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 		glog.V(1).Info("Performing periodic sync of ipvs services")
 		err := nsc.sync()
 		if err != nil {
-			glog.Errorf("Error during periodic ipvs sync: " + err.Error())
+			glog.Errorf("Error during periodic ipvs sync in network service controller. Error: " + err.Error())
+			glog.Errorf("Skipping sending heartbeat from network service controller as periodic sync failed.")
 		} else {
 			healthcheck.SendHeartBeat(healthChan, "NSC")
 		}


### PR DESCRIPTION
Users have been reporting failing health checks (For e.g. #396) and kube-router pod restarts due to health check failured. This PR fixes below possible issues causing the problem.

- start health controller to health check only after network policy, network service and routing controller are started
- performs less aggressive periodic health check's at 5sec interval
- on start, time delay of 1 min is added before health check controller starts health checking.
- initialize NetworkPolicyControllerAlive, NetworkRoutingControllerAlive, NetworkServicesControllerAlive values