### PR TITLE
Fixes regression, where adding service VIP to the tunnel interface inside the pods when DSR is used was failing

### DIFF
--- a/pkg/controllers/proxy/network_services_controller_moq.go
+++ b/pkg/controllers/proxy/network_services_controller_moq.go
@@ -43,7 +43,7 @@ var (
 //             getKubeDummyInterfaceFunc: func() (netlink.Link, error) {
 // 	               panic("TODO: mock out the getKubeDummyInterface method")
 //             },
-//             ipAddrAddFunc: func(iface netlink.Link, ip string) error {
+//             ipAddrAddFunc: func(iface netlink.Link, ip string, addRoute bool) error {
 // 	               panic("TODO: mock out the ipAddrAdd method")
 //             },
 //             ipAddrDelFunc: func(iface netlink.Link, ip string) error {
@@ -105,7 +105,7 @@ type LinuxNetworkingMock struct {
 	getKubeDummyInterfaceFunc func() (netlink.Link, error)
 
 	// ipAddrAddFunc mocks the ipAddrAdd method.
-	ipAddrAddFunc func(iface netlink.Link, ip string) error
+	ipAddrAddFunc func(iface netlink.Link, ip string, addRoute bool) error
 
 	// ipAddrDelFunc mocks the ipAddrDel method.
 	ipAddrDelFunc func(iface netlink.Link, ip string) error
@@ -174,6 +174,8 @@ type LinuxNetworkingMock struct {
 			Iface netlink.Link
 			// IP is the ip argument value.
 			IP string
+			// AddRoute is the addRoute argument value.
+			AddRoute bool
 		}
 		// ipAddrDel holds details about calls to the ipAddrDel method.
 		ipAddrDel []struct {
@@ -355,33 +357,37 @@ func (mock *LinuxNetworkingMock) getKubeDummyInterfaceCalls() []struct {
 }
 
 // ipAddrAdd calls ipAddrAddFunc.
-func (mock *LinuxNetworkingMock) ipAddrAdd(iface netlink.Link, ip string) error {
+func (mock *LinuxNetworkingMock) ipAddrAdd(iface netlink.Link, ip string, addRoute bool) error {
 	if mock.ipAddrAddFunc == nil {
 		panic("moq: LinuxNetworkingMock.ipAddrAddFunc is nil but LinuxNetworking.ipAddrAdd was just called")
 	}
 	callInfo := struct {
-		Iface netlink.Link
-		IP    string
+		Iface    netlink.Link
+		IP       string
+		AddRoute bool
 	}{
-		Iface: iface,
-		IP:    ip,
+		Iface:    iface,
+		IP:       ip,
+		AddRoute: addRoute,
 	}
 	lockLinuxNetworkingMockipAddrAdd.Lock()
 	mock.calls.ipAddrAdd = append(mock.calls.ipAddrAdd, callInfo)
 	lockLinuxNetworkingMockipAddrAdd.Unlock()
-	return mock.ipAddrAddFunc(iface, ip)
+	return mock.ipAddrAddFunc(iface, ip, addRoute)
 }
 
 // ipAddrAddCalls gets all the calls that were made to ipAddrAdd.
 // Check the length with:
 //     len(mockedLinuxNetworking.ipAddrAddCalls())
 func (mock *LinuxNetworkingMock) ipAddrAddCalls() []struct {
-	Iface netlink.Link
-	IP    string
+	Iface    netlink.Link
+	IP       string
+	AddRoute bool
 } {
 	var calls []struct {
-		Iface netlink.Link
-		IP    string
+		Iface    netlink.Link
+		IP       string
+		AddRoute bool
 	}
 	lockLinuxNetworkingMockipAddrAdd.RLock()
 	calls = mock.calls.ipAddrAdd

--- a/pkg/controllers/proxy/network_services_controller_test.go
+++ b/pkg/controllers/proxy/network_services_controller_test.go
@@ -46,7 +46,7 @@ func (lnm *LinuxNetworkingMockImpl) ipvsGetServices() ([]*ipvs.Service, error) {
 	copy(svcsCopy, lnm.ipvsSvcs)
 	return svcsCopy, nil
 }
-func (lnm *LinuxNetworkingMockImpl) ipAddrAdd(iface netlink.Link, addr string) error {
+func (lnm *LinuxNetworkingMockImpl) ipAddrAdd(iface netlink.Link, addr string, addRouter bool) error {
 	return nil
 }
 func (lnm *LinuxNetworkingMockImpl) ipvsAddServer(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination, local bool, podCidr string) error {


### PR DESCRIPTION
Fixes regression, where adding service VIP to the tunnel interface inside the pods when DSR is used was failing

kube-dummy-if was being used inside the pods, which does not exist in the pods.