### PR TITLE
Health 1

### DIFF
--- a/pkg/healthcheck/health_controller.go
+++ b/pkg/healthcheck/health_controller.go
@@ -104,7 +104,7 @@ func (hc *HealthController) HandleHeartbeat(beat *ControllerHeartbeat) {
 // CheckHealth evaluates the time since last heartbeat to decide if the controller is running or not
 func (hc *HealthController) CheckHealth() bool {
 	health := true
-	extra := time.Duration(5 * time.Second)
+	extra := time.Duration(1500 * time.Millisecond)
 
 	if hc.Config.RunFirewall {
 

--- a/pkg/healthcheck/health_controller.go
+++ b/pkg/healthcheck/health_controller.go
@@ -104,25 +104,25 @@ func (hc *HealthController) HandleHeartbeat(beat *ControllerHeartbeat) {
 // CheckHealth evaluates the time since last heartbeat to decide if the controller is running or not
 func (hc *HealthController) CheckHealth() bool {
 	health := true
-	extra := time.Duration(1500 * time.Millisecond)
+	graceTime := time.Duration(1500 * time.Millisecond)
 
 	if hc.Config.RunFirewall {
 
-		if time.Since(hc.Status.NetworkPolicyControllerAlive) > hc.Config.IPTablesSyncPeriod+hc.Status.NetworkPolicyControllerAliveTTL+extra {
+		if time.Since(hc.Status.NetworkPolicyControllerAlive) > hc.Config.IPTablesSyncPeriod+hc.Status.NetworkPolicyControllerAliveTTL+graceTime {
 			glog.Error("Network Policy Controller heartbeat missed")
 			health = false
 		}
 	}
 
 	if hc.Config.RunRouter {
-		if time.Since(hc.Status.NetworkRoutingControllerAlive) > hc.Config.RoutesSyncPeriod+hc.Status.NetworkRoutingControllerAliveTTL+extra {
+		if time.Since(hc.Status.NetworkRoutingControllerAlive) > hc.Config.RoutesSyncPeriod+hc.Status.NetworkRoutingControllerAliveTTL+graceTime {
 			glog.Error("Network Routing Controller heartbeat missed")
 			health = false
 		}
 	}
 
 	if hc.Config.RunServiceProxy {
-		if time.Since(hc.Status.NetworkServicesControllerAlive) > hc.Config.IpvsSyncPeriod+hc.Status.NetworkServicesControllerAliveTTL+extra {
+		if time.Since(hc.Status.NetworkServicesControllerAlive) > hc.Config.IpvsSyncPeriod+hc.Status.NetworkServicesControllerAliveTTL+graceTime {
 			glog.Error("NetworkService Controller heartbeat missed")
 			health = false
 		}

--- a/pkg/healthcheck/health_controller.go
+++ b/pkg/healthcheck/health_controller.go
@@ -28,11 +28,14 @@ type HealthController struct {
 //HealthStats is holds the latest heartbeats
 type HealthStats struct {
 	sync.Mutex
-	Healthy                        bool
-	MetricsControllerAlive         time.Time
-	NetworkPolicyControllerAlive   time.Time
-	NetworkRoutingControllerAlive  time.Time
-	NetworkServicesControllerAlive time.Time
+	Healthy                           bool
+	MetricsControllerAlive            time.Time
+	NetworkPolicyControllerAlive      time.Time
+	NetworkPolicyControllerAliveTTL   time.Duration
+	NetworkRoutingControllerAlive     time.Time
+	NetworkRoutingControllerAliveTTL  time.Duration
+	NetworkServicesControllerAlive    time.Time
+	NetworkServicesControllerAliveTTL time.Duration
 }
 
 //SendHeartBeat sends a heartbeat on the passed channel
@@ -73,37 +76,53 @@ func (hc *HealthController) HandleHeartbeat(beat *ControllerHeartbeat) {
 	hc.Status.Lock()
 	defer hc.Status.Unlock()
 
-	switch component := beat.Component; component {
-	case "NSC":
-		hc.Status.NetworkServicesControllerAlive = time.Now()
-	case "NRC":
-		hc.Status.NetworkRoutingControllerAlive = time.Now()
-	case "NPC":
-		hc.Status.NetworkPolicyControllerAlive = time.Now()
-	case "MC":
-		hc.Status.MetricsControllerAlive = time.Now()
+	switch {
+	// The first heartbeat will set the initial gracetime the controller has to report in, A static time is added as well when checking to allow for load variation in sync time
+	case beat.Component == "NSC":
+		if hc.Status.NetworkServicesControllerAliveTTL == 0 {
+			hc.Status.NetworkServicesControllerAliveTTL = time.Since(hc.Status.NetworkServicesControllerAlive)
+		}
+		hc.Status.NetworkServicesControllerAlive = beat.LastHeartBeat
+
+	case beat.Component == "NRC":
+		if hc.Status.NetworkRoutingControllerAliveTTL == 0 {
+			hc.Status.NetworkRoutingControllerAliveTTL = time.Since(hc.Status.NetworkRoutingControllerAlive)
+		}
+		hc.Status.NetworkRoutingControllerAlive = beat.LastHeartBeat
+
+	case beat.Component == "NPC":
+		if hc.Status.NetworkPolicyControllerAliveTTL == 0 {
+			hc.Status.NetworkPolicyControllerAliveTTL = time.Since(hc.Status.NetworkPolicyControllerAlive)
+		}
+		hc.Status.NetworkPolicyControllerAlive = beat.LastHeartBeat
+
+	case beat.Component == "MC":
+		hc.Status.MetricsControllerAlive = beat.LastHeartBeat
 	}
 }
 
-//CheckHealth evaluates the time since last heartbeat to decide if the controller is running or not
+// CheckHealth evaluates the time since last heartbeat to decide if the controller is running or not
 func (hc *HealthController) CheckHealth() bool {
 	health := true
+	extra := time.Duration(5 * time.Second)
+
 	if hc.Config.RunFirewall {
-		if time.Since(hc.Status.NetworkPolicyControllerAlive) > hc.Config.IPTablesSyncPeriod+5*time.Second {
+
+		if time.Since(hc.Status.NetworkPolicyControllerAlive) > hc.Config.IPTablesSyncPeriod+hc.Status.NetworkPolicyControllerAliveTTL+extra {
 			glog.Error("Network Policy Controller heartbeat missed")
 			health = false
 		}
 	}
 
 	if hc.Config.RunRouter {
-		if time.Since(hc.Status.NetworkRoutingControllerAlive) > hc.Config.RoutesSyncPeriod+5*time.Second {
+		if time.Since(hc.Status.NetworkRoutingControllerAlive) > hc.Config.RoutesSyncPeriod+hc.Status.NetworkRoutingControllerAliveTTL+extra {
 			glog.Error("Network Routing Controller heartbeat missed")
 			health = false
 		}
 	}
 
 	if hc.Config.RunServiceProxy {
-		if time.Since(hc.Status.NetworkServicesControllerAlive) > hc.Config.IpvsSyncPeriod+5*time.Second {
+		if time.Since(hc.Status.NetworkServicesControllerAlive) > hc.Config.IpvsSyncPeriod+hc.Status.NetworkServicesControllerAliveTTL+extra {
 			glog.Error("NetworkService Controller heartbeat missed")
 			health = false
 		}
@@ -142,9 +161,6 @@ func (hc *HealthController) Run(healthChan <-chan *ControllerHeartbeat, stopCh <
 	} else {
 		hc.HTTPEnabled = false
 	}
-
-	//Give the controllers a few seconds to start before checking health
-	time.Sleep(60 * time.Second)
 
 	for {
 		select {


### PR DESCRIPTION
PR does:

Health controller starts first, every controller has it's own sync period as part of heartbeat timeout. since all controllers fire full sync the first time they start we measure how long it takes to get the first heartbeat and add that as a "buffer" time to the heartbeat timeout for each controller

the following are the default sync times

      --iptables-sync-period duration    The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0. (default 5m0s)
      --ipvs-sync-period duration        The delay between ipvs config synchronizations (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
      --routes-sync-period duration      The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)

a additional 1500 ms static time is added to this to this to allow for load variation or increase in services

so the controllers heartbeat timeout would be syncinterval + buffer + extra 1500 ms

on start the controllers would have syncintervall + extra 1500 ms to complete before being reported as unhealthy