### PR TITLE
Report delay metrics as seconds, not nanos

### DIFF
--- a/dashboard/kube-router.json
+++ b/dashboard/kube-router.json
@@ -480,7 +480,7 @@
           },
           "yaxes": [
             {
-              "format": "ns",
+              "format": "s",
               "label": "Time",
               "logBase": 1,
               "max": null,
@@ -555,7 +555,7 @@
           },
           "yaxes": [
             {
-              "format": "ns",
+              "format": "s",
               "label": "Time",
               "logBase": 1,
               "max": null,
@@ -630,7 +630,7 @@
           },
           "yaxes": [
             {
-              "format": "ns",
+              "format": "s",
               "label": "Time",
               "logBase": 1,
               "max": null,
@@ -705,7 +705,7 @@
           },
           "yaxes": [
             {
-              "format": "ns",
+              "format": "s",
               "label": "Time",
               "logBase": 1,
               "max": null,

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -209,7 +209,7 @@ func (npc *NetworkPolicyController) Sync() error {
 	defer func() {
 		endTime := time.Since(start)
 		if npc.MetricsEnabled {
-			metrics.ControllerIptablesSyncTime.WithLabelValues().Set(float64(endTime))
+			metrics.ControllerIptablesSyncTime.WithLabelValues().Set(float64(endTime.Seconds()))
 		}
 		glog.V(1).Infof("sync iptables took %v", endTime)
 	}()

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -329,7 +329,7 @@ func (nsc *NetworkServicesController) publishMetrics(serviceInfoMap serviceInfoM
 	defer func() {
 		endTime := time.Since(start)
 		glog.V(2).Infof("Publishing IPVS metrics took %v", endTime)
-		metrics.ControllerIpvsMetricsExportTime.WithLabelValues().Set(float64(endTime))
+		metrics.ControllerIpvsMetricsExportTime.WithLabelValues().Set(float64(endTime.Seconds()))
 	}()
 
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()
@@ -500,7 +500,7 @@ func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInf
 	defer func() {
 		endTime := time.Since(start)
 		if nsc.MetricsEnabled {
-			metrics.ControllerIpvsServicesSyncTime.WithLabelValues().Set(float64(endTime))
+			metrics.ControllerIpvsServicesSyncTime.WithLabelValues().Set(float64(endTime.Seconds()))
 		}
 		glog.V(1).Infof("sync ipvs services took %v", endTime)
 	}()

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -29,7 +29,7 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 	start := time.Now()
 	defer func() {
 		endTime := time.Since(start)
-		metrics.ControllerBGPInternalPeersSyncTime.WithLabelValues().Set(float64(endTime))
+		metrics.ControllerBGPInternalPeersSyncTime.WithLabelValues().Set(float64(endTime.Seconds()))
 		glog.V(2).Infof("Syncing BGP peers for the node took %v", endTime)
 	}()
 


### PR DESCRIPTION
Fixes #459 