### PR TITLE
issue-385: make it optional on which ip address BGP server listens

### DIFF
--- a/docs/bgp.md
+++ b/docs/bgp.md
@@ -142,3 +142,13 @@ kubectl annotate node <kube-node> "kube-router.io/peer.ips=192.168.1.99,192.168.
 kubectl annotate node <kube-node> "kube-router.io/peer.asns=65000,65000"
 kubectl annotate node <kube-node> "kube-router.io/peer.passwords=U2VjdXJlUGFzc3dvcmQK,"
 ```
+
+## BGP listen address list 
+
+By default GoBGP server binds on the node IP address. However in case of nodes with multiple IP address it is desirable to bind GoBGP to multiple local adresses. Local IP address on which GoGBP should listen on an node can be configured with annotation `kube-router.io/bgp-local-addresses`.
+
+Here is sample example to make GoBGP server to listen on multiple IP address
+```
+kubectl annotate node ip-172-20-46-87.us-west-2.compute.internal "kube-router.io/bgp-local-addresses=172.20.56.25,192.168.1.99"
+```
+

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -866,6 +866,12 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	} else {
 		glog.Infof("Found annotaion `kube-router.io/bgp-local-addresses` on node object so BGP will listen on local IP's: %s", bgpLocalAddressListAnnotation)
 		localAddresses := stringToSlice(bgpLocalAddressListAnnotation, ",")
+		for _, addr := range localAddresses {
+			ip := net.ParseIP(addr)
+			if ip == nil {
+				glog.Fatalf("Invalid IP address %s specified in `kube-router.io/bgp-local-addresses`.", addr)
+			}
+		}
 		nrc.localAddressList = append(nrc.localAddressList, localAddresses...)
 	}
 	nrc.svcLister = svcInformer.GetIndexer()


### PR DESCRIPTION
Modifying the fix done for https://github.com/cloudnativelabs/kube-router/issues/385 in commit https://github.com/cloudnativelabs/kube-router/commit/8c746b2cbc8026717d534236358033007fd7c9b0

Adding an option `bgp-listen-all-ip` to control on which IP GoBGP server listens on. By default value is false, and GoBGP server will just listen on node IP. When set to true GoBGP server will listen on `0.0.0.0`

This flexibility is desinrable when node is  multi-homed and GoBGP server can learn routes advertised from different networks.

cc @Thoro 