### PR TITLE
Added support for custom BGP ports with 179 still being default (#492)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -31,6 +31,7 @@ Usage of kube-router:
       --advertise-loadbalancer-ip        Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
       --advertise-pod-cidr               Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
       --bgp-graceful-restart             Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
+      --bgp-port uint16                  The port open for incoming BGP connections and to use for connecting with other BGP peers. (default 179)
       --cache-sync-timeout duration      The timeout for cache synchronization (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
       --cleanup-config                   Cleanup iptables rules, ipvs, ipset configuration and exit.
       --cluster-asn uint                 ASN number under which cluster nodes will run iBGP.
@@ -58,6 +59,7 @@ Usage of kube-router:
       --peer-router-ips ipSlice          The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's. (default [])
       --peer-router-multihop-ttl uint8   Enable eBGP multihop supports -- sets multihop-ttl. (Relevant only if ttl >= 2)
       --peer-router-passwords strings    Password for authenticating against the BGP peer defined with "--peer-router-ips".
+      --peer-router-ports uints          The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used. (default [])
       --routes-sync-period duration      The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
       --run-firewall                     Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
       --run-router                       Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)

--- a/pkg/controllers/routing/export_policies.go
+++ b/pkg/controllers/routing/export_policies.go
@@ -121,7 +121,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 	externalBgpPeers := make([]string, 0)
 	if len(nrc.globalPeerRouters) != 0 {
 		for _, peer := range nrc.globalPeerRouters {
-			externalBgpPeers = append(externalBgpPeers, peer.NeighborAddress)
+			externalBgpPeers = append(externalBgpPeers, peer.Config.NeighborAddress)
 		}
 	}
 	if len(nrc.nodePeerRouters) != 0 {

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -1258,12 +1258,12 @@ func Test_addExportPolicies(t *testing.T) {
 				bgpEnableInternal: true,
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
-				globalPeerRouters: []*config.NeighborConfig{
+				globalPeerRouters: []*config.Neighbor{
 					{
-						NeighborAddress: "10.10.0.1",
+						Config: config.NeighborConfig{NeighborAddress: "10.10.0.1"},
 					},
 					{
-						NeighborAddress: "10.10.0.2",
+						Config: config.NeighborConfig{NeighborAddress: "10.10.0.2"},
 					},
 				},
 				nodeAsnNumber: 100,
@@ -1393,12 +1393,12 @@ func Test_addExportPolicies(t *testing.T) {
 				bgpEnableInternal: false,
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
-				globalPeerRouters: []*config.NeighborConfig{
+				globalPeerRouters: []*config.Neighbor{
 					{
-						NeighborAddress: "10.10.0.1",
+						Config: config.NeighborConfig{NeighborAddress: "10.10.0.1"},
 					},
 					{
-						NeighborAddress: "10.10.0.2",
+						Config: config.NeighborConfig{NeighborAddress: "10.10.0.2"},
 					},
 				},
 				nodeAsnNumber: 100,
@@ -1515,12 +1515,12 @@ func Test_addExportPolicies(t *testing.T) {
 				pathPrependAS:     "65100",
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
-				globalPeerRouters: []*config.NeighborConfig{
+				globalPeerRouters: []*config.Neighbor{
 					{
-						NeighborAddress: "10.10.0.1",
+						Config: config.NeighborConfig{NeighborAddress: "10.10.0.1"},
 					},
 					{
-						NeighborAddress: "10.10.0.2",
+						Config: config.NeighborConfig{NeighborAddress: "10.10.0.2"},
 					},
 				},
 				nodeAsnNumber: 100,
@@ -1658,12 +1658,12 @@ func Test_addExportPolicies(t *testing.T) {
 				pathPrependAS:     "65100",
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
-				globalPeerRouters: []*config.NeighborConfig{
+				globalPeerRouters: []*config.Neighbor{
 					{
-						NeighborAddress: "10.10.0.1",
+						Config: config.NeighborConfig{NeighborAddress: "10.10.0.1"},
 					},
 					{
-						NeighborAddress: "10.10.0.2",
+						Config: config.NeighborConfig{NeighborAddress: "10.10.0.2"},
 					},
 				},
 				nodeAsnNumber: 100,

--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -35,6 +35,18 @@ func stringSliceToIPs(s []string) ([]net.IP, error) {
 	return ips, nil
 }
 
+func stringSliceToUInt16(s []string) ([]uint16, error) {
+	ints := make([]uint16, 0)
+	for _, intString := range s {
+		newInt, err := strconv.ParseUint(intString, 0, 16)
+		if err != nil {
+			return nil, fmt.Errorf("Could not parse \"%s\" as an integer", intString)
+		}
+		ints = append(ints, uint16(newInt))
+	}
+	return ints, nil
+}
+
 func stringSliceToUInt32(s []string) ([]uint32, error) {
 	ints := make([]uint32, 0)
 	for _, intString := range s {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -5,7 +5,10 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+	"strconv"
 )
+
+const DEFAULT_BGP_PORT = 179
 
 type KubeRouterConfig struct {
 	AdvertiseClusterIp      bool
@@ -13,6 +16,7 @@ type KubeRouterConfig struct {
 	AdvertiseNodePodCidr    bool
 	AdvertiseLoadBalancerIp bool
 	BGPGracefulRestart      bool
+	BGPPort                 uint16
 	CacheSyncTimeout        time.Duration
 	CleanupConfig           bool
 	ClusterAsn              uint
@@ -40,6 +44,7 @@ type KubeRouterConfig struct {
 	PeerASNs                []uint
 	PeerMultihopTtl         uint8
 	PeerPasswords           []string
+	PeerPorts               []uint
 	PeerRouters             []net.IP
 	RoutesSyncPeriod        time.Duration
 	RunFirewall             bool
@@ -101,6 +106,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers.")
 	fs.IPSliceVar(&s.PeerRouters, "peer-router-ips", s.PeerRouters,
 		"The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's.")
+	fs.UintSliceVar(&s.PeerPorts, "peer-router-ports", s.PeerPorts,
+		"The remote port of the external BGP to which all nodes will peer. If not set, default BGP port ("+strconv.Itoa(DEFAULT_BGP_PORT)+") will be used.")
 	fs.UintVar(&s.ClusterAsn, "cluster-asn", s.ClusterAsn,
 		"ASN number under which cluster nodes will run iBGP.")
 	fs.UintSliceVar(&s.PeerASNs, "peer-router-asns", s.PeerASNs,
@@ -111,6 +118,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Each node in the cluster will setup BGP peering with rest of the nodes.")
 	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
+	fs.Uint16Var(&s.BGPPort, "bgp-port", DEFAULT_BGP_PORT,
+		"The port open for incoming BGP connections and to use for connecting with other BGP peers.")
 	fs.BoolVar(&s.EnableCNI, "enable-cni", true,
 		"Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin.")
 	fs.BoolVar(&s.EnableiBGP, "enable-ibgp", true,


### PR DESCRIPTION
* Introduced new cmdline flag --bgp-port, which controls BGP Server listening port and remote port of in-cluster node peers

* Introduced new cmdline flag --peer-router-ports, which controls remote BGP port for external peers

* Introduced new node annotation kube-router.io/peer.ports with same effect as --peer-router-ports



Note: Although it is now possible to specify a custom remote port for external peers, still only **one** BGPServer will be started locally, listening on the port specified with the `--bgp-port` flag. 
Hence; in case you are using a custom `--bgp-port` for in-cluster peering and different `--peer-router-ports` for external peering, the external peering connection becomes one-way (passive). 