### PR TITLE
Add the ability to announce additional static CIDRs

### DIFF
--- a/docs/bgp.md
+++ b/docs/bgp.md
@@ -142,3 +142,17 @@ kubectl annotate node <kube-node> "kube-router.io/peer.ips=192.168.1.99,192.168.
 kubectl annotate node <kube-node> "kube-router.io/peer.asns=65000,65000"
 kubectl annotate node <kube-node> "kube-router.io/peer.passwords=U2VjdXJlUGFzc3dvcmQK,"
 ```
+
+## Additional BGP features
+
+### Advertising additional static CIDRs to routers
+
+If kube-router should announce additional routes and CIDRs, that a local bird instance might take care of in other use-cases. It is possible to specify these either by using the command line flag:
+```
+--static-cidrs=192.168.1.100/32,10.255.255.0/24
+```
+
+And alternative use node annotations to add static CIDRs to advertise on a per node basis:
+```
+kubectl annotate node <kube-node> "kube-router.io/static-cidrs=192.168.1.100/32,10.255.255.0/24"
+```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -60,6 +60,7 @@ Usage of kube-router:
       --run-firewall                     Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
       --run-router                       Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
       --run-service-proxy                Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)
+      --static-cidrs strings             Optionally specifies a list of static CIDRs that will be advertised.
   -v, --v string                         log level for V logs (default "0")
   -V, --version                          Print version information.
 ```

--- a/pkg/controllers/routing/export_policies.go
+++ b/pkg/controllers/routing/export_policies.go
@@ -64,6 +64,22 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 		nrc.bgpServer.AddDefinedSet(clusterIpPrefixSet)
 	}
 
+	// creates prefix set to represent all the static cidrs
+	if len(nrc.staticCidrs) > 0 {
+		staticCidrPrefixList := make([]config.Prefix, 0)
+		for _, cidr := range nrc.staticCidrs {
+			staticCidrPrefixList = append(staticCidrPrefixList, config.Prefix{IpPrefix: cidr})
+		}
+		staticCidrPrefixSet, err := table.NewPrefixSet(config.PrefixSet{
+			PrefixSetName: "staticcidrprefixset",
+			PrefixList:    staticCidrPrefixList,
+		})
+		err = nrc.bgpServer.ReplaceDefinedSet(staticCidrPrefixSet)
+		if err != nil {
+			nrc.bgpServer.AddDefinedSet(staticCidrPrefixSet)
+		}
+	}
+
 	statements := make([]config.Statement, 0)
 
 	var bgpActions config.BgpActions
@@ -149,6 +165,22 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 				BgpActions:       bgpActions,
 			},
 		})
+		if len(nrc.staticCidrs) > 0 {
+			statements = append(statements, config.Statement{
+				Conditions: config.Conditions{
+					MatchPrefixSet: config.MatchPrefixSet{
+						PrefixSet: "staticcidrprefixset",
+					},
+					MatchNeighborSet: config.MatchNeighborSet{
+						NeighborSet: "externalpeerset",
+					},
+				},
+				Actions: config.Actions{
+					RouteDisposition: config.ROUTE_DISPOSITION_ACCEPT_ROUTE,
+					BgpActions:       bgpActions,
+				},
+			})
+		}
 		if nrc.advertisePodCidr {
 			statements = append(statements, config.Statement{
 				Conditions: config.Conditions{

--- a/pkg/controllers/routing/export_policies.go
+++ b/pkg/controllers/routing/export_policies.go
@@ -65,18 +65,18 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 	}
 
 	// creates prefix set to represent all the static cidrs
-	if len(nrc.staticCidrs) > 0 {
-		staticCidrPrefixList := make([]config.Prefix, 0)
-		for _, cidr := range nrc.staticCidrs {
-			staticCidrPrefixList = append(staticCidrPrefixList, config.Prefix{IpPrefix: cidr})
+	if len(nrc.staticCIDRs) > 0 {
+		staticCIDRPrefixList := make([]config.Prefix, 0)
+		for _, cidr := range nrc.staticCIDRs {
+			staticCIDRPrefixList = append(staticCIDRPrefixList, config.Prefix{IpPrefix: cidr})
 		}
-		staticCidrPrefixSet, err := table.NewPrefixSet(config.PrefixSet{
+		staticCIDRPrefixSet, err := table.NewPrefixSet(config.PrefixSet{
 			PrefixSetName: "staticcidrprefixset",
-			PrefixList:    staticCidrPrefixList,
+			PrefixList:    staticCIDRPrefixList,
 		})
-		err = nrc.bgpServer.ReplaceDefinedSet(staticCidrPrefixSet)
+		err = nrc.bgpServer.ReplaceDefinedSet(staticCIDRPrefixSet)
 		if err != nil {
-			nrc.bgpServer.AddDefinedSet(staticCidrPrefixSet)
+			nrc.bgpServer.AddDefinedSet(staticCIDRPrefixSet)
 		}
 	}
 
@@ -165,7 +165,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 				BgpActions:       bgpActions,
 			},
 		})
-		if len(nrc.staticCidrs) > 0 {
+		if len(nrc.staticCIDRs) > 0 {
 			statements = append(statements, config.Statement{
 				Conditions: config.Conditions{
 					MatchPrefixSet: config.MatchPrefixSet{

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -43,7 +43,7 @@ type KubeRouterConfig struct {
 	RunFirewall             bool
 	RunRouter               bool
 	RunServiceProxy         bool
-	StaticCidrs             []string
+	StaticCIDRs             []string
 	Version                 bool
 	VLevel                  string
 	// FullMeshPassword    string
@@ -122,8 +122,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 			"When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets")
 	fs.StringSliceVar(&s.PeerPasswords, "peer-router-passwords", s.PeerPasswords,
 		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
-	fs.StringSliceVar(&s.StaticCidrs, "static-cidrs", s.StaticCidrs,
-		"Static CIDRs to announce via bgp.")
+	fs.StringSliceVar(&s.StaticCIDRs, "static-cidrs", s.StaticCIDRs,
+		"Optionally specifies a list of static CIDRs that will be advertised.")
 	fs.BoolVar(&s.EnablePprof, "enable-pprof", false,
 		"Enables pprof for debugging performance and memory leak issues.")
 	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, (Default 0, Disabled)")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -43,6 +43,7 @@ type KubeRouterConfig struct {
 	RunFirewall             bool
 	RunRouter               bool
 	RunServiceProxy         bool
+	StaticCidrs             []string
 	Version                 bool
 	VLevel                  string
 	// FullMeshPassword    string
@@ -121,6 +122,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 			"When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets")
 	fs.StringSliceVar(&s.PeerPasswords, "peer-router-passwords", s.PeerPasswords,
 		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
+	fs.StringSliceVar(&s.StaticCidrs, "static-cidrs", s.StaticCidrs,
+		"Static CIDRs to announce via bgp.")
 	fs.BoolVar(&s.EnablePprof, "enable-pprof", false,
 		"Enables pprof for debugging performance and memory leak issues.")
 	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, (Default 0, Disabled)")


### PR DESCRIPTION
We have several static CIDRs that are announce for each machine in our 3 layer CLOS topology. Because bird and kube-router have to peer with the same switches, we needed kube-router to announce additional CIDRs for us. 

This PR adds the ability to either specify additional CIDRs via the new `--static-cidrs` flag or by annotating nodes with `kube-router.io/static-cidrs=...`. Both take a comma separated list of CIDRs.

This PR adds:
* Flag and annotations to advertise static CIDRs
* Additional tests and documentation to accommodate the new feature