### PR TITLE
Ipv6; Support ipset with "family inet6"

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -839,7 +839,7 @@ func cleanupStaleRules(activePolicyChains, activePodFwChains, activePolicyIPSets
 	if err != nil {
 		glog.Fatalf("failed to initialize iptables command executor due to %s", err.Error())
 	}
-	ipsets, err := utils.NewIPSet()
+	ipsets, err := utils.NewIPSet(false)
 	if err != nil {
 		glog.Fatalf("failed to create ipsets command executor due to %s", err.Error())
 	}
@@ -1410,7 +1410,7 @@ func (npc *NetworkPolicyController) Cleanup() {
 	}
 
 	// delete all ipsets
-	ipset, err := utils.NewIPSet()
+	ipset, err := utils.NewIPSet(false)
 	if err != nil {
 		glog.Errorf("Failed to clean up ipsets: " + err.Error())
 	}
@@ -1514,7 +1514,7 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	}
 	npc.nodeIP = nodeIP
 
-	ipset, err := utils.NewIPSet()
+	ipset, err := utils.NewIPSet(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -466,7 +466,7 @@ func (nrc *NetworkRoutingController) Cleanup() {
 	}
 
 	// delete all ipsets created by kube-router
-	ipset, err := utils.NewIPSet()
+	ipset, err := utils.NewIPSet(false)
 	if err != nil {
 		glog.Errorf("Failed to clean up ipsets: " + err.Error())
 	}
@@ -804,7 +804,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		}
 	}
 
-	nrc.ipSetHandler, err = utils.NewIPSet()
+	nrc.ipSetHandler, err = utils.NewIPSet(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -240,7 +240,7 @@ func (entry *Entry) Del() error {
 	if err != nil {
 		return err
 	}
-	entry.Set.Parent.Save() // <-- EKM: Implications??
+	entry.Set.Parent.Save()
 	return nil
 }
 

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -83,6 +83,7 @@ const (
 type IPSet struct {
 	ipSetPath *string
 	Sets      map[string]*Set
+	isIpv6    bool
 }
 
 // Set reprensent a ipset set entry.
@@ -146,7 +147,7 @@ func (ipset *IPSet) runWithStdin(stdin *bytes.Buffer, args ...string) (string, e
 }
 
 // NewIPSet create a new IPSet with ipSetPath initialized.
-func NewIPSet() (*IPSet, error) {
+func NewIPSet(isIpv6 bool) (*IPSet, error) {
 	ipSetPath, err := getIPSetPath()
 	if err != nil {
 		return nil, err
@@ -154,6 +155,7 @@ func NewIPSet() (*IPSet, error) {
 	ipSet := &IPSet{
 		ipSetPath: ipSetPath,
 		Sets:      make(map[string]*Set),
+		isIpv6:    isIpv6,
 	}
 	return ipSet, nil
 }
@@ -180,13 +182,22 @@ func (ipset *IPSet) Create(setName string, createOptions ...string) (*Set, error
 
 	// Create set if missing from the system
 	if !setIsActive {
-		_, err := ipset.run(append([]string{"create", "-exist", setName},
-			createOptions...)...)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to create ipset set on system: %s", err)
+		if ipset.isIpv6 {
+			// Add "family inet6" option and a "inet6:" prefix for IPv6 sets.
+			args := []string{"create", "-exist", ipset.Sets[setName].name()}
+			args = append(args, createOptions...)
+			args = append(args, "family", "inet6")
+			if _, err := ipset.run(args...); err != nil {
+				return nil, fmt.Errorf("Failed to create ipset set on system: %s", err)
+			}
+		} else {
+			_, err := ipset.run(append([]string{"create", "-exist", setName},
+				createOptions...)...)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to create ipset set on system: %s", err)
+			}
 		}
 	}
-
 	return ipset.Sets[setName], nil
 }
 
@@ -215,7 +226,7 @@ func (set *Set) Add(addOptions ...string) (*Entry, error) {
 		Options: addOptions,
 	}
 	set.Entries = append(set.Entries, entry)
-	_, err := set.Parent.run(append([]string{"add", "-exist", entry.Set.Name}, addOptions...)...)
+	_, err := set.Parent.run(append([]string{"add", "-exist", entry.Set.name()}, addOptions...)...)
 	if err != nil {
 		return nil, err
 	}
@@ -225,18 +236,18 @@ func (set *Set) Add(addOptions ...string) (*Entry, error) {
 // Del an entry from a set. If the -exist option is specified and the entry is
 // not in the set (maybe already expired), then the command is ignored.
 func (entry *Entry) Del() error {
-	_, err := entry.Set.Parent.run(append([]string{"del", entry.Set.Name}, entry.Options...)...)
+	_, err := entry.Set.Parent.run(append([]string{"del", entry.Set.name()}, entry.Options...)...)
 	if err != nil {
 		return err
 	}
-	entry.Set.Parent.Save()
+	entry.Set.Parent.Save() // <-- EKM: Implications??
 	return nil
 }
 
 // Test wether an entry is in a set or not. Exit status number is zero if the
 // tested entry is in the set and nonzero if it is missing from the set.
 func (set *Set) Test(testOptions ...string) (bool, error) {
-	_, err := set.Parent.run(append([]string{"test", set.Name}, testOptions...)...)
+	_, err := set.Parent.run(append([]string{"test", set.name()}, testOptions...)...)
 	if err != nil {
 		return false, err
 	}
@@ -246,13 +257,12 @@ func (set *Set) Test(testOptions ...string) (bool, error) {
 // Destroy the specified set or all the sets if none is given. If the set has
 // got reference(s), nothing is done and no set destroyed.
 func (set *Set) Destroy() error {
-	_, err := set.Parent.run("destroy", set.Name)
+	_, err := set.Parent.run("destroy", set.name())
 	if err != nil {
 		return err
 	}
 
 	delete(set.Parent.Sets, set.Name)
-
 	return nil
 }
 
@@ -287,7 +297,7 @@ func (ipset *IPSet) DestroyAllWithin() error {
 
 // IsActive checks if a set exists on the system with the same name.
 func (set *Set) IsActive() (bool, error) {
-	_, err := set.Parent.run("list", set.Name)
+	_, err := set.Parent.run("list", set.name())
 	if err != nil {
 		if strings.Contains(err.Error(), "name does not exist") {
 			return false, nil
@@ -295,6 +305,14 @@ func (set *Set) IsActive() (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func (set *Set) name() string {
+	if set.Parent.isIpv6 {
+		return "inet6:" + set.Name
+	} else {
+		return set.Name
+	}
 }
 
 // Parse ipset save stdout.
@@ -398,7 +416,10 @@ func (ipset *IPSet) Get(setName string) *Set {
 
 // Rename a set. Set identified by SETNAME-TO must not exist.
 func (set *Set) Rename(newName string) error {
-	_, err := set.Parent.run("rename", set.Name, newName)
+	if set.Parent.isIpv6 {
+		newName = "ipv6:" + newName
+	}
+	_, err := set.Parent.run("rename", set.name(), newName)
 	if err != nil {
 		return err
 	}
@@ -409,7 +430,7 @@ func (set *Set) Rename(newName string) error {
 // sets. The referred sets must exist and compatible type of sets can be
 // swapped only.
 func (set *Set) Swap(setTo *Set) error {
-	_, err := set.Parent.run("swap", set.Name, setTo.Name)
+	_, err := set.Parent.run("swap", set.name(), setTo.name())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Handle ipset for ipv4, ipv6 and dual-stack

For ipv6 and dual-stack support the `IPSet` is altered. An effort is made to be compatible with existing ipv4-only code while allowing an easy switch to ipv6-only. Dual-stack is considered in the sense that instances of `IPSet` for ipv4 and ipv6 can exist in paralell.

This PR is preliminary and intended for discussions on how to introduce ipv6-only and dual-stack, but it is a serious effort and my hope is that it will be accepted eventually.

### NewIPSet

An `isIpv6` flag is added to `IPSet` and is passed on creation;

```
nrc.ipSetHandler, err = utils.NewIPSet(false)
```

All other calls to functions in `IPSet` will remain the same, so to switch to ipv6-only should be simple.

For dual-stack all functions calls must go to both an ipv4 and ipv6 instance of `IPSet`. So perhaps it would be better to pass an enum; `ipv4/ipv6/dual-stack` to `NewIPSet(operation)`. But then again, it is hard for me to decide at this early stage, another abstraction layer may be better(?). The current flag is sufficient for ipv6-only and can easily be changed for dual-stack if needed.

The `family` options becomes invalid for any set operation to the `IPSet` (since it is implicit). I do not consider that as a problem.


### Ipset name-space

Unlike `iptables` the same `ipset` is used for both ipv4 and ipv6. This means that the sets must have different names for ipv4 and ipv6. This makes it impossible to intantiate two `IPSet` for dual-stack with the same set names. For coding in higher levels this becomes a mess so instead a prefix `inet6:` is silently added to all set names if the `IPSet` is of ipv6 type.


### Save/Restore/Flush

These operations seem to be imported from other code (the "file" comments) and not fully adapted. It works on **all** ipsets. For instance a `IPSet.Save()` operation will "slurp-in" all ipset's on the host to the `IPSet` ([example](https://github.com/cloudnativelabs/kube-router/blob/cd4ad6f32efa57cd4381fe738789f254d525f54f/pkg/utils/ipset.go#L232)).

This must be fixed in some way, but this is a larger job and not really necessary for ipv6-only. So I postpone this for now.

An idea may be to pass a regexp to `NewIPSet()` that filters the ipset to only names allowed.


### Test

For now the ipv6 tests are manual. IMO the most important is that ipv4-only still works in the same way as before, including upgrades, so regression tests are very important.

For the future ipv6, and ultimately dual-stack, tests are needed. There are updates in this area initiated for Kubernetes that hopefully can be used.

The current status is that I have temporary hard-coded `NewIPSet(true)` to get the CNI part of `kube-router` up and running for ipv6-only. Ipset's are created ok;

```
# ipset list
Name: inet6:kube-router-pod-subnets
Type: hash:net
Revision: 6
Header: family inet6 hashsize 1024 maxelem 65536 timeout 0
Size in memory: 1128
References: 0
Number of entries: 0
Members:

Name: inet6:kube-router-node-ips
Type: hash:ip
Revision: 4
Header: family inet6 hashsize 1024 maxelem 65536 timeout 0
Size in memory: 104
References: 0
Number of entries: 0
Members:
```

But the `gobgp` can't be started;

```
E0917 09:37:13.528009     400 network_routes_controller.go:210] Failed to start node BGP server: Failed to start BGP server due to : listen tcp6 [2000::4]:179: bind: address already in use
```

and re-tries continue forever. This indicates that port is not properly closed on cleanup of some earlier failure. But I will take that in a later PR.
