### PR TITLE
Add CLI option to toggle disabling of source-dest-check in EC2

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -36,6 +36,7 @@ Usage of kube-router:
       --cleanup-config                   Cleanup iptables rules, ipvs, ipset configuration and exit.
       --cluster-asn uint                 ASN number under which cluster nodes will run iBGP.
       --cluster-cidr string              CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.
+      --disable-source-dest-check        Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way. (default true)
       --enable-cni                       Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin. (default true)
       --enable-ibgp                      Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)
       --enable-overlay                   When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -333,7 +333,7 @@ func (nrc *NetworkRoutingController) OnNodeUpdate(obj interface{}) {
 
 	// skip if first round of disableSourceDestinationCheck() is not done yet, this is to prevent
 	// all the nodes for all the node add update trying to perfrom disableSourceDestinationCheck
-	if nrc.initSrcDstCheckDone && nrc.ec2IamAuthorized {
+	if nrc.disableSrcDstCheck && nrc.initSrcDstCheckDone && nrc.ec2IamAuthorized {
 		nrc.disableSourceDestinationCheck()
 	}
 }

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -90,6 +90,7 @@ type NetworkRoutingController struct {
 	bgpRRServer             bool
 	bgpClusterID            uint32
 	cniConfFile             string
+	disableSrcDstCheck      bool
 	initSrcDstCheckDone     bool
 	ec2IamAuthorized        bool
 	pathPrependAS           string
@@ -121,8 +122,10 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 	}
 
 	// In case of cluster provisioned on AWS disable source-destination check
-	nrc.disableSourceDestinationCheck()
-	nrc.initSrcDstCheckDone = true
+	if nrc.disableSrcDstCheck {
+		nrc.disableSourceDestinationCheck()
+		nrc.initSrcDstCheckDone = true
+	}
 
 	// enable IP forwarding for the packets coming in/out from the pods
 	err = nrc.enableForwarding()
@@ -789,6 +792,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	nrc.bgpRRClient = false
 	nrc.bgpRRServer = false
 	nrc.bgpServerStarted = false
+	nrc.disableSrcDstCheck = kubeRouterConfig.DisableSrcDstCheck
 	nrc.initSrcDstCheckDone = false
 
 	// lets start with assumption we hace necessary IAM creds to access EC2 api

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -21,6 +21,7 @@ type KubeRouterConfig struct {
 	CleanupConfig           bool
 	ClusterAsn              uint
 	ClusterCIDR             string
+	DisableSrcDstCheck      bool
 	EnableCNI               bool
 	EnableiBGP              bool
 	EnableOverlay           bool
@@ -144,4 +145,6 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&s.VLevel, "v", "v", "0", "log level for V logs")
 	fs.Uint16Var(&s.HealthPort, "health-port", 20244, "Health check port, 0 = Disabled")
 	fs.BoolVar(&s.OverrideNextHop, "override-nexthop", false, "Override the next-hop in bgp routes sent to peers with the local ip.")
+	fs.BoolVar(&s.DisableSrcDstCheck, "disable-source-dest-check", true,
+		"Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way.")
 }


### PR DESCRIPTION
When the number of nodes in a cluster is high enough, the
`disableSourceDestinationCheck()` logic creates a high number
of requests to EC2, resulting in throttling and subsequent
problems, such as the inability to attach EBS volumes. This is
not necessarily mitigated by the `ec2IamAuthorized` attribute
which was added to overcome this issue, as the number of
requests can still be high enough to reach Amazon's request
limits. In addition, it is not necessary to run this multiple
times in a loop for all the nodes in a cluster, as it is
sufficient to set it once when an instance boots.

This CLI option allows an administrator to turn off this
feature for kube-router so they can use some other means of
setting the attribute.