### PR TITLE
Ipv6; BGP peering

### DIFF
--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -98,7 +98,7 @@ func getNodeSubnet(nodeIp net.IP) (net.IPNet, string, error) {
 		return net.IPNet{}, "", errors.New("Failed to get list of links")
 	}
 	for _, link := range links {
-		addresses, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		addresses, err := netlink.AddrList(link, netlink.FAMILY_ALL)
 		if err != nil {
 			return net.IPNet{}, "", errors.New("Failed to get list of addr")
 		}

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -440,7 +440,8 @@ func (set *Set) Swap(setTo *Set) error {
 // Refresh a Set with new entries.
 func (set *Set) Refresh(entries []string, extraOptions ...string) error {
 	var err error
-	tempName := set.Name + "-temp"
+	// The set-name must be < 32 characters!
+	tempName := set.Name + "-"
 
 	newSet := &Set{
 		Parent:  set.Parent,


### PR DESCRIPTION
## BGP peering in a ipv6-only cluster

This PR takes ipv6 support as far as bgp peering for nodes inside the cluster;

```
# gobgp neighbor
Peer                AS  Up/Down State       |#Received  Accepted
1000::1:c0a8:101 64512 00:00:37 Establ      |        0         0
1000::1:c0a8:102 64512 00:00:37 Establ      |        0         0
1000::1:c0a8:103 64512 00:00:40 Establ      |        0         0
```

**NOTE**; with this PR ipv6 code is actually used if the nodeIP is recognised as an ipv6 address. Before ipv4 operation was hard-coded.

The CIDR handling does not work yet so the veth devices does not get any (ipv6) addresses. The `kube-bridge` device is howerver assigned an ipv6 address;

```
# ip -6 addr show dev kube-bridge
11: kube-bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 state UP qlen 1000
    inet6 1000::2:b00:301/120 scope global 
       valid_lft forever preferred_lft forever
    inet6 fe80::6409:c0ff:fe65:9419/64 scope link 
       valid_lft forever preferred_lft forever
```

### Design notes

The `iptablesCmdHandler` is now created with protocol;

```
iptables.NewWithProtocol(iptables.ProtocolIPv6)
```

A function for creating the right iptablesCmdHandler is provided to avoid code duplication. The `PodEgressRules` funtions are now methods in `NetworkRoutingController` to be able to access ipv6 stuff.

#### The ipset 31-caracter name limitation

This is a problem. The `Refresh` function added "-temp" to the name which together with the "inet6:" prefix made the temp names too long. As a temporary solution just a "-" is added.
IMO some hash string like "tmp_d2d362cdc6579390f1c0617d7" shall be used for temporary ipset's to make the temp name independent from the original set name.

Please comment on this.