### PR TITLE
Improved detect in ipv6IsEnabled()

### DIFF
--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -83,7 +83,7 @@ func ipv4IsEnabled() bool {
 }
 
 func ipv6IsEnabled() bool {
-	l, err := net.Listen("tcp6", "")
+	l, err := net.Listen("tcp6", "[::1]:0")
 	if err != nil {
 		return false
 	}

--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -83,6 +83,13 @@ func ipv4IsEnabled() bool {
 }
 
 func ipv6IsEnabled() bool {
+	// If ipv6 is disabled with;
+	//
+	//  sysctl -w net.ipv6.conf.all.disable_ipv6=1
+	//
+	// It is still possible to listen on the any-address "::". So this
+	// function tries the loopback address "::1" which must be present
+	// if ipv6 is enabled.
 	l, err := net.Listen("tcp6", "[::1]:0")
 	if err != nil {
 		return false


### PR DESCRIPTION
The ipv6IsEnabled() function only checks if the kernel has ipv6 support, not if it is disabled with;

```
sysctl -w net.ipv6.conf.all.disable_ipv6=1
```

By trying to open a port on the standard looback address for ipv6 `[::1]:0` a disabled ipv6 is also detected.

This caused #155 to resurface.