### PR TITLE
Allow changing default behavior of the service.local configuration

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -49,6 +49,7 @@ Usage of kube-router:
       --iptables-sync-period duration    The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0. (default 5m0s)
       --ipvs-sync-period duration        The delay between ipvs config synchronizations (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
       --kubeconfig string                Path to kubeconfig file with authorization information (the master location is set by the master flag).
+      --local-services                   Only advertise service VIPs from nodes that have at least one service endpoint pod.
       --masquerade-all                   SNAT all traffic to cluster IP/node port.
       --master string                    The address of the Kubernetes API server (overrides any value in kubeconfig).
       --metrics-path string              Prometheus metrics path (default "/metrics")

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -208,6 +208,7 @@ type NetworkServicesController struct {
 	MetricsEnabled      bool
 	ln                  LinuxNetworking
 	readyForUpdates     bool
+	localServices       bool
 
 	svcLister cache.Indexer
 	epLister  cache.Indexer
@@ -1086,7 +1087,7 @@ func (nsc *NetworkServicesController) buildServicesInfo() serviceInfoMap {
 				name:        svc.ObjectMeta.Name,
 				namespace:   svc.ObjectMeta.Namespace,
 				externalIPs: make([]string, len(svc.Spec.ExternalIPs)),
-				local:       false,
+				local:       nsc.localServices,
 			}
 			dsrMethod, ok := svc.ObjectMeta.Annotations[svcDSRAnnotation]
 			if ok {
@@ -1964,6 +1965,7 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 
 	nsc.syncPeriod = config.IpvsSyncPeriod
 	nsc.globalHairpin = config.GlobalHairpinMode
+	nsc.localServices = config.LocalServices
 
 	nsc.serviceMap = make(serviceInfoMap)
 	nsc.endpointsMap = make(endpointsInfoMap)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -35,6 +35,7 @@ type KubeRouterConfig struct {
 	IPTablesSyncPeriod      time.Duration
 	IpvsSyncPeriod          time.Duration
 	Kubeconfig              string
+	LocalServices           bool
 	MasqueradeAll           bool
 	Master                  string
 	MetricsEnabled          bool
@@ -147,4 +148,6 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.OverrideNextHop, "override-nexthop", false, "Override the next-hop in bgp routes sent to peers with the local ip.")
 	fs.BoolVar(&s.DisableSrcDstCheck, "disable-source-dest-check", true,
 		"Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way.")
+	fs.BoolVar(&s.LocalServices, "local-services", false,
+		"Only advertise service VIPs from nodes that have at least one service endpoint pod.")
 }


### PR DESCRIPTION
We use kube-routers routing and proxy features and have run into the problem that is described in detail in this issue: https://github.com/moby/moby/issues/35082#issuecomment-385433755

After a lot of experimentation and testing, we've come to the conclusion described by my colleague here: https://github.com/cloudnativelabs/kube-router/issues/544#issuecomment-431394829

To reduce complexity for us and for our users we'd like be able to set the default behavior of the service.local configuration, hence this PR. We understand that this might be a corner case but we want to avoid rolling our own version of kube-router if possible.