### PR TITLE
Added "--router-id=" parameter.

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -61,6 +61,7 @@ Usage of kube-router:
       --peer-router-multihop-ttl uint8   Enable eBGP multihop supports -- sets multihop-ttl. (Relevant only if ttl >= 2)
       --peer-router-passwords strings    Password for authenticating against the BGP peer defined with "--peer-router-ips".
       --peer-router-ports uints          The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used. (default [])
+      --router-id string                 BGP router-id. Must be specified in a ipv6 only cluster.
       --routes-sync-period duration      The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
       --run-firewall                     Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
       --run-router                       Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -47,6 +47,7 @@ type KubeRouterConfig struct {
 	PeerPasswords           []string
 	PeerPorts               []uint
 	PeerRouters             []net.IP
+	RouterId                string
 	RoutesSyncPeriod        time.Duration
 	RunFirewall             bool
 	RunRouter               bool
@@ -121,6 +122,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
 	fs.Uint16Var(&s.BGPPort, "bgp-port", DEFAULT_BGP_PORT,
 		"The port open for incoming BGP connections and to use for connecting with other BGP peers.")
+	fs.StringVar(&s.RouterId, "router-id", "", "BGP router-id. Must be specified in a ipv6 only cluster.")
 	fs.BoolVar(&s.EnableCNI, "enable-cni", true,
 		"Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin.")
 	fs.BoolVar(&s.EnableiBGP, "enable-ibgp", true,


### PR DESCRIPTION
For ipv6 it is not possible to use the ip address as router-id
and this parameter is required.

There is discussions ongoing on how to handle router-id in an ipv6-only cluster.  For now at least the router-id must be specified using this command line parameter. This keeps the procedure to obtain a router-id outside the `kube-router` binary and allows ipv6 testing to continue.
