### PR TITLE
Add mount of /lib/modules to kube-router kubeadm setup doc

### DIFF
--- a/docs/kubeadm.md
+++ b/docs/kubeadm.md
@@ -26,7 +26,7 @@ Now since kube-router provides service proxy as well. Run below commands to remo
 
 ```sh
 KUBECONFIG=/etc/kubernetes/admin.conf kubectl -n kube-system delete ds kube-proxy
-docker run --privileged --net=host k8s.gcr.io/kube-proxy-amd64:v1.10.2 kube-proxy --cleanup
+docker run --privileged -v /lib/modules:/lib/modules --net=host k8s.gcr.io/kube-proxy-amd64:v1.10.2 kube-proxy --cleanup
 ```
 
 


### PR DESCRIPTION
The 'kube-proxy --cleanup' checks that ip_vs.ko exists/is loaded.
To do this it ends up looking in /lib/modules/... and generates
an error: `Running modprobe ip_vs failed with message...`.
Add -v /lib/modules:/lib/modules to instructions.

Signed-off-by: Don Bowman <db@donbowman.ca>