### PR TITLE
Fixes regression in BGP route reflector functionality.

### DIFF
--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -130,11 +130,11 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 				n.RouteReflector = config.RouteReflector{
 					Config: config.RouteReflectorConfig{
 						RouteReflectorClient:    true,
-						RouteReflectorClusterId: config.RrClusterIdType(nrc.bgpClusterID),
+						RouteReflectorClusterId: config.RrClusterIdType(fmt.Sprint(nrc.bgpClusterID)),
 					},
 					State: config.RouteReflectorState{
 						RouteReflectorClient:    true,
-						RouteReflectorClusterId: config.RrClusterIdType(nrc.bgpClusterID),
+						RouteReflectorClusterId: config.RrClusterIdType(fmt.Sprint(nrc.bgpClusterID)),
 					},
 				}
 			}


### PR DESCRIPTION
Use proper conversion so correct cluster ID is passed to GoBGP library. GoBGP was complaining:

```
E1114 19:05:19.722793       1 bgp_peers.go:146] Failed to add node 192.168.56.101 as peer due to route-reflector-cluster-id should be specified as IPv4 address or 32-bit unsigned integer
E1114 19:05:19.723448       1 bgp_peers.go:146] Failed to add node 192.168.56.102 as peer due to route-reflector-cluster-id should be specified as IPv4 address or 32-bit unsigned integer

```
with out this fix as kube-router was passing wrong cluster-id.

Please use `cloudnativelabs/kube-router-git:rr-fix` if you would like to test.