### PR TITLE
No reason to restrict Peer ASN's to private only. 

### DIFF
--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -257,10 +257,13 @@ func newGlobalPeers(ips []net.IP, ports []uint16, asns []uint32, passwords []str
 	}
 
 	for i := 0; i < len(ips); i++ {
-		if !((asns[i] >= 64512 && asns[i] <= 65535) ||
-			(asns[i] >= 4200000000 && asns[i] <= 4294967294)) {
-			return nil, fmt.Errorf("Invalid ASN number \"%d\" for global BGP peer",
-				asns[i])
+		if !((asns[i] >= 1 && asns[i] <= 23455) ||
+			(asns[i] >= 23457 && asns[i] <= 63999) ||
+				(asns[i] >= 64512 && asns[i] <= 65534) ||
+					(asns[i] >= 131072 && asns[i] <= 4199999999) ||
+						(asns[i] >= 4200000000 && asns[i] <= 4294967294)) {
+						return nil, fmt.Errorf("Reserved ASN number \"%d\" for global BGP peer",
+						asns[i])
 		}
 
 		peer := &config.Neighbor{

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -259,11 +259,11 @@ func newGlobalPeers(ips []net.IP, ports []uint16, asns []uint32, passwords []str
 	for i := 0; i < len(ips); i++ {
 		if !((asns[i] >= 1 && asns[i] <= 23455) ||
 			(asns[i] >= 23457 && asns[i] <= 63999) ||
-				(asns[i] >= 64512 && asns[i] <= 65534) ||
-					(asns[i] >= 131072 && asns[i] <= 4199999999) ||
-						(asns[i] >= 4200000000 && asns[i] <= 4294967294)) {
-						return nil, fmt.Errorf("Reserved ASN number \"%d\" for global BGP peer",
-						asns[i])
+			(asns[i] >= 64512 && asns[i] <= 65534) ||
+			(asns[i] >= 131072 && asns[i] <= 4199999999) ||
+			(asns[i] >= 4200000000 && asns[i] <= 4294967294)) {
+			return nil, fmt.Errorf("Reserved ASN number \"%d\" for global BGP peer",
+				asns[i])
 		}
 
 		peer := &config.Neighbor{


### PR DESCRIPTION
This change is to restrict to public and private ranges. As per https://en.wikipedia.org/wiki/Autonomous_system_(Internet)#ASN_Table

