### PR TITLE
make NSC set net.ipv4.vs.conn_reuse_mode=0

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -296,7 +296,7 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 
 	err = ensureIpvsConnReuseMode()
 	if err != nil {
-		return errors.New("Failed to do sysctl net.ipv4.vs.conn_reuse_mode=0 due to: %s" + err.Error())
+		return fmt.Errorf("failed to set net.ipv4.vs.conn_reuse_mode=0: %s", err)
 	}
 
 	// loop forever unitl notified to stop on stopCh

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -30,7 +30,6 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	"golang.org/x/net/context"
-
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
@@ -293,6 +292,11 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 	err = ensureIpvsQuiescentTemplate()
 	if err != nil {
 		return errors.New("Failed to do sysctl net.ipv4.vs.expire_quiescent_template=1 due to: %s" + err.Error())
+	}
+
+	err = ensureIpvsConnReuseMode()
+	if err != nil {
+		return errors.New("Failed to do sysctl net.ipv4.vs.conn_reuse_mode=0 due to: %s" + err.Error())
 	}
 
 	// loop forever unitl notified to stop on stopCh
@@ -1403,6 +1407,10 @@ func deleteHairpinIptablesRules() error {
 
 func ensureIpvsConntrack() error {
 	return ioutil.WriteFile("/proc/sys/net/ipv4/vs/conntrack", []byte(strconv.Itoa(1)), 0640)
+}
+
+func ensureIpvsConnReuseMode() error {
+	return ioutil.WriteFile("/proc/sys/net/ipv4/vs/conn_reuse_mode", []byte(strconv.Itoa(0)), 0640)
 }
 
 func ensureIpvsExpireNodestConn() error {


### PR DESCRIPTION
will fix the IPVS low throughput issues

https://github.com/kubernetes/kubernetes/pull/71114

