### PR TITLE
Make ipv6 routing to pods (CNI routing) work for ipv6

### DIFF
--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -120,6 +120,17 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 						},
 					},
 				},
+				{
+					Config: config.AfiSafiConfig{
+						AfiSafiName: config.AFI_SAFI_TYPE_IPV6_UNICAST,
+						Enabled:     true,
+					},
+					MpGracefulRestart: config.MpGracefulRestart{
+						Config: config.MpGracefulRestartConfig{
+							Enabled: true,
+						},
+					},
+				},
 			}
 		}
 
@@ -196,6 +207,17 @@ func connectToExternalBGPPeers(server *gobgp.BgpServer, peerNeighbors []*config.
 				{
 					Config: config.AfiSafiConfig{
 						AfiSafiName: config.AFI_SAFI_TYPE_IPV4_UNICAST,
+						Enabled:     true,
+					},
+					MpGracefulRestart: config.MpGracefulRestart{
+						Config: config.MpGracefulRestartConfig{
+							Enabled: true,
+						},
+					},
+				},
+				{
+					Config: config.AfiSafiConfig{
+						AfiSafiName: config.AFI_SAFI_TYPE_IPV6_UNICAST,
 						Enabled:     true,
 					},
 					MpGracefulRestart: config.MpGracefulRestart{

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -350,18 +350,43 @@ func (nrc *NetworkRoutingController) advertisePodRoute() error {
 	cidrStr := strings.Split(cidr, "/")
 	subnet := cidrStr[0]
 	cidrLen, _ := strconv.Atoi(cidrStr[1])
-	attrs := []bgp.PathAttributeInterface{
-		bgp.NewPathAttributeOrigin(0),
-		bgp.NewPathAttributeNextHop(nrc.nodeIP.String()),
+	if nrc.isIpv6 {
+		prefixes := []bgp.AddrPrefixInterface{bgp.NewIPv6AddrPrefix(uint8(cidrLen), subnet)}
+		attrs := []bgp.PathAttributeInterface{
+			bgp.NewPathAttributeOrigin(bgp.BGP_ORIGIN_ATTR_TYPE_IGP),
+			// This requires some research.
+			// For ipv6 what should be next-hop value? According to	 this https://www.noction.com/blog/bgp-next-hop
+			// using the link-local	 address may be more appropriate.
+			bgp.NewPathAttributeMpReachNLRI(nrc.nodeIP.String(), prefixes),
+			&bgp.PathAttributeNextHop{
+				PathAttribute: bgp.PathAttribute{
+					Flags:  bgp.PathAttrFlags[bgp.BGP_ATTR_TYPE_NEXT_HOP],
+					Type:   bgp.BGP_ATTR_TYPE_NEXT_HOP,
+					Length: 16,
+				},
+				Value: nrc.nodeIP,
+			},
+		}
+
+		glog.V(2).Infof("Advertising route: '%s/%s via %s' to peers using attribute: %+q", subnet, strconv.Itoa(cidrLen), nrc.nodeIP.String(), attrs)
+
+		if _, err := nrc.bgpServer.AddPath("", []*table.Path{table.NewPath(nil, bgp.NewIPv6AddrPrefix(uint8(cidrLen),
+			subnet), false, attrs, time.Now(), false)}); err != nil {
+			return fmt.Errorf(err.Error())
+		}
+	} else {
+		attrs := []bgp.PathAttributeInterface{
+			bgp.NewPathAttributeOrigin(0),
+			bgp.NewPathAttributeNextHop(nrc.nodeIP.String()),
+		}
+
+		glog.V(2).Infof("Advertising route: '%s/%s via %s' to peers", subnet, strconv.Itoa(cidrLen), nrc.nodeIP.String())
+
+		if _, err := nrc.bgpServer.AddPath("", []*table.Path{table.NewPath(nil, bgp.NewIPAddrPrefix(uint8(cidrLen),
+			subnet), false, attrs, time.Now(), false)}); err != nil {
+			return fmt.Errorf(err.Error())
+		}
 	}
-
-	glog.V(2).Infof("Advertising route: '%s/%s via %s' to peers", subnet, strconv.Itoa(cidrLen), nrc.nodeIP.String())
-
-	if _, err := nrc.bgpServer.AddPath("", []*table.Path{table.NewPath(nil, bgp.NewIPAddrPrefix(uint8(cidrLen),
-		subnet), false, attrs, time.Now(), false)}); err != nil {
-		return fmt.Errorf(err.Error())
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
With this PR ipv6 router to pod CIDRs are inserted in the ipv6 routing table;

```
# gobgp neighbor
Peer                AS  Up/Down State       |#Received  Accepted
1000::1:c0a8:101 64512 00:00:18 Establ      |        1         1
1000::1:c0a8:102 64512 00:00:17 Establ      |        1         1
1000::1:c0a8:103 64512 00:00:18 Establ      |        1         1
# ip -6 ro
1000::1:c0a8:100/120 dev eth1 proto kernel metric 256  pref medium
1000::2:b00:0/120 via 1000::1:c0a8:103 dev eth1 proto 17 metric 1024  pref medium
1000::2:b00:100/120 via 1000::1:c0a8:102 dev eth1 proto 17 metric 1024  pref medium
1000::2:b00:300/120 via 1000::1:c0a8:101 dev eth1 proto 17 metric 1024  pref med
...
```
Params to `kube-controller-manager`;
```
kube-controller-manager --allocate-node-cidrs=true --cluster-cidr=1000::2:11.0.0.0/112 --node-cidr-mask-size=120
```
**Note** The final update for get this working was not made by me (@uablrek) I just doing the PR.

Only basic (manual) test are executed on [xcluster](https://github.com/Nordix/xcluster).