### PR TITLE
Updating deployment files for kubeadm

### DIFF
--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -88,6 +88,9 @@ spec:
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
         operator: Exists
+      - effect: NoSchedule
+        key: kubeadmNode
+        operator: Exists
       volumes:
       - name: lib-modules
         hostPath:

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -105,6 +105,9 @@ spec:
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
         operator: Exists
+      - effect: NoSchedule
+        key: kubeadmNode
+        operator: Exists
       volumes:
       - name: lib-modules
         hostPath:

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -100,6 +100,9 @@ spec:
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
         operator: Exists
+      - effect: NoSchedule
+        key: kubeadmNode
+        operator: Exists
       volumes:
       - name: lib-modules
         hostPath:

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -99,6 +99,9 @@ spec:
       - effect: NoSchedule
         key: node.kubernetes.io/not-ready
         operator: Exists
+      - effect: NoSchedule
+        key: kubeadmNode
+        operator: Exists
       volumes:
       - name: lib-modules
         hostPath:


### PR DESCRIPTION
Adding tolerations for key kubeadmNode.

This taint is added in kubeadm and makes the daemonset unable to install on the master nodes in a cluster installed by kubeadm. Without it the demonset will install on all nodes except the masters.

Tested on a cluster with Kubernetes version 1.12.2