### PR TITLE
netlink.RouteReplace matches the kernels static and replaces it. 

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -454,7 +454,7 @@ func (nrc *NetworkRoutingController) injectRoute(path *table.Path) error {
 		return netlink.RouteDel(route)
 	}
 	glog.V(2).Infof("Inject route: '%s via %s' from peer to routing table", dst, nexthop)
-	return netlink.RouteReplace(route)
+	return netlink.RouteAdd(route)
 }
 
 // Cleanup performs the cleanup of configurations done


### PR DESCRIPTION
netlink.RouteAdd doesn't disrupt the static. netlink.RouteDel still handles the withdraw correctly for those inserted with RouteAdd, but keeps the kernels statics in tact

Fixes https://github.com/cloudnativelabs/kube-router/issues/584