### PR TITLE
docs/bgp.md: change example to use printf

### DIFF
--- a/docs/bgp.md
+++ b/docs/bgp.md
@@ -120,8 +120,8 @@ kube-router requires that they are encoded as base64.
 
 On a Linux or MacOS system you can encode your passwords on the command line:
 ```
-$ echo "SecurePassword" | base64
-U2VjdXJlUGFzc3dvcmQK
+$ printf "SecurePassword" | base64
+U2VjdXJlUGFzc3dvcmQ=
 ```
 
 #### Password Configuration Examples


### PR DESCRIPTION
Using echo places a new-line character at the end of the base64 generated string which will cause the peering to fail for most use-cases as it is unlikely to be present in the configuration of the other peer.