### PR TITLE
Periodicaly sync default forward rules

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -250,6 +250,12 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 			}
 		}
 
+		// enable IP forwarding for the packets coming in/out from the pods
+		err = nrc.enableForwarding()
+		if err != nil {
+			glog.Errorf("Failed to enable IP forwarding of traffic from pods: %s", err.Error())
+		}
+
 		// advertise or withdraw IPs for the services to be reachable via host
 		toAdvertise, toWithdraw, err := nrc.getActiveVIPs()
 		if err != nil {


### PR DESCRIPTION
Fix for #588

Adds default forward rules if they was removed
```
-A FORWARD -i kube-bridge -m comment --comment "allow outbound traffic from pods" -j ACCEPT
-A FORWARD -o kube-bridge -m comment --comment "allow inbound traffic to pods" -j ACCEPT
-A FORWARD -o v4 -m comment --comment "allow outbound node port traffic on node interface with which node ip is associated" -j ACCEPT
```