### PR TITLE
keep ipset names consistent

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -56,7 +56,7 @@ const (
 	svcSchedFlagsAnnotation = "kube-router.io/service.schedflags"
 
 	LeaderElectionRecordAnnotationKey = "control-plane.alpha.kubernetes.io/leader"
-	svcIpSetName                      = "KUBE-SVC-ALL"
+	svcIpSetName                      = "kube-router-svc-all"
 )
 
 var (


### PR DESCRIPTION
renaming `KUBE-SVC-ALL` to `kube-router-svc-all` to keep it consistent with other kube-router ipset's (kube-router-pod-subnets, kube-router-node-ips)

CC: @bazuchan
 