### PR TITLE
Specify docker.io as registry for multiple registries environment

### DIFF
--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         imagePullPolicy: Always
         args:
         - "--run-router=true"

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -58,7 +58,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         imagePullPolicy: Always
         args:
         - "--run-router=true"

--- a/daemonset/generic-kuberouter-only-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-only-advertise-routes.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         imagePullPolicy: Always
         args:
         - "--run-router=true"

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         imagePullPolicy: Always
         args:
         - "--run-router=true"

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         args:
           - "--run-router=true"
           - "--run-firewall=true"

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         args: ["--run-router=true", "--run-firewall=true", "--run-service-proxy=true", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
         securityContext:
           privileged: true

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         args: ["--run-router=false", "--run-firewall=true", "--run-service-proxy=false", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
         securityContext:
           privileged: true

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         args: ["--run-router=false", "--run-firewall=false", "--run-service-proxy=true", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
         securityContext:
           privileged: true

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccount: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         imagePullPolicy: Always
         args:
         - --run-router=true

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -52,7 +52,7 @@ spec:
       serviceAccount: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         imagePullPolicy: Always
         args:
         - --run-router=true

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccount: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         imagePullPolicy: Always
         args:
         - --run-router=true

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccount: kube-router
       containers:
       - name: kube-router
-        image: cloudnativelabs/kube-router
+        image: docker.io/cloudnativelabs/kube-router
         imagePullPolicy: Always
         args:
         - --run-router=true


### PR DESCRIPTION
when use multiple registries for pulling images in container runtime 
we need specify which registry will use exacly

because https://quay.io/repository/cloudnativelabs/kube-router already exists and contains old kube-router image