### PR TITLE
fix docs: broken links in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 
 This document covers how to contribute to the kube-router project. Kube-router uses github PRs to manage contributions (could be anything from documentation, bug fixes, manifests etc.).
 
-Please read [users guide](./Documentation/README.md#user-guide) and [developers guide](/Documentation/developing.md) for the functionality and internals of kube-router.
+Please read [users guide](./docs/user-guide.md) and [developers guide](/docs/developing.md) for the functionality and internals of kube-router.
 
 ## Filing issues
 


### PR DESCRIPTION
The links to `user guide` and `developing` are broken. Not sure if they should point to the md file in the repo or to the official docs at `kube-router.io/docs`.

Signed-off-by: Moritz Johner <beller.moritz@googlemail.com>