### PR TITLE
If no endpoint is available, don't create the ipvs rule

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -841,7 +841,7 @@ func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInf
 
 		endpoints := endpointsInfoMap[k]
 
-		if svc.local && !hasActiveEndpoints(svc, endpoints) {
+		if !hasActiveEndpoints(svc, endpoints) {
 			glog.V(1).Infof("Skipping service %s/%s as it does not have active endpoints\n", svc.namespace, svc.name)
 			continue
 		}


### PR DESCRIPTION
Had to close initial PR #653 sorry for that

This PR propose a temporary fix to issue #652 by just skipping ipvs rule creation when no endpoint is available.

I have removed the condition to filter for svc.local when filtering the ipvs rules creation.

Now ipvs is skipped when no endpoint is available.

There may be a better way to handle this but it stop create and delete ipvs rules