### PR TITLE
Introduces the option --overlay-type={subnet,full}, to be able to always generate IPIP tunnels regardless of node subnets

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -49,9 +49,10 @@ Usage of kube-router:
       --disable-source-dest-check        Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way. (default true)
       --enable-cni                       Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin. (default true)
       --enable-ibgp                      Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)
-      --enable-overlay                   When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
+      --enable-overlay                   When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastructure is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
       --enable-pod-egress                SNAT traffic from Pods to destinations outside the cluster. (default true)
       --enable-pprof                     Enables pprof for debugging performance and memory leak issues.
+      --full-overlay                     When full-overlay is set to true, it changes "--enable-overlay=true" default behavior so that IP-in-IP tunneling is used for pod-to-pod networking across nodes regardless of the subnet the nodes are in. When set to false, the default, default "--enable-overlay=true" behavior is used
       --hairpin-mode                     Add iptables rules for every Service Endpoint to support hairpin traffic.
       --health-port uint16               Health check port, 0 = Disabled (default 20244)
   -h, --help                             Print usage information.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -52,7 +52,6 @@ Usage of kube-router:
       --enable-overlay                   When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastructure is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
       --enable-pod-egress                SNAT traffic from Pods to destinations outside the cluster. (default true)
       --enable-pprof                     Enables pprof for debugging performance and memory leak issues.
-      --full-overlay                     When full-overlay is set to true, it changes "--enable-overlay=true" default behavior so that IP-in-IP tunneling is used for pod-to-pod networking across nodes regardless of the subnet the nodes are in. When set to false, the default, default "--enable-overlay=true" behavior is used
       --hairpin-mode                     Add iptables rules for every Service Endpoint to support hairpin traffic.
       --health-port uint16               Health check port, 0 = Disabled (default 20244)
   -h, --help                             Print usage information.
@@ -66,6 +65,7 @@ Usage of kube-router:
       --metrics-port uint16              Prometheus metrics port, (Default 0, Disabled)
       --nodeport-bindon-all-ip           For service of NodePort type create IPVS service that listens on all IP's of the node.
       --nodes-full-mesh                  Each node in the cluster will setup BGP peering with rest of the nodes. (default true)
+      --overlay-type string              Possible values: subnet,full - When set to "subnet", the default, default "--enable-overlay=true" behavior is used. When set to "full", it changes "--enable-overlay=true" default behavior so that IP-in-IP tunneling is used for pod-to-pod networking across nodes regardless of the subnet the nodes are in. (default "subnet")
       --override-nexthop                 Override the next-hop in bgp routes sent to peers with the local ip.
       --peer-router-asns uints           ASN numbers of the BGP peer to which cluster nodes will advertise cluster ip and node's pod cidr. (default [])
       --peer-router-ips ipSlice          The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's. (default [])

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -4,8 +4,9 @@ import (
 	"net"
 	"time"
 
-	"github.com/spf13/pflag"
 	"strconv"
+
+	"github.com/spf13/pflag"
 )
 
 const DEFAULT_BGP_PORT = 179
@@ -28,6 +29,7 @@ type KubeRouterConfig struct {
 	EnablePodEgress         bool
 	EnablePprof             bool
 	FullMeshMode            bool
+	FullOverlay             bool
 	GlobalHairpinMode       bool
 	HealthPort              uint16
 	HelpRequested           bool
@@ -134,8 +136,11 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.NodePortBindOnAllIp, "nodeport-bindon-all-ip", false,
 		"For service of NodePort type create IPVS service that listens on all IP's of the node.")
 	fs.BoolVar(&s.EnableOverlay, "enable-overlay", true,
-		"When enable-overlay set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. "+
-			"When set to false no tunneling is used and routing infrastrcture is expected to route traffic for pod-to-pod networking across nodes in different subnets")
+		"When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. "+
+			"When set to false no tunneling is used and routing infrastructure is expected to route traffic for pod-to-pod networking across nodes in different subnets")
+	fs.BoolVar(&s.FullOverlay, "full-overlay", false,
+		"When full-overlay is set to true, it changes \"--enable-overlay=true\" default behavior so that IP-in-IP tunneling is used for pod-to-pod networking across nodes regardless of the subnet the nodes are in. "+
+			"When set to false, the default, default \"--enable-overlay=true\" behavior is used")
 	fs.StringSliceVar(&s.PeerPasswords, "peer-router-passwords", s.PeerPasswords,
 		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
 	fs.BoolVar(&s.EnablePprof, "enable-pprof", false,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,7 +29,7 @@ type KubeRouterConfig struct {
 	EnablePodEgress         bool
 	EnablePprof             bool
 	FullMeshMode            bool
-	FullOverlay             bool
+	OverlayType             string
 	GlobalHairpinMode       bool
 	HealthPort              uint16
 	HelpRequested           bool
@@ -66,6 +66,7 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		IPTablesSyncPeriod: 5 * time.Minute,
 		RoutesSyncPeriod:   5 * time.Minute,
 		EnableOverlay:      true,
+		OverlayType:        "subnet",
 	}
 }
 
@@ -138,9 +139,10 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableOverlay, "enable-overlay", true,
 		"When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. "+
 			"When set to false no tunneling is used and routing infrastructure is expected to route traffic for pod-to-pod networking across nodes in different subnets")
-	fs.BoolVar(&s.FullOverlay, "full-overlay", false,
-		"When full-overlay is set to true, it changes \"--enable-overlay=true\" default behavior so that IP-in-IP tunneling is used for pod-to-pod networking across nodes regardless of the subnet the nodes are in. "+
-			"When set to false, the default, default \"--enable-overlay=true\" behavior is used")
+	fs.StringVar(&s.OverlayType, "overlay-type", s.OverlayType,
+		"Possible values: subnet,full - "+
+			"When set to \"subnet\", the default, default \"--enable-overlay=true\" behavior is used. "+
+			"When set to \"full\", it changes \"--enable-overlay=true\" default behavior so that IP-in-IP tunneling is used for pod-to-pod networking across nodes regardless of the subnet the nodes are in.")
 	fs.StringSliceVar(&s.PeerPasswords, "peer-router-passwords", s.PeerPasswords,
 		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
 	fs.BoolVar(&s.EnablePprof, "enable-pprof", false,


### PR DESCRIPTION
This PR implements PR #371 ideas, keeping the existing behaviour but allowing users to opt in for a full overlay regardless of the subnet the nodes are in