### PR TITLE
default cni config to list format

### DIFF
--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
   kubeconfig: |
     apiVersion: v1
@@ -74,6 +80,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -103,10 +111,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi;
           if [ ! -f /var/lib/kube-router/kubeconfig ]; then
             TMP=/var/lib/kube-router/.tmp-kubeconfig;

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
   kubeconfig: |
     apiVersion: v1
@@ -70,6 +76,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -99,10 +107,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi;
           if [ ! -f /var/lib/kube-router/kubeconfig ]; then
             TMP=/var/lib/kube-router/.tmp-kubeconfig;

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
 
 ---
@@ -50,6 +56,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -76,10 +84,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi
         volumeMounts:
         - mountPath: /etc/cni/net.d

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
 ---
 apiVersion: extensions/v1beta1
@@ -53,6 +59,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -76,10 +84,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi
         volumeMounts:
         - name: cni-conf-dir

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
 ---
 apiVersion: extensions/v1beta1
@@ -45,6 +51,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -68,10 +76,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi
         volumeMounts:
         - name: cni-conf-dir

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
 ---
 apiVersion: extensions/v1beta1
@@ -45,6 +51,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -68,10 +76,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi
         volumeMounts:
         - name: cni-conf-dir

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
 ---
 apiVersion: extensions/v1beta1
@@ -45,6 +51,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -68,10 +76,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi
         volumeMounts:
         - name: cni-conf-dir

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
 ---
 apiVersion: extensions/v1beta1
@@ -51,6 +57,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -83,10 +91,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi
         volumeMounts:
         - name: cni-conf-dir

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"0.6.0",
        "name":"mynet",
        "plugins":[
           {
@@ -96,6 +96,9 @@ spec:
         - -c
         - set -e -x;
           if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
             mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
 ---
 apiVersion: extensions/v1beta1
@@ -51,6 +57,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -80,10 +88,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi
         volumeMounts:
         - name: cni-conf-dir

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.6.0",
+       "cniVersion":"0.3.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -9,13 +9,19 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name":"kubernetes",
-      "type":"bridge",
-      "bridge":"kube-bridge",
-      "isDefaultGateway":true,
-      "ipam": {
-        "type":"host-local"
-      }
+       "cniVersion":"0.6.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
     }
 ---
 apiVersion: extensions/v1beta1
@@ -50,6 +56,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBE_ROUTER_CNI_CONF_FILE
+          value: /etc/cni/net.d/10-kuberouter.conflist
         livenessProbe:
           httpGet:
             path: /healthz
@@ -79,10 +87,13 @@ spec:
         - /bin/sh
         - -c
         - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conf ]; then
+          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
+            if [ -f /etc/cni/net.d/*.conf ]; then
+              rm -f /etc/cni/net.d/*.conf;
+            fi;
             TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
             cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conf;
+            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi
         volumeMounts:
         - mountPath: /etc/cni/net.d


### PR DESCRIPTION
Updated PR - this one also deletes existing *.conf files in cni config directory.  These are some thoughts:

1. This deletes existing *.conf file so it can safely be applied over existing kube-router and it will update the conf format.

2. Although the kubelet only reads the first config in lexicographic order, there doesn't appear to be any limitation in the cni spec itself against having multiple configs.  Therefore, the init container only deletes *.conf files if there was no pre-existing kube-router-installed 10-kuberouter.conflist file.  The assumption is the first install is in a prepared environment, but after that all bets are off.

2. Existing *.conflist or other files are not deleted.  If kube-router is deployed into an environment like this the assumption is that the environment is complex and carefully crafted.  But, if it gets deployed without that extra care, it may break things but at least it doesn't irretrievably destroy the previous configs.

3. Perhaps some intelligence could be added where the init/install process parses existing conf/conflist files and reworks/adds itself in seamlessly, but this seems out of scope for a simple deployment config change like this.