### PR TITLE
docs,pkgs: change 'can not' to 'cannot'

### DIFF
--- a/docs/ipv6.md
+++ b/docs/ipv6.md
@@ -68,7 +68,7 @@ The CNI configuration is also updated with ipv6 addresses;
 This means that pod's gets assigned ipv6 addresses.
 
 The announcement of the pod CIDRs does not work yet. So pods on other
-nodes than the own can not be reached.
+nodes than the own cannot be reached.
 
 To get this working the routes must be inserted in the RIB for
 `gobgp`. Checking the ipv4 rib gives an error;

--- a/pkg/controllers/routing/aws.go
+++ b/pkg/controllers/routing/aws.go
@@ -21,7 +21,7 @@ import (
 func (nrc *NetworkRoutingController) disableSourceDestinationCheck() {
 	nodes, err := nrc.clientset.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
-		glog.Errorf("Failed to list nodes from API server due to: %s. Can not perform BGP peer sync", err.Error())
+		glog.Errorf("Failed to list nodes from API server due to: %s. Cannot perform BGP peer sync", err.Error())
 		return
 	}
 

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -39,7 +39,7 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 	// get the current list of the nodes from API server
 	nodes, err := nrc.clientset.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
-		glog.Errorf("Failed to list nodes from API server due to: %s. Can not perform BGP peer sync", err.Error())
+		glog.Errorf("Failed to list nodes from API server due to: %s. Cannot perform BGP peer sync", err.Error())
 		return
 	}
 	if nrc.MetricsEnabled {


### PR DESCRIPTION
This commit fixes a grammar mistake in a doc and some log messages.