### PR TITLE
add --nodeport-bindon-all-ip to generic kuberouter manifests.

### DIFF
--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -70,6 +70,7 @@ spec:
         - "--run-router=true"
         - "--run-firewall=true"
         - "--run-service-proxy=true"
+        - "--nodeport-bindon-all-ip"
         - "--kubeconfig=/var/lib/kube-router/kubeconfig"
         - "--peer-router-ips=10.1.201.254"
         - "--peer-router-asns=64512"

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -70,6 +70,7 @@ spec:
         - "--run-router=true"
         - "--run-firewall=true"
         - "--run-service-proxy=true"
+        - "--nodeport-bindon-all-ip"
         - "--kubeconfig=/var/lib/kube-router/kubeconfig"
         env:
         - name: NODE_NAME

--- a/daemonset/generic-kuberouter-only-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-only-advertise-routes.yaml
@@ -25,6 +25,7 @@ spec:
         - "--run-router=true"
         - "--run-firewall=false"
         - "--run-service-proxy=false"
+        - "--nodeport-bindon-all-ip"
         - "--enable-cni=false"
         - "--enable-ibgp=false"
         - "--enable-overlay=false"

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -49,6 +49,7 @@ spec:
         imagePullPolicy: Always
         args:
         - "--run-router=true"
+        - "--nodeport-bindon-all-ip"
         - "--run-firewall=true"
         - "--run-service-proxy=false"
         env:


### PR DESCRIPTION
I have a cluster on linode where worker nodes have a public IP and a private IP. Without the --nodeport-bindon-all-ip, kuberouter binds the nodeport to the public IP only, but linode load balancers require a private IP, so the ingress doesn't work without this flag.