### PR TITLE
Prefer node PodCIDR from an annotation

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -549,7 +549,15 @@ func (nrc *NetworkRoutingController) syncNodeIPSets() error {
 	currentPodCidrs := make([]string, 0)
 	currentNodeIPs := make([]string, 0)
 	for _, node := range nodes.Items {
-		currentPodCidrs = append(currentPodCidrs, node.Spec.PodCIDR)
+		podCIDR := node.GetAnnotations()["kube-router.io/pod-cidr"]
+		if podCIDR == "" {
+			podCIDR = node.Spec.PodCIDR
+		}
+		if podCIDR == "" {
+			glog.Warningf("Couldn't determine PodCIDR of the %v node", node.Name)
+			continue
+		}
+		currentPodCidrs = append(currentPodCidrs, podCIDR)
 		nodeIP, err := utils.GetNodeIP(&node)
 		if err != nil {
 			return fmt.Errorf("Failed to find a node IP: %s", err)


### PR DESCRIPTION
Current implementation never considers the "kube-router.io/pod-cidr"
annotation when creating an ipset for the node pod network CIDR.
The Node.Spec.PodCIDR is always used instead.

This patch prefers the annotation PodCIDR over the Node.Spec.PodCIDR