### PR TITLE
Add Import Policy for Service VIPs

### DIFF
--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -350,7 +350,7 @@ func (nrc *NetworkRoutingController) OnNodeUpdate(obj interface{}) {
 	}
 
 	// update export policies so that NeighborSet gets updated with new set of nodes
-	err := nrc.addPolicies()
+	err := nrc.AddPolicies()
 	if err != nil {
 		glog.Errorf("Error adding BGP policies: %s", err.Error())
 	}

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -350,9 +350,9 @@ func (nrc *NetworkRoutingController) OnNodeUpdate(obj interface{}) {
 	}
 
 	// update export policies so that NeighborSet gets updated with new set of nodes
-	err := nrc.addExportPolicies()
+	err := nrc.addPolicies()
 	if err != nil {
-		glog.Errorf("Error adding BGP export policies: %s", err.Error())
+		glog.Errorf("Error adding BGP policies: %s", err.Error())
 	}
 
 	if nrc.bgpEnableInternal {

--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -94,7 +94,7 @@ func (nrc *NetworkRoutingController) handleServiceUpdate(svc *v1core.Service) {
 	}
 
 	// update export policies so that new VIP's gets addedd to clusteripprefixsit and vip gets advertised to peers
-	err = nrc.addPolicies()
+	err = nrc.AddPolicies()
 	if err != nil {
 		glog.Errorf("Error adding BGP policies: %s", err.Error())
 	}
@@ -162,7 +162,7 @@ func (nrc *NetworkRoutingController) newEndpointsEventHandler() cache.ResourceEv
 
 // OnEndpointsAdd handles endpoint add events from apiserver
 // This method calls OnEndpointsUpdate with the addition of updating BGP export policies
-// Calling addExportPolicies here covers the edge case where addExportPolicies fails in
+// Calling AddPolicies here covers the edge case where AddPolicies fails in
 // OnServiceUpdate because the corresponding Endpoint resource for the
 // Service was not created yet.
 func (nrc *NetworkRoutingController) OnEndpointsAdd(obj interface{}) {
@@ -171,7 +171,7 @@ func (nrc *NetworkRoutingController) OnEndpointsAdd(obj interface{}) {
 		return
 	}
 
-	err := nrc.addPolicies()
+	err := nrc.AddPolicies()
 	if err != nil {
 		glog.Errorf("error adding BGP policies: %s", err)
 	}

--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -94,9 +94,9 @@ func (nrc *NetworkRoutingController) handleServiceUpdate(svc *v1core.Service) {
 	}
 
 	// update export policies so that new VIP's gets addedd to clusteripprefixsit and vip gets advertised to peers
-	err = nrc.addExportPolicies()
+	err = nrc.addPolicies()
 	if err != nil {
-		glog.Errorf("Error adding BGP export policies: %s", err.Error())
+		glog.Errorf("Error adding BGP policies: %s", err.Error())
 	}
 
 	nrc.advertiseVIPs(toAdvertise)
@@ -171,9 +171,9 @@ func (nrc *NetworkRoutingController) OnEndpointsAdd(obj interface{}) {
 		return
 	}
 
-	err := nrc.addExportPolicies()
+	err := nrc.addPolicies()
 	if err != nil {
-		glog.Errorf("error adding BGP export policies: %s", err)
+		glog.Errorf("error adding BGP policies: %s", err)
 	}
 
 	nrc.OnEndpointsUpdate(obj)

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -286,7 +286,7 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 			glog.Errorf("Error advertising route: %s", err.Error())
 		}
 
-		err = nrc.addPolicies()
+		err = nrc.AddPolicies()
 		if err != nil {
 			glog.Errorf("Error adding BGP policies: %s", err.Error())
 		}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -286,9 +286,9 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 			glog.Errorf("Error advertising route: %s", err.Error())
 		}
 
-		err = nrc.addExportPolicies()
+		err = nrc.addPolicies()
 		if err != nil {
-			glog.Errorf("Error adding BGP export policies: %s", err.Error())
+			glog.Errorf("Error adding BGP policies: %s", err.Error())
 		}
 
 		if nrc.bgpEnableInternal {

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -1482,18 +1482,21 @@ func Test_OnNodeUpdate(t *testing.T) {
 }
 */
 
+type PolicyTestCase struct {
+	name                   string
+	nrc                    *NetworkRoutingController
+	existingNodes          []*v1core.Node
+	existingServices       []*v1core.Service
+	podDefinedSet          *config.DefinedSets
+	clusterIPDefinedSet    *config.DefinedSets
+	externalPeerDefinedSet *config.DefinedSets
+	exportPolicyStatements []*config.Statement
+	importPolicyStatements []*config.Statement
+	err                    error
+}
+
 func Test_AddPolicies(t *testing.T) {
-	testcases := []struct {
-		name                   string
-		nrc                    *NetworkRoutingController
-		existingNodes          []*v1core.Node
-		existingServices       []*v1core.Service
-		podDefinedSet          *config.DefinedSets
-		clusterIPDefinedSet    *config.DefinedSets
-		externalPeerDefinedSet *config.DefinedSets
-		policyStatements       []*config.Statement
-		err                    error
-	}{
+	testcases := []PolicyTestCase{
 		{
 			"has nodes and services",
 			&NetworkRoutingController{
@@ -1590,6 +1593,20 @@ func Test_AddPolicies(t *testing.T) {
 					},
 					Actions: config.Actions{
 						RouteDisposition: config.ROUTE_DISPOSITION_ACCEPT_ROUTE,
+					},
+				},
+			},
+			[]*config.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: config.Conditions{
+						MatchPrefixSet: config.MatchPrefixSet{
+							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+					},
+					Actions: config.Actions{
+						RouteDisposition: config.ROUTE_DISPOSITION_REJECT_ROUTE,
 					},
 				},
 			},
@@ -1728,6 +1745,20 @@ func Test_AddPolicies(t *testing.T) {
 					},
 				},
 			},
+			[]*config.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: config.Conditions{
+						MatchPrefixSet: config.MatchPrefixSet{
+							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+					},
+					Actions: config.Actions{
+						RouteDisposition: config.ROUTE_DISPOSITION_REJECT_ROUTE,
+					},
+				},
+			},
 			nil,
 		},
 		{
@@ -1844,6 +1875,20 @@ func Test_AddPolicies(t *testing.T) {
 					},
 					Actions: config.Actions{
 						RouteDisposition: config.ROUTE_DISPOSITION_ACCEPT_ROUTE,
+					},
+				},
+			},
+			[]*config.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: config.Conditions{
+						MatchPrefixSet: config.MatchPrefixSet{
+							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+					},
+					Actions: config.Actions{
+						RouteDisposition: config.ROUTE_DISPOSITION_REJECT_ROUTE,
 					},
 				},
 			},
@@ -1991,6 +2036,20 @@ func Test_AddPolicies(t *testing.T) {
 					},
 				},
 			},
+			[]*config.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: config.Conditions{
+						MatchPrefixSet: config.MatchPrefixSet{
+							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+					},
+					Actions: config.Actions{
+						RouteDisposition: config.ROUTE_DISPOSITION_REJECT_ROUTE,
+					},
+				},
+			},
 			nil,
 		},
 		{
@@ -2128,6 +2187,20 @@ func Test_AddPolicies(t *testing.T) {
 					},
 				},
 			},
+			[]*config.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: config.Conditions{
+						MatchPrefixSet: config.MatchPrefixSet{
+							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+					},
+					Actions: config.Actions{
+						RouteDisposition: config.ROUTE_DISPOSITION_REJECT_ROUTE,
+					},
+				},
+			},
 			nil,
 		},
 	}
@@ -2207,51 +2280,57 @@ func Test_AddPolicies(t *testing.T) {
 				t.Error("unexpected external peer defined set")
 			}
 
-			policies := testcase.nrc.bgpServer.GetPolicy()
-			policyExists := false
-			for _, policy := range policies {
-				if policy.Name == "kube_router_export" {
-					policyExists = true
-					break
-				}
-			}
-			if !policyExists {
-				t.Errorf("policy 'kube_router_export' was not added")
-			}
-
-			routeType, policyAssignments, err := testcase.nrc.bgpServer.GetPolicyAssignment("", table.POLICY_DIRECTION_EXPORT)
-			if routeType != table.ROUTE_TYPE_REJECT {
-				t.Errorf("expected route type 'reject' for export policy assignment, but got %v", routeType)
-			}
-			if err != nil {
-				t.Fatalf("failed to get policy assignments: %v", err)
-			}
-
-			policyAssignmentExists := false
-			for _, policyAssignment := range policyAssignments {
-				if policyAssignment.Name == "kube_router_export" {
-					policyAssignmentExists = true
-				}
-			}
-
-			if !policyAssignmentExists {
-				t.Error("export policy assignment 'kube_router_export' was not added")
-			}
-
-			statements := testcase.nrc.bgpServer.GetStatement()
-			for _, expectedStatement := range testcase.policyStatements {
-				found := false
-				for _, statement := range statements {
-					if reflect.DeepEqual(statement, expectedStatement) {
-						found = true
-					}
-				}
-
-				if !found {
-					t.Errorf("statement %v not found", expectedStatement)
-				}
-			}
+			checkPolicies(t, testcase, table.POLICY_DIRECTION_EXPORT, table.ROUTE_TYPE_REJECT, testcase.exportPolicyStatements)
+			checkPolicies(t, testcase, table.POLICY_DIRECTION_IMPORT, table.ROUTE_TYPE_ACCEPT, testcase.importPolicyStatements)
 		})
+	}
+}
+
+func checkPolicies(t *testing.T, testcase PolicyTestCase, direction table.PolicyDirection, defaultPolicy table.RouteType,
+	policyStatements []*config.Statement) {
+	policies := testcase.nrc.bgpServer.GetPolicy()
+	policyExists := false
+	for _, policy := range policies {
+		if policy.Name == "kube_router_"+direction.String() {
+			policyExists = true
+			break
+		}
+	}
+	if !policyExists {
+		t.Errorf("policy 'kube_router_%v' was not added", direction)
+	}
+
+	routeType, policyAssignments, err := testcase.nrc.bgpServer.GetPolicyAssignment("", direction)
+	if routeType != defaultPolicy {
+		t.Errorf("expected route type '%v' for %v policy assignment, but got %v", defaultPolicy, direction, routeType)
+	}
+	if err != nil {
+		t.Fatalf("failed to get policy assignments: %v", err)
+	}
+
+	policyAssignmentExists := false
+	for _, policyAssignment := range policyAssignments {
+		if policyAssignment.Name == "kube_router_"+direction.String() {
+			policyAssignmentExists = true
+		}
+	}
+
+	if !policyAssignmentExists {
+		t.Errorf("export policy assignment 'kube_router_%v' was not added", direction)
+	}
+
+	statements := testcase.nrc.bgpServer.GetStatement()
+	for _, expectedStatement := range policyStatements {
+		found := false
+		for _, statement := range statements {
+			if reflect.DeepEqual(statement, expectedStatement) {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Errorf("statement %v not found", expectedStatement)
+		}
 	}
 }
 

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -1577,7 +1577,7 @@ func Test_AddPolicies(t *testing.T) {
 			&config.DefinedSets{},
 			[]*config.Statement{
 				{
-					Name: "kube_router_stmt0",
+					Name: "kube_router_export_stmt0",
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "podcidrprefixset",
@@ -1696,7 +1696,7 @@ func Test_AddPolicies(t *testing.T) {
 			},
 			[]*config.Statement{
 				{
-					Name: "kube_router_stmt0",
+					Name: "kube_router_export_stmt0",
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "podcidrprefixset",
@@ -1712,7 +1712,7 @@ func Test_AddPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "kube_router_stmt1",
+					Name: "kube_router_export_stmt1",
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "clusteripprefixset",
@@ -1831,7 +1831,7 @@ func Test_AddPolicies(t *testing.T) {
 			},
 			[]*config.Statement{
 				{
-					Name: "kube_router_stmt0",
+					Name: "kube_router_export_stmt0",
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "clusteripprefixset",
@@ -1953,7 +1953,7 @@ func Test_AddPolicies(t *testing.T) {
 			},
 			[]*config.Statement{
 				{
-					Name: "kube_router_stmt0",
+					Name: "kube_router_export_stmt0",
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "podcidrprefixset",
@@ -1969,7 +1969,7 @@ func Test_AddPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "kube_router_stmt1",
+					Name: "kube_router_export_stmt1",
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "clusteripprefixset",
@@ -2096,7 +2096,7 @@ func Test_AddPolicies(t *testing.T) {
 			},
 			[]*config.Statement{
 				{
-					Name: "kube_router_stmt0",
+					Name: "kube_router_export_stmt0",
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "podcidrprefixset",
@@ -2112,7 +2112,7 @@ func Test_AddPolicies(t *testing.T) {
 					},
 				},
 				{
-					Name: "kube_router_stmt1",
+					Name: "kube_router_export_stmt1",
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "clusteripprefixset",
@@ -2210,13 +2210,13 @@ func Test_AddPolicies(t *testing.T) {
 			policies := testcase.nrc.bgpServer.GetPolicy()
 			policyExists := false
 			for _, policy := range policies {
-				if policy.Name == "kube_router" {
+				if policy.Name == "kube_router_export" {
 					policyExists = true
 					break
 				}
 			}
 			if !policyExists {
-				t.Errorf("policy 'kube_router' was not added")
+				t.Errorf("policy 'kube_router_export' was not added")
 			}
 
 			routeType, policyAssignments, err := testcase.nrc.bgpServer.GetPolicyAssignment("", table.POLICY_DIRECTION_EXPORT)
@@ -2229,13 +2229,13 @@ func Test_AddPolicies(t *testing.T) {
 
 			policyAssignmentExists := false
 			for _, policyAssignment := range policyAssignments {
-				if policyAssignment.Name == "kube_router" {
+				if policyAssignment.Name == "kube_router_export" {
 					policyAssignmentExists = true
 				}
 			}
 
 			if !policyAssignmentExists {
-				t.Error("export policy assignment 'kube_router' was not added")
+				t.Error("export policy assignment 'kube_router_export' was not added")
 			}
 
 			statements := testcase.nrc.bgpServer.GetStatement()

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -1482,7 +1482,7 @@ func Test_OnNodeUpdate(t *testing.T) {
 }
 */
 
-func Test_addExportPolicies(t *testing.T) {
+func Test_AddPolicies(t *testing.T) {
 	testcases := []struct {
 		name                   string
 		nrc                    *NetworkRoutingController
@@ -2167,7 +2167,7 @@ func Test_addExportPolicies(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(testcase.nrc.clientset, 0)
 			nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 			testcase.nrc.nodeLister = nodeInformer.GetIndexer()
-			err = testcase.nrc.addPolicies()
+			err = testcase.nrc.AddPolicies()
 			if !reflect.DeepEqual(err, testcase.err) {
 				t.Logf("expected err %v", testcase.err)
 				t.Logf("actual err %v", err)

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -2167,7 +2167,7 @@ func Test_addExportPolicies(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(testcase.nrc.clientset, 0)
 			nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 			testcase.nrc.nodeLister = nodeInformer.GetIndexer()
-			err = testcase.nrc.addExportPolicies()
+			err = testcase.nrc.addPolicies()
 			if !reflect.DeepEqual(err, testcase.err) {
 				t.Logf("expected err %v", testcase.err)
 				t.Logf("actual err %v", err)


### PR DESCRIPTION
@murali-reddy I finally got around to making good on an implementation for #633 based on your recommendation.

The main goal of this request is to add a BGP import policy that rejects cluster VIPs so that they don't get added to the local routing table and instead are routed via pure ECMP.

In the process of doing this, I found that there was quite a bit of logic crossover between the export policies and the import policies (all of the prefixset and neighborset stuff). So rather than duplicate the logic or make the function larger than it was already I broke `addImportPolicies` and `addExportPolicies` into their own functions. This makes it easier to read and identify them as separate functionality. They are now called from a new `AddPolicies` function that first sets up the common prefix and neighbor sets and then calls the import/export functions.

Everything that used to call `addExportPolicies` has been converted to run `AddPolicies`.