### PR TITLE
Correct ipip Always On

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -440,7 +440,8 @@ func (nrc *NetworkRoutingController) injectRoute(path *table.Path) error {
 
 	// create IPIP tunnels only when node is not in same subnet or overlay-type is set to 'full'
 	// prevent creation when --override-nexthop=true as well
-	if (!sameSubnet || nrc.overlayType == "full") && !nrc.overrideNextHop {
+	// if the user has disabled overlays, don't create tunnels
+	if (!sameSubnet || nrc.overlayType == "full") && !nrc.overrideNextHop && nrc.enableOverlays {
 		// create ip-in-ip tunnel and inject route as overlay is enabled
 		var link netlink.Link
 		var err error
@@ -488,7 +489,7 @@ func (nrc *NetworkRoutingController) injectRoute(path *table.Path) error {
 			Dst:       dst,
 			Protocol:  0x11,
 		}
-	} else {
+	} else if sameSubnet {
 		route = &netlink.Route{
 			Dst:      dst,
 			Gw:       nexthop,


### PR DESCRIPTION
@murali-reddy @lucasmundim 

In the wake of #666 we removed some returns from the route/tunnel cleanup process of the `injectRoute` function in order to facilitate the `--overlay-type=full` option. However, these returns were what prevented routes and tunnels from being created when `--enable-overlay=false` was specified.

As such, kube-router will now make IPIP tunnels and route traffic to them regardless of whether `--enable-overlay=true` or not. This PR facilitates both functionalities by choosing to return ONLY if overlays have been disabled.

In other words:
* `--enable-overlay=false` - means that tunnels and routes to those tunnels will be cleaned and NOT created no matter how `--overlay-type` is set
* `--enable-overlay=true` - IPIP tunnels and routes to those tunnels will be created based upon the value of the `--overlay-type` setting

I've tested this in my own cluster and can confirm that it works correctly.