### PR TITLE
handle null *route

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -495,6 +495,8 @@ func (nrc *NetworkRoutingController) injectRoute(path *table.Path) error {
 			Gw:       nexthop,
 			Protocol: 0x11,
 		}
+	} else {
+		return nil
 	}
 
 	if path.IsWithdraw {


### PR DESCRIPTION
handle case when `route *netlink.Route` is not set in `injectRoute`