### PR TITLE
First stab at pushing multiarch releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - 1.10.8
 
 branches:
-  only: 
+  only:
     - master
     - /^bzub-.*$/
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
@@ -22,6 +22,7 @@ script:
   - build/travis-test.sh
   # All successfully built commits get an image placed in the kube-router-git
   # image repo and tagged with the commit hash.
+  - wget https://github.com/estesp/manifest-tool/releases/download/v1.0.0-rc2/manifest-tool-linux-amd64 -O manifest-tool && chmod +x manifest-tool
   - build/travis-deploy.sh
 
 # This fixes issues when a contributor uses their own Travis CI account to test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMG_NAMESPACE?=cloudnativelabs
 GIT_COMMIT=$(shell git describe --tags --dirty)
 GIT_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD)
 IMG_TAG?=$(if $(IMG_TAG_PREFIX),$(IMG_TAG_PREFIX)-)$(if $(ARCH_TAG_PREFIX),$(ARCH_TAG_PREFIX)-)$(GIT_BRANCH)
-RELEASE_TAG?=$(shell build/get-git-tag.sh)
+RELEASE_TAG?=$(GOARCH)-$(shell build/get-git-tag.sh)
 REGISTRY?=$(if $(IMG_FQDN),$(IMG_FQDN)/$(IMG_NAMESPACE)/$(NAME),$(IMG_NAMESPACE)/$(NAME))
 REGISTRY_DEV?=$(REGISTRY)$(DEV_SUFFIX)
 IN_DOCKER_GROUP=$(filter docker,$(shell groups))
@@ -31,6 +31,7 @@ ARCH_TAG_PREFIX=$(GOARCH)
 FILE_ARCH=IBM S/390
 DOCKERFILE_SED_EXPR?=
 else
+ARCH_TAG_PREFIX=amd64
 DOCKERFILE_SED_EXPR?=
 FILE_ARCH=x86-64
 endif
@@ -120,9 +121,20 @@ push-release: push
 	@echo Starting kube-router release container image push.
 	@test -n "$(RELEASE_TAG)"
 	$(DOCKER) tag "$(REGISTRY_DEV):$(IMG_TAG)" "$(REGISTRY):$(RELEASE_TAG)"
-	$(DOCKER) tag "$(REGISTRY):$(RELEASE_TAG)" "$(REGISTRY):latest"
 	$(DOCKER) push "$(REGISTRY)"
 	@echo Finished kube-router release container image push.
+
+push-manifest:
+	@echo Starting kube-router manifest push.
+	./manifest-tool push from-args \
+		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x \
+		--template "$(REGISTRY):ARCH-${RELEASE_TAG}" \
+		--target "$(REGISTRY):$(RELEASE_TAG)"
+
+	./manifest-tool push from-args \
+		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x \
+		--template "$(REGISTRY):ARCH-${RELEASE_TAG}" \
+		--target "$(REGISTRY):latest"
 
 github-release:
 	@echo Starting kube-router GitHub release creation.

--- a/build/travis-deploy.sh
+++ b/build/travis-deploy.sh
@@ -10,14 +10,23 @@ if [ "${TRAVIS_EVENT_TYPE}" = "pull_request" ]; then
       exit 0
     fi
     echo "Building/pushing PR$TRAVIS_PULL_REQUEST from $PR_USER"
-    make push IMG_TAG="PR$TRAVIS_PULL_REQUEST"
+    make push IMG_TAG="PR$TRAVIS_PULL_REQUEST" GOARCH=amd64
+    make push IMG_TAG="PR$TRAVIS_PULL_REQUEST" GOARCH=arm64
+    make push IMG_TAG="PR$TRAVIS_PULL_REQUEST" GOARCH=arm
+    make push IMG_TAG="PR$TRAVIS_PULL_REQUEST" GOARCH=s390x
     exit 0
 fi
 
 # Release image tag format: v0.0.0 and latest
 if [ -n "$TRAVIS_TAG" ]; then
     echo "Running Release build on Travis"
-    make push-release RELEASE_TAG="$TRAVIS_TAG"
+    make push-release RELEASE_TAG="amd64-$TRAVIS_TAG" GOARCH=amd64
+    make push-release RELEASE_TAG="arm64-$TRAVIS_TAG" GOARCH=arm64
+    make push-release RELEASE_TAG="arm-$TRAVIS_TAG" GOARCH=arm
+    make push-release RELEASE_TAG="s390x-$TRAVIS_TAG" GOARCH=s390x
+
+    echo "Pushing manifest on Travis"
+    make push-manifest RELEASE_TAG="$TRAVIS_TAG"
     exit 0
 fi
 


### PR DESCRIPTION
Closes: #622 #591

I tried to understand the build and push process and adapted it so it should push and build multiarch.

Added the `push-manifest` in the makefile, it uses the [estesp/manifest-tool](https://github.com/estesp/manifest-tool) to push the manifest for the release and latest tag.

It should work but I haven't test it :)