### PR TITLE
New Feature: CLI option to automatically configure Route Reflector servers and clients

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -74,6 +74,7 @@ Usage of kube-router:
       --peer-router-multihop-ttl uint8   Enable eBGP multihop supports -- sets multihop-ttl. (Relevant only if ttl >= 2)
       --peer-router-passwords strings    Password for authenticating against the BGP peer defined with "--peer-router-ips".
       --peer-router-ports uints          The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used. (default [])
+      --route-reflector-mode string      Possible values: manual,auto - When set to "manual", the default, route-reflector is setup using annotations on the node. When set to "auto", Kubernetes master nodes are automatically configured as route-reflector servers and Kubernetes worker nodes as route-reflector clients. (default "manual")
       --router-id string                 BGP router-id. Must be specified in a ipv6 only cluster.
       --routes-sync-period duration      The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
       --run-firewall                     Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
@@ -212,7 +213,7 @@ Please read below blog on how to user DSR in combination with `--advertise-exter
 https://cloudnativelabs.github.io/post/2017-11-01-kube-high-available-ingress/
 
 You can enable DSR(Direct Server Return) functionality per service. When enabled service endpoint
-will directly respond to the client by passing the service proxy. When DSR is enabled Kube-router 
+will directly respond to the client by passing the service proxy. When DSR is enabled Kube-router
 will uses LVS's tunneling mode to achieve this.
 
 To enable DSR you need to annotate service with `kube-router.io/service.dsr=tunnel` annotation. For e.g.
@@ -228,14 +229,14 @@ kubectl annotate service my-service "kube-router.io/service.dsr=tunnel"
 You will need to enable `hostIPC: true` and `hostPID: true` in kube-router daemonset manifest.
 Also host path `/var/run/docker.sock` must be made a volumemount to kube-router.
 
-Above changes are required for kube-router to enter pod namespeace and create ipip tunnel in the pod and to 
-assign the external IP to the VIP. 
+Above changes are required for kube-router to enter pod namespeace and create ipip tunnel in the pod and to
+assign the external IP to the VIP.
 
 For an e.g manifest please look at [manifest](../daemonset/kubeadm-kuberouter-all-features-dsr.yaml) with DSR requirements enabled.
 
 ## Load balancing Scheduling Algorithms
 
-Kube-router uses LVS for service proxy. LVS support rich set of [scheduling alogirthms](http://kb.linuxvirtualserver.org/wiki/IPVS#Job_Scheduling_Algorithms). You can annotate 
+Kube-router uses LVS for service proxy. LVS support rich set of [scheduling alogirthms](http://kb.linuxvirtualserver.org/wiki/IPVS#Job_Scheduling_Algorithms). You can annotate
 the service to choose one of the scheduling alogirthms. When a service is not annotated `round-robin` scheduler is selected by default
 
 ```

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -18,6 +18,7 @@ type KubeRouterConfig struct {
 	AdvertiseLoadBalancerIp bool
 	BGPGracefulRestart      bool
 	BGPPort                 uint16
+	BGPRouteReflectorMode   string
 	CacheSyncTimeout        time.Duration
 	CleanupConfig           bool
 	ClusterAsn              uint
@@ -63,13 +64,14 @@ type KubeRouterConfig struct {
 
 func NewKubeRouterConfig() *KubeRouterConfig {
 	return &KubeRouterConfig{
-		CacheSyncTimeout:   1 * time.Minute,
-		IpvsSyncPeriod:     5 * time.Minute,
-		IPTablesSyncPeriod: 5 * time.Minute,
-		IpvsGracefulPeriod: 30 * time.Second,
-		RoutesSyncPeriod:   5 * time.Minute,
-		EnableOverlay:      true,
-		OverlayType:        "subnet",
+		CacheSyncTimeout:      1 * time.Minute,
+		IpvsSyncPeriod:        5 * time.Minute,
+		IPTablesSyncPeriod:    5 * time.Minute,
+		IpvsGracefulPeriod:    30 * time.Second,
+		RoutesSyncPeriod:      5 * time.Minute,
+		EnableOverlay:         true,
+		OverlayType:           "subnet",
+		BGPRouteReflectorMode: "manual",
 	}
 }
 
@@ -150,6 +152,10 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Possible values: subnet,full - "+
 			"When set to \"subnet\", the default, default \"--enable-overlay=true\" behavior is used. "+
 			"When set to \"full\", it changes \"--enable-overlay=true\" default behavior so that IP-in-IP tunneling is used for pod-to-pod networking across nodes regardless of the subnet the nodes are in.")
+	fs.StringVar(&s.BGPRouteReflectorMode, "route-reflector-mode", s.BGPRouteReflectorMode,
+		"Possible values: manual,auto - "+
+			"When set to \"manual\", the default, route-reflector is setup using annotations on the node. "+
+			"When set to \"auto\", Kubernetes master nodes are automatically configured as route-reflector servers and Kubernetes worker nodes as route-reflector clients.")
 	fs.StringSliceVar(&s.PeerPasswords, "peer-router-passwords", s.PeerPasswords,
 		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
 	fs.BoolVar(&s.EnablePprof, "enable-pprof", false,


### PR DESCRIPTION
#### What type of PR is this?

New feature

#### What this PR does / why we need it:

kube-router currently supports enabling BGP Route Reflection by annotating Kubernetes nodes to be Route Reflector servers or clients. The problem is cluster provisioning tools such as `kubeadm` and `kops` do not support adding annotations to nodes during bootstrapping.

What if this could be done in a more Kubernetes native way? Kubernetes master nodes can be Route Reflector servers as they have a more permanent presence in the cluster. And Kubernetes worker nodes should only be Route Reflector clients due to their ephemeral nature.

This PR adds a new command-line option: `--route-reflector-mode.` This can be set to `manual` or `auto`.
* `manual` mode is the default and keeps the existing method of configuring Route-Reflector servers and clients by checking annotations on node objects.
* `auto` mode checks if a node is a Kubernetes master node by verifying it has the label `node-role.kubernetes.io/master`. If it has this label, the node is configured as as a Route Reflector server, otherwise it will be configured as a Route Reflector client.

The label `node-role.kubernetes.io/master` is automatically set on Kubernetes master nodes by all cluster provisioning tools.