### PR TITLE
Send heartbeats during NetworkPolicy and NetworkService sync.

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -58,6 +58,7 @@ type NetworkPolicyController struct {
 	MetricsEnabled  bool
 	v1NetworkPolicy bool
 	readyForUpdates bool
+	healthChan      chan<- *healthcheck.ControllerHeartbeat
 
 	// list of all active network policies expressed as networkPolicyInfo
 	networkPoliciesInfo *[]networkPolicyInfo
@@ -140,6 +141,7 @@ func (npc *NetworkPolicyController) Run(healthChan chan<- *healthcheck.Controlle
 	defer wg.Done()
 
 	glog.Info("Starting network policy controller")
+	npc.healthChan = healthChan
 
 	// loop forever till notified to stop on stopCh
 	for {
@@ -222,6 +224,7 @@ func (npc *NetworkPolicyController) Sync() error {
 	npc.mu.Lock()
 	defer npc.mu.Unlock()
 
+	healthcheck.SendHeartBeat(npc.healthChan, "NPC")
 	start := time.Now()
 	syncVersion := strconv.FormatInt(start.UnixNano(), 10)
 	defer func() {

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -384,6 +384,7 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 
 		case <-t.C:
 			glog.V(1).Info("Performing periodic sync of ipvs services")
+			healthcheck.SendHeartBeat(healthChan, "NSC")
 			err := nsc.doSync()
 			if err != nil {
 				glog.Errorf("Error during periodic ipvs sync in network service controller. Error: " + err.Error())


### PR DESCRIPTION
In reference to issue #725, we modified kube-router to send
heartbeats during policy sync to prevent missing heartbeats
while running iptables commands.

This commit is the first part to make kube-router faster and
more robust when applying network policies.

Signed-off-by: Jérôme Poulin <jeromepoulin@gmail.com>