### PR TITLE
Enabling --bgp-graceful-restart by default when the router component is deployed via daemonset

### DIFF
--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -70,6 +70,7 @@ spec:
         - "--run-router=true"
         - "--run-firewall=true"
         - "--run-service-proxy=true"
+        - "--bgp-graceful-restart=true"
         - "--kubeconfig=/var/lib/kube-router/kubeconfig"
         - "--peer-router-ips=10.1.201.254"
         - "--peer-router-asns=64512"
@@ -130,7 +131,7 @@ spec:
         - mountPath: /etc/kube-router
           name: kube-router-cfg
         - name: kubeconfig
-          mountPath: /var/lib/kube-router          
+          mountPath: /var/lib/kube-router
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -70,6 +70,7 @@ spec:
         - "--run-router=true"
         - "--run-firewall=true"
         - "--run-service-proxy=true"
+        - "--bgp-graceful-restart=true"
         - "--kubeconfig=/var/lib/kube-router/kubeconfig"
         env:
         - name: NODE_NAME
@@ -126,7 +127,7 @@ spec:
         - mountPath: /etc/kube-router
           name: kube-router-cfg
         - name: kubeconfig
-          mountPath: /var/lib/kube-router          
+          mountPath: /var/lib/kube-router
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly

--- a/daemonset/generic-kuberouter-only-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-only-advertise-routes.yaml
@@ -25,6 +25,7 @@ spec:
         - "--run-router=true"
         - "--run-firewall=false"
         - "--run-service-proxy=false"
+        - "--bgp-graceful-restart=true"
         - "--enable-cni=false"
         - "--enable-ibgp=false"
         - "--enable-overlay=false"

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -51,6 +51,7 @@ spec:
         - "--run-router=true"
         - "--run-firewall=true"
         - "--run-service-proxy=false"
+        - "--bgp-graceful-restart=true"
         env:
         - name: NODE_NAME
           valueFrom:
@@ -96,7 +97,7 @@ spec:
         - mountPath: /etc/cni/net.d
           name: cni-conf-dir
         - mountPath: /etc/kube-router
-          name: kube-router-cfg       
+          name: kube-router-cfg
       hostNetwork: true
       tolerations:
       - key: CriticalAddonsOnly

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -46,6 +46,7 @@ spec:
           - "--run-router=true"
           - "--run-firewall=true"
           - "--run-service-proxy=true"
+          - "--bgp-graceful-restart=true"
           - "--kubeconfig=/var/lib/kube-router/kubeconfig"
           - "--advertise-cluster-ip=true"
           - "--cluster-asn=64512"

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -42,7 +42,12 @@ spec:
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
-        args: ["--run-router=true", "--run-firewall=true", "--run-service-proxy=true", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
+        args:
+          - "--run-router=true"
+          - "--run-firewall=true"
+          - "--run-service-proxy=true"
+          - "--bgp-graceful-restart=true"
+          - "--kubeconfig=/var/lib/kube-router/kubeconfig"
         securityContext:
           privileged: true
         imagePullPolicy: Always

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -42,7 +42,11 @@ spec:
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
-        args: ["--run-router=false", "--run-firewall=true", "--run-service-proxy=false", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
+        args:
+          - "--run-router=false"
+          - "--run-firewall=true"
+          - "--run-service-proxy=false"
+          - "--kubeconfig=/var/lib/kube-router/kubeconfig"
         securityContext:
           privileged: true
         imagePullPolicy: Always

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -42,7 +42,11 @@ spec:
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
-        args: ["--run-router=false", "--run-firewall=false", "--run-service-proxy=true", "--kubeconfig=/var/lib/kube-router/kubeconfig"]
+        args:
+          - "--run-router=false"
+          - "--run-firewall=false"
+          - "--run-service-proxy=true"
+          - "--kubeconfig=/var/lib/kube-router/kubeconfig"
         securityContext:
           privileged: true
         imagePullPolicy: Always

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -51,6 +51,7 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true
+        - --bgp-graceful-restart=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
         env:
         - name: NODE_NAME

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -58,6 +58,7 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true
+        - --bgp-graceful-restart=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
         env:
         - name: NODE_NAME

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -51,6 +51,7 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=true
+        - --bgp-graceful-restart=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
         env:
         - name: NODE_NAME

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -51,6 +51,7 @@ spec:
         - --run-router=true
         - --run-firewall=true
         - --run-service-proxy=false
+        - --bgp-graceful-restart=true
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
I believe this `fixes` this issue:

https://github.com/cloudnativelabs/kube-router/issues/675