### PR TITLE
Issue 230 - Support for BGP communities via node annotation

### DIFF
--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -164,12 +164,12 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 			bgpActions.SetNextHop = "self"
 		}
 		
-		// set community for the routes advertised to external bgp peers if configured
-		if len(nrc.nodeGlobalCommunities) > 0 {
+		// bgp action to set community for the routes advertised to external bgp peers
+		if len(nrc.nodeCommunities) > 0 {
 			bgpActions.SetCommunity = config.SetCommunity{
 				Options: string(config.BGP_SET_COMMUNITY_OPTION_TYPE_ADD),
 				SetCommunityMethod: config.SetCommunityMethod{
-					CommunitiesList: nrc.nodeGlobalCommunities,
+					CommunitiesList: nrc.nodeCommunities,
 				},
 			}
 		}

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -163,6 +163,17 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 		if nrc.overrideNextHop {
 			bgpActions.SetNextHop = "self"
 		}
+		
+		// set community for the routes advertised to external bgp peers if configured
+		if len(nrc.nodeGlobalCommunities) > 0 {
+			bgpActions.SetCommunity = config.SetCommunity{
+				Options: string(config.BGP_SET_COMMUNITY_OPTION_TYPE_ADD),
+				SetCommunityMethod: config.SetCommunityMethod{
+					CommunitiesList: nrc.nodeGlobalCommunities,
+				},
+			}
+		}
+		
 		// statement to represent the export policy to permit advertising cluster IP's
 		// only to the global BGP peer or node specific BGP peer
 		statements = append(statements, config.Statement{

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -731,7 +731,6 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 	go g.Serve()
 
 	var localAddressList []string
-	var nodeCommunities []string
 	
 	if ipv4IsEnabled() {
 		localAddressList = append(localAddressList, nrc.localAddressList...)
@@ -814,16 +813,12 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 		}
 		
 		// Get Global Communities configs
+		var nodeCommunities []string
 		nodeBgpNodeCommunitiesAnnotation, ok := node.ObjectMeta.Annotations[nodeCommunitiesAnnotation]
 		if !ok {
 			glog.Infof("Could not find BGP communities info in the node's annotations. Assuming no communities.")
 		} else {
-			communitiesStrings := stringToSlice(nodeBgpNodeCommunitiesAnnotation, ",")
-			nodeCommunities, err = stringSliceB64Decode(communitiesStrings)
-			if err != nil {
-				nrc.bgpServer.Stop()
-				return fmt.Errorf("Failed to parse node's Communities Annotation: %s", err)
-			}
+			nodeCommunities = stringToSlice(nodeBgpNodeCommunitiesAnnotation, ",")
 		}
 		nrc.nodeGlobalCommunities = nodeCommunities
 		

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -84,7 +84,7 @@ type NetworkRoutingController struct {
 	advertisePodCidr        bool
 	defaultNodeAsnNumber    uint32
 	nodeAsnNumber           uint32
-	nodeGlobalCommunities   []string
+	nodeCommunities         []string
 	globalPeerRouters       []*config.Neighbor
 	nodePeerRouters         []string
 	enableCNI               bool
@@ -731,7 +731,6 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 	go g.Serve()
 
 	var localAddressList []string
-	
 	if ipv4IsEnabled() {
 		localAddressList = append(localAddressList, nrc.localAddressList...)
 	}
@@ -812,15 +811,15 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 			}
 		}
 		
-		// Get Global Communities configs
+		// Get Node Communities configs
 		var nodeCommunities []string
-		nodeBgpNodeCommunitiesAnnotation, ok := node.ObjectMeta.Annotations[nodeCommunitiesAnnotation]
+		nodeBgpCommunitiesAnnotation, ok := node.ObjectMeta.Annotations[nodeCommunitiesAnnotation]
 		if !ok {
 			glog.Infof("Could not find BGP communities info in the node's annotations. Assuming no communities.")
 		} else {
-			nodeCommunities = stringToSlice(nodeBgpNodeCommunitiesAnnotation, ",")
+			nodeCommunities = stringToSlice(nodeBgpCommunitiesAnnotation, ",")
 		}
-		nrc.nodeGlobalCommunities = nodeCommunities
+		nrc.nodeCommunities = nodeCommunities
 		
 		
 		// Create and set Global Peer Router complete configs


### PR DESCRIPTION
For #230 
This change enables adding a list of communities to a node via annotations, which then gets configured as part of export policy for external bgp peers + svc vips(clusteripprefixset) match only.
