### PR TITLE
add heartbeat

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -255,6 +255,7 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 		default:
 		}
 
+		healthcheck.SendHeartBeat(healthChan, "NRC")
 		// Update ipset entries
 		if nrc.enablePodEgress || nrc.enableOverlays {
 			glog.V(1).Info("Syncing ipsets")


### PR DESCRIPTION
We are noticing `Network Routing Controller heartbeat missed` log messages coming from the health controller. We are wondering if this is because route syncing is taking too long on the NetworkRoutesController. It looks like this issue was addressed in  [this commit](https://github.com/cloudnativelabs/kube-router/commit/42a046b5d17ef421f5216747fdebf46074eb581d) so we are trying to apply a similar fix to the NetworkRoutesController.