### PR TITLE
fix clusteripprefixset import policy

### DIFF
--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -53,10 +53,10 @@ func (nrc *NetworkRoutingController) AddPolicies() error {
 		nrc.bgpServer.AddDefinedSet(clusterIPPrefixSet)
 	}
 
+	iBGPPeers := make([]string, 0)
 	if nrc.bgpEnableInternal {
 		// Get the current list of the nodes from the local cache
 		nodes := nrc.nodeLister.List()
-		iBGPPeers := make([]string, 0)
 		for _, node := range nodes {
 			nodeObj := node.(*v1core.Node)
 			nodeIP, err := utils.GetNodeIP(nodeObj)
@@ -95,6 +95,17 @@ func (nrc *NetworkRoutingController) AddPolicies() error {
 		if err != nil {
 			nrc.bgpServer.AddDefinedSet(ns)
 		}
+	}
+
+	// a slice of all peers is used as a match condition for reject statement of clusteripprefixset import polcy
+	allBgpPeers := append(externalBgpPeers, iBGPPeers...)
+	ns, _ := table.NewNeighborSet(config.NeighborSet{
+		NeighborSetName:  "allpeerset",
+		NeighborInfoList: allBgpPeers,
+	})
+	err = nrc.bgpServer.ReplaceDefinedSet(ns)
+	if err != nil {
+		nrc.bgpServer.AddDefinedSet(ns)
 	}
 
 	err = nrc.addExportPolicies()
@@ -258,7 +269,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 }
 
 // BGP import policies are added so that the following conditions are met:
-// - do not import Service VIPs at all, instead traffic to service VIPs should be sent to the gateway and ECMPed from there
+// - do not import Service VIPs advertised from any peers, instead each kube-router originates and injects Service VIPs into local rib.
 func (nrc *NetworkRoutingController) addImportPolicies() error {
 	statements := make([]config.Statement, 0)
 
@@ -266,6 +277,9 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 		Conditions: config.Conditions{
 			MatchPrefixSet: config.MatchPrefixSet{
 				PrefixSet: "clusteripprefixset",
+			},
+			MatchNeighborSet: config.MatchNeighborSet{
+				NeighborSet: "allpeerset",
 			},
 		},
 		Actions: config.Actions{

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -1490,6 +1490,7 @@ type PolicyTestCase struct {
 	podDefinedSet          *config.DefinedSets
 	clusterIPDefinedSet    *config.DefinedSets
 	externalPeerDefinedSet *config.DefinedSets
+	allPeerDefinedSet      *config.DefinedSets
 	exportPolicyStatements []*config.Statement
 	importPolicyStatements []*config.Statement
 	err                    error
@@ -1578,6 +1579,17 @@ func Test_AddPolicies(t *testing.T) {
 				BgpDefinedSets: config.BgpDefinedSets{},
 			},
 			&config.DefinedSets{},
+			&config.DefinedSets{
+				PrefixSets: []config.PrefixSet{},
+				NeighborSets: []config.NeighborSet{
+					{
+						NeighborSetName:  "allpeerset",
+						NeighborInfoList: []string{},
+					},
+				},
+				TagSets:        []config.TagSet{},
+				BgpDefinedSets: config.BgpDefinedSets{},
+			},
 			[]*config.Statement{
 				{
 					Name: "kube_router_export_stmt0",
@@ -1602,6 +1614,10 @@ func Test_AddPolicies(t *testing.T) {
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+						MatchNeighborSet: config.MatchNeighborSet{
+							NeighborSet:     "allpeerset",
 							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
 						},
 					},
@@ -1711,6 +1727,17 @@ func Test_AddPolicies(t *testing.T) {
 				TagSets:        []config.TagSet{},
 				BgpDefinedSets: config.BgpDefinedSets{},
 			},
+			&config.DefinedSets{
+				PrefixSets: []config.PrefixSet{},
+				NeighborSets: []config.NeighborSet{
+					{
+						NeighborSetName:  "allpeerset",
+						NeighborInfoList: []string{"10.10.0.1/32", "10.10.0.2/32"},
+					},
+				},
+				TagSets:        []config.TagSet{},
+				BgpDefinedSets: config.BgpDefinedSets{},
+			},
 			[]*config.Statement{
 				{
 					Name: "kube_router_export_stmt0",
@@ -1751,6 +1778,10 @@ func Test_AddPolicies(t *testing.T) {
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+						MatchNeighborSet: config.MatchNeighborSet{
+							NeighborSet:     "allpeerset",
 							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
 						},
 					},
@@ -1860,6 +1891,17 @@ func Test_AddPolicies(t *testing.T) {
 				TagSets:        []config.TagSet{},
 				BgpDefinedSets: config.BgpDefinedSets{},
 			},
+			&config.DefinedSets{
+				PrefixSets: []config.PrefixSet{},
+				NeighborSets: []config.NeighborSet{
+					{
+						NeighborSetName:  "allpeerset",
+						NeighborInfoList: []string{"10.10.0.1/32", "10.10.0.2/32"},
+					},
+				},
+				TagSets:        []config.TagSet{},
+				BgpDefinedSets: config.BgpDefinedSets{},
+			},
 			[]*config.Statement{
 				{
 					Name: "kube_router_export_stmt0",
@@ -1884,6 +1926,10 @@ func Test_AddPolicies(t *testing.T) {
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+						MatchNeighborSet: config.MatchNeighborSet{
+							NeighborSet:     "allpeerset",
 							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
 						},
 					},
@@ -1996,6 +2042,17 @@ func Test_AddPolicies(t *testing.T) {
 				TagSets:        []config.TagSet{},
 				BgpDefinedSets: config.BgpDefinedSets{},
 			},
+			&config.DefinedSets{
+				PrefixSets: []config.PrefixSet{},
+				NeighborSets: []config.NeighborSet{
+					{
+						NeighborSetName:  "allpeerset",
+						NeighborInfoList: []string{"10.10.0.1/32", "10.10.0.2/32"},
+					},
+				},
+				TagSets:        []config.TagSet{},
+				BgpDefinedSets: config.BgpDefinedSets{},
+			},
 			[]*config.Statement{
 				{
 					Name: "kube_router_export_stmt0",
@@ -2042,6 +2099,10 @@ func Test_AddPolicies(t *testing.T) {
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+						MatchNeighborSet: config.MatchNeighborSet{
+							NeighborSet:     "allpeerset",
 							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
 						},
 					},
@@ -2153,6 +2214,17 @@ func Test_AddPolicies(t *testing.T) {
 				TagSets:        []config.TagSet{},
 				BgpDefinedSets: config.BgpDefinedSets{},
 			},
+			&config.DefinedSets{
+				PrefixSets: []config.PrefixSet{},
+				NeighborSets: []config.NeighborSet{
+					{
+						NeighborSetName:  "allpeerset",
+						NeighborInfoList: []string{"10.10.0.1/32", "10.10.0.2/32"},
+					},
+				},
+				TagSets:        []config.TagSet{},
+				BgpDefinedSets: config.BgpDefinedSets{},
+			},
 			[]*config.Statement{
 				{
 					Name: "kube_router_export_stmt0",
@@ -2193,6 +2265,10 @@ func Test_AddPolicies(t *testing.T) {
 					Conditions: config.Conditions{
 						MatchPrefixSet: config.MatchPrefixSet{
 							PrefixSet:       "clusteripprefixset",
+							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
+						},
+						MatchNeighborSet: config.MatchNeighborSet{
+							NeighborSet:     "allpeerset",
 							MatchSetOptions: config.MATCH_SET_OPTIONS_RESTRICTED_TYPE_ANY,
 						},
 					},
@@ -2278,6 +2354,17 @@ func Test_AddPolicies(t *testing.T) {
 				t.Logf("expected external peer defined set: %+v", testcase.externalPeerDefinedSet.NeighborSets)
 				t.Logf("actual external peer defined set: %+v", externalPeerDefinedSet.NeighborSets)
 				t.Error("unexpected external peer defined set")
+			}
+
+			allPeerDefinedSet, err := testcase.nrc.bgpServer.GetDefinedSet(table.DEFINED_TYPE_NEIGHBOR, "allpeerset")
+			if err != nil {
+				t.Fatalf("error validating defined sets: %v", err)
+			}
+
+			if !allPeerDefinedSet.Equal(testcase.allPeerDefinedSet) {
+				t.Logf("expected all peer defined set: %+v", testcase.allPeerDefinedSet.NeighborSets)
+				t.Logf("actual all peer defined set: %+v", allPeerDefinedSet.NeighborSets)
+				t.Error("unexpected all peer defined set")
 			}
 
 			checkPolicies(t, testcase, table.POLICY_DIRECTION_EXPORT, table.ROUTE_TYPE_REJECT, testcase.exportPolicyStatements)


### PR DESCRIPTION
This patch is a fix for each kube-router to properly originate `clusteripprefixset` (next-hop-self) injected by controller while still rejecting to import the same NLRI advertised from peers, so it can export the originated paths to eBGP peer(s). 

- without this patch:
```
Name kube_router_import:
    StatementName kube_router_import_stmt0:
      Conditions:
        PrefixSet: any clusteripprefixset
      Actions:
         reject
```

- with this patch:
```
Name kube_router_import:
    StatementName kube_router_import_stmt0:
      Conditions:
        PrefixSet: any clusteripprefixset
        NeighborSet: any allpeerset
      Actions:
         reject
```