### PR TITLE
#797 Conditionally disable "Allow All" input on IPVS KUBE-ROUTER-SERVICES

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -61,6 +61,7 @@ Usage of kube-router:
       --ipvs-graceful-period duration                 The graceful period before removing destinations from IPVS services (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 30s)
       --ipvs-graceful-termination                     Enables the experimental IPVS graceful terminaton capability
       --ipvs-sync-period duration                     The delay between ipvs config synchronizations (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
+      --ipvs-allow-all-input                          Enables rule to accept all incoming traffic on the node. (default true).
       --kubeconfig string                             Path to kubeconfig file with authorization information (the master location is set by the master flag).
       --masquerade-all                                SNAT all traffic to cluster IP/node port.
       --master string                                 The address of the Kubernetes API server (overrides any value in kubeconfig).

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -39,6 +39,7 @@ type KubeRouterConfig struct {
 	IpvsSyncPeriod                 time.Duration
 	IpvsGracefulPeriod             time.Duration
 	IpvsGracefulTermination        bool
+	IpvsAllowAllInput              bool
 	Kubeconfig                     string
 	MasqueradeAll                  bool
 	Master                         string
@@ -108,6 +109,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"The graceful period before removing destinations from IPVS services (e.g. '5s', '1m', '2h22m'). Must be greater than 0.")
 	fs.BoolVar(&s.IpvsGracefulTermination, "ipvs-graceful-termination", false,
 		"Enables the experimental IPVS graceful terminaton capability")
+	fs.BoolVar(&s.IpvsAllowAllInput, "ipvs-allow-all-input", true,
+		"Enables rule to accept all incoming traffic on the node. Default: true.")
 	fs.DurationVar(&s.RoutesSyncPeriod, "routes-sync-period", s.RoutesSyncPeriod,
 		"The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0.")
 	fs.BoolVar(&s.AdvertiseClusterIp, "advertise-cluster-ip", false,


### PR DESCRIPTION
See #797 for more details. 

fix#797
fix#682

This is to support people wanting to prevent all incoming connections from being accepted. 

In our case, we selectively whitelist items, so we would rather have this specific rule disabled. 

Can someone confirm if there's a better naming convention here for these types of flags? 