### PR TITLE
Allow setting BGP Graceful restart time from CLI

### DIFF
--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -143,6 +143,13 @@ func (kr *KubeRouter) Run() error {
 	}
 
 	if kr.Config.BGPGracefulRestart {
+		if kr.Config.BGPGracefulRestartTime > time.Second*4095 {
+			return errors.New("BGPGracefuleRestartTime should be less than 4095 seconds")
+		}
+		if kr.Config.BGPGracefulRestartTime <= 0 {
+			return errors.New("BGPGracefuleRestartTime must be positive")
+		}
+
 		if kr.Config.BGPGracefulRestartDeferralTime > time.Hour*18 {
 			return errors.New("BGPGracefuleRestartDeferralTime should be less than 18 hours")
 		}

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -104,7 +104,8 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 		if nrc.bgpGracefulRestart {
 			n.GracefulRestart = config.GracefulRestart{
 				Config: config.GracefulRestartConfig{
-					Enabled:      true,
+					Enabled: true,
+					RestartTime:  uint16(nrc.bgpGracefulRestartTime.Seconds()),
 					DeferralTime: uint16(nrc.bgpGracefulRestartDeferralTime.Seconds()),
 				},
 				State: config.GracefulRestartState{
@@ -195,13 +196,15 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 }
 
 // connectToExternalBGPPeers adds all the configured eBGP peers (global or node specific) as neighbours
-func connectToExternalBGPPeers(server *gobgp.BgpServer, peerNeighbors []*config.Neighbor, bgpGracefulRestart bool, bgpGracefulRestartDeferralTime time.Duration, peerMultihopTtl uint8) error {
+func connectToExternalBGPPeers(server *gobgp.BgpServer, peerNeighbors []*config.Neighbor, bgpGracefulRestart bool, bgpGracefulRestartDeferralTime time.Duration,
+	bgpGracefulRestartTime time.Duration, peerMultihopTtl uint8) error {
 	for _, n := range peerNeighbors {
 
 		if bgpGracefulRestart {
 			n.GracefulRestart = config.GracefulRestart{
 				Config: config.GracefulRestartConfig{
 					Enabled:      true,
+					RestartTime:  uint16(bgpGracefulRestartTime.Seconds()),
 					DeferralTime: uint16(bgpGracefulRestartDeferralTime.Seconds()),
 				},
 				State: config.GracefulRestartState{

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -89,6 +89,7 @@ type NetworkRoutingController struct {
 	bgpFullMeshMode                bool
 	bgpEnableInternal              bool
 	bgpGracefulRestart             bool
+	bgpGracefulRestartTime         time.Duration
 	bgpGracefulRestartDeferralTime time.Duration
 	ipSetHandler                   *utils.IPSet
 	enableOverlays                 bool
@@ -822,7 +823,8 @@ func (nrc *NetworkRoutingController) startBgpServer() error {
 	}
 
 	if len(nrc.globalPeerRouters) != 0 {
-		err := connectToExternalBGPPeers(nrc.bgpServer, nrc.globalPeerRouters, nrc.bgpGracefulRestart, nrc.bgpGracefulRestartDeferralTime, nrc.peerMultihopTTL)
+		err := connectToExternalBGPPeers(nrc.bgpServer, nrc.globalPeerRouters, nrc.bgpGracefulRestart,
+			nrc.bgpGracefulRestartDeferralTime, nrc.bgpGracefulRestartTime, nrc.peerMultihopTTL)
 		if err != nil {
 			nrc.bgpServer.Stop()
 			return fmt.Errorf("Failed to peer with Global Peer Router(s): %s",
@@ -860,6 +862,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	nrc.bgpEnableInternal = kubeRouterConfig.EnableiBGP
 	nrc.bgpGracefulRestart = kubeRouterConfig.BGPGracefulRestart
 	nrc.bgpGracefulRestartDeferralTime = kubeRouterConfig.BGPGracefulRestartDeferralTime
+	nrc.bgpGracefulRestartTime = kubeRouterConfig.BGPGracefulRestartTime
 	nrc.peerMultihopTTL = kubeRouterConfig.PeerMultihopTtl
 	nrc.enablePodEgress = kubeRouterConfig.EnablePodEgress
 	nrc.syncPeriod = kubeRouterConfig.RoutesSyncPeriod

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -17,6 +17,7 @@ type KubeRouterConfig struct {
 	AdvertiseNodePodCidr           bool
 	AdvertiseLoadBalancerIp        bool
 	BGPGracefulRestart             bool
+	BGPGracefulRestartTime         time.Duration
 	BGPGracefulRestartDeferralTime time.Duration
 	BGPPort                        uint16
 	CacheSyncTimeout               time.Duration
@@ -69,6 +70,7 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		IPTablesSyncPeriod:             5 * time.Minute,
 		IpvsGracefulPeriod:             30 * time.Second,
 		RoutesSyncPeriod:               5 * time.Minute,
+		BGPGracefulRestartTime:         90 * time.Second,
 		BGPGracefulRestartDeferralTime: 360 * time.Second,
 		EnableOverlay:                  true,
 		OverlayType:                    "subnet",
@@ -132,6 +134,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Each node in the cluster will setup BGP peering with rest of the nodes.")
 	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
+	fs.DurationVar(&s.BGPGracefulRestartTime, "bgp-graceful-restart-time", s.BGPGracefulRestartTime,
+		"BGP Graceful restart time according to RFC4724 3, maximum 4095s.")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time", s.BGPGracefulRestartDeferralTime,
 		"BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h.")
 	fs.Uint16Var(&s.BGPPort, "bgp-port", DEFAULT_BGP_PORT,


### PR DESCRIPTION
Default value remains the same as GoBGP (90s)

We currently use kube-router for podCIDRs only, in a baremetal environment  where nodes do not change that much. If kube-router goes down, we want to route to survive more than 90s.
Tweaking this allows us to achieve this goal.

Support for LLGR would prossibly be better and more granular, but I haven't got around to implementing the proper gobgp config in kube-router yet.

ref: https://tools.ietf.org/html/rfc4724