### PR TITLE
Add support for reading peer passwords via a file

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -959,12 +959,23 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		peerPorts = append(peerPorts, uint16(i))
 	}
 
-	// Decode base64 passwords
+	// PeerPasswords as cli params take precedence over password file
 	peerPasswords := make([]string, 0)
 	if len(kubeRouterConfig.PeerPasswords) != 0 {
 		peerPasswords, err = stringSliceB64Decode(kubeRouterConfig.PeerPasswords)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to parse CLI Peer Passwords flag: %s", err)
+		}
+	} else if len(kubeRouterConfig.PeerPasswordsFile) != 0 {
+		// Contents of the pw file should be in the same format as pw from CLI arg
+		pwfileBytes, err := ioutil.ReadFile(kubeRouterConfig.PeerPasswordsFile)
+		if err != nil {
+			return nil, fmt.Errorf("Error loading Peer Passwords File : %s", err)
+		}
+		pws := strings.Split(string(pwfileBytes), ",")
+		peerPasswords, err = stringSliceB64Decode(pws)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to decode CLI Peer Passwords file: %s", err)
 		}
 	}
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -50,6 +50,7 @@ type KubeRouterConfig struct {
 	PeerASNs                       []uint
 	PeerMultihopTtl                uint8
 	PeerPasswords                  []string
+	PeerPasswordsFile              string
 	PeerPorts                      []uint
 	PeerRouters                    []net.IP
 	RouterId                       string
@@ -156,6 +157,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 			"When set to \"full\", it changes \"--enable-overlay=true\" default behavior so that IP-in-IP tunneling is used for pod-to-pod networking across nodes regardless of the subnet the nodes are in.")
 	fs.StringSliceVar(&s.PeerPasswords, "peer-router-passwords", s.PeerPasswords,
 		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
+	fs.StringVar(&s.PeerPasswordsFile, "peer-router-passwords-file", s.PeerPasswordsFile,
+		"Path to file containing password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
 	fs.BoolVar(&s.EnablePprof, "enable-pprof", false,
 		"Enables pprof for debugging performance and memory leak issues.")
 	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, (Default 0, Disabled)")


### PR DESCRIPTION
Syntax of the file is the same as for --peer-router-passwords, that is,
a comma separated list of base64 encoded passwords.

Passwords specified with --peer-router-passwords have precedence over
passwords read from peer-router-passwords-file.

This can be useful for using k8s secrets to store the passwords instead of having them in the pod manifests.

```
kubectl -n kube-system create secret generic kube-router-rr-peer-passwords --from-literal=peer-passwords-file=$(echo -n password[,password,password,...] | base64)
```


```
        args:
        - --run-router=true
        - --peer-router-passwords-file=/etc/kube-router/peer-passwords/peer-passwords-file
        [...]
        volumeMounts:
        [...]
        - name: peer-passwords
          mountPath: /etc/kube-router/peer-passwords
          readOnly: true

      volumes:
      [...]
      - name: peer-passwords
        secret:
          secretName: kube-router-rr-peer-passwords
```