### PR TITLE
external ip for egress

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -75,6 +75,7 @@ Usage of kube-router:
       --peer-router-multihop-ttl uint8                Enable eBGP multihop supports -- sets multihop-ttl. (Relevant only if ttl >= 2)
       --peer-router-passwords strings                 Password for authenticating against the BGP peer defined with "--peer-router-ips".
       --peer-router-ports uints                       The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used. (default [])
+      --pod-egress-ip-annotation string               Node annotation to determine the ip to use for pod egress. If no annotation is found on the node, the pod source ip will be masqueraded to the node ip if pod egress is enabled. (default "kube-router.io/pod.egress.ip")
       --router-id string                              BGP router-id. Must be specified in a ipv6 only cluster.
       --routes-sync-period duration                   The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
       --run-firewall                                  Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -41,6 +41,12 @@ func (nrc *NetworkRoutingController) AddPolicies() error {
 	// creates prefix set to represent all the advertisable IP associated with the services
 	advIPPrefixList := make([]config.Prefix, 0)
 	advIps, _, _ := nrc.getAllVIPs()
+
+	//add pod egress ip to allow advertisements
+	if nrc.egressIP != nil {
+		advIps = append(advIps, nrc.egressIP.String())
+	}
+
 	for _, ip := range advIps {
 		advIPPrefixList = append(advIPPrefixList, config.Prefix{IpPrefix: ip + "/32"})
 	}

--- a/pkg/controllers/routing/pod_egress.go
+++ b/pkg/controllers/routing/pod_egress.go
@@ -3,75 +3,179 @@ package routing
 import (
 	"errors"
 	"fmt"
-
+	"github.com/cloudnativelabs/kube-router/pkg/options"
 	"github.com/golang/glog"
+	apiv1 "k8s.io/api/core/v1"
+	"strings"
 )
 
 // set up MASQUERADE rule so that egress traffic from the pods gets masqueraded to node's IP
+// or set up SNAT rule so that egress traffic from the pods uses external egress IP
 
 var (
-	podEgressArgs4 = []string{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
+	podMasqueradeEgressArgs4 = [][]string{{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
 		"-m", "set", "!", "--match-set", nodeAddrsIPSetName, "dst",
-		"-j", "MASQUERADE"}
-	podEgressArgs6 = []string{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
+		"-j", "MASQUERADE"}}
+	podMasqueradeEgressArgs6 = [][]string{{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
 		"-m", "set", "!", "--match-set", "inet6:" + nodeAddrsIPSetName, "dst",
-		"-j", "MASQUERADE"}
+		"-j", "MASQUERADE"}}
+
 	podEgressArgsBad4 = [][]string{{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
 		"-j", "MASQUERADE"}}
 	podEgressArgsBad6 = [][]string{{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
 		"-j", "MASQUERADE"}}
+
+	podSnatEgressArgs4 = [][]string{
+		{"-m", "set", "!", "--match-set", podSubnetsIPSetName, "src", "-j", "RETURN"},
+		{"-m", "set", "--match-set", podSubnetsIPSetName, "dst", "-j", "RETURN"},
+		{"-m", "set", "--match-set", nodeAddrsIPSetName, "dst", "-j", "RETURN"},
+		{"-d", "10.0.0.0/8", "-j", "MASQUERADE"},
+	}
+	podSnatEgressArgs6 = [][]string{
+		{"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "src", "-j", "RETURN"},
+		{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "dst", "-j", "RETURN"},
+		{"-m", "set", "--match-set", "inet6:" + nodeAddrsIPSetName, "dst", "-j", "RETURN"},
+		{"-d", "10.0.0.0/8", "-j", "MASQUERADE"},
+	}
 )
 
-func (nrc *NetworkRoutingController) createPodEgressRule() error {
-	iptablesCmdHandler, err := nrc.newIptablesCmdHandler()
-	if err != nil {
-		return errors.New("Failed create iptables handler:" + err.Error())
-	}
+func (nrc *NetworkRoutingController) preparePodEgress(node *apiv1.Node, kubeRouterConfig *options.KubeRouterConfig) {
+	if nrc.egressIP != nil {
+		var args [][]string
 
-	podEgressArgs := podEgressArgs4
-	if nrc.isIpv6 {
-		podEgressArgs = podEgressArgs6
-	}
-	err = iptablesCmdHandler.AppendUnique("nat", "POSTROUTING", podEgressArgs...)
-	if err != nil {
-		return errors.New("Failed to add iptables rule to masquerade outbound traffic from pods: " +
-			err.Error() + "External connectivity will not work.")
+		if nrc.isIpv6 {
+			args = podSnatEgressArgs6
+			podEgressArgsBad6 = append(podEgressArgsBad6, podMasqueradeEgressArgs6...)
+		} else {
+			args = podSnatEgressArgs4
+			podEgressArgsBad4 = append(podEgressArgsBad4, podMasqueradeEgressArgs4...)
+		}
 
-	}
+		args = append(args, []string{"-j", "SNAT", "--to-source", nrc.egressIP.String()})
 
-	glog.V(1).Infof("Added iptables rule to masquerade outbound traffic from pods.")
-	return nil
+		if nrc.isIpv6 {
+			podSnatEgressArgs6 = args
+		} else {
+			podSnatEgressArgs4 = args
+		}
+
+		glog.V(1).Infof("Using SNAT to '%s' instead of MASQUERADE for outbound traffic from pods.", nrc.egressIP.String())
+	} else {
+		if nrc.isIpv6 {
+			podEgressArgsBad6 = append(podEgressArgsBad6, podSnatEgressArgs6...)
+		} else {
+			podEgressArgsBad4 = append(podEgressArgsBad4, podSnatEgressArgs4...)
+		}
+
+		iptablesCmdHandler, err := nrc.newIptablesCmdHandler()
+		if err != nil {
+			glog.Error("Failed create iptables handler: " + err.Error())
+			return
+		}
+
+		rules, err := iptablesCmdHandler.List("nat", "POSTROUTING")
+		if err != nil {
+			glog.Error("Failed to list rules from 'nat' table in 'POSTROUTING' chain: " + err.Error())
+			return
+		}
+
+		//find the snat rule and add it to the list of rules to be removed
+		for _, rule := range rules {
+			if strings.Contains(rule, "-j SNAT --to-source") {
+				snatRuleArgs := strings.Split(rule, " ")[2:]
+				if nrc.isIpv6 {
+					podEgressArgsBad6 = append(podEgressArgsBad6, snatRuleArgs)
+				} else {
+					podEgressArgsBad4 = append(podEgressArgsBad4, snatRuleArgs)
+				}
+				break
+			}
+		}
+	}
 }
 
-func (nrc *NetworkRoutingController) deletePodEgressRule() error {
+func (nrc *NetworkRoutingController) createPodEgressRules() error {
 	iptablesCmdHandler, err := nrc.newIptablesCmdHandler()
 	if err != nil {
 		return errors.New("Failed create iptables handler:" + err.Error())
 	}
 
-	podEgressArgs := podEgressArgs4
-	if nrc.isIpv6 {
-		podEgressArgs = podEgressArgs6
-	}
-	exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", podEgressArgs...)
-	if err != nil {
-		return errors.New("Failed to lookup iptables rule to masquerade outbound traffic from pods: " + err.Error())
-	}
+	var podEgressArgs [][]string
 
-	if exists {
-		err = iptablesCmdHandler.Delete("nat", "POSTROUTING", podEgressArgs...)
-		if err != nil {
-			return errors.New("Failed to delete iptables rule to masquerade outbound traffic from pods: " +
-				err.Error() + ". Pod egress might still work...")
+	if nrc.egressIP != nil {
+		podEgressArgs = podSnatEgressArgs4
+		if nrc.isIpv6 {
+			podEgressArgs = podSnatEgressArgs6
 		}
-		glog.Infof("Deleted iptables rule to masquerade outbound traffic from pods.")
+	} else {
+		podEgressArgs = podMasqueradeEgressArgs4
+		if nrc.isIpv6 {
+			podEgressArgs = podMasqueradeEgressArgs6
+		}
 	}
 
-	return nil
+	var lastError error = nil
+
+	for _, args := range podEgressArgs {
+		err = iptablesCmdHandler.AppendUnique("nat", "POSTROUTING", args...)
+		if err != nil {
+			lastError = errors.New("Failed to add iptables rule for outbound traffic from pods: " +
+				err.Error() + "External connectivity will not work.")
+		}
+	}
+
+	if lastError == nil {
+		glog.V(1).Infof("Added iptables rules for outbound traffic from pods.")
+	}
+
+	return lastError
+}
+
+func (nrc *NetworkRoutingController) deletePodEgressRules() error {
+	iptablesCmdHandler, err := nrc.newIptablesCmdHandler()
+	if err != nil {
+		return errors.New("Failed create iptables handler:" + err.Error())
+	}
+
+	var podEgressArgs [][]string
+
+	if nrc.egressIP != nil {
+		podEgressArgs = podSnatEgressArgs4
+		if nrc.isIpv6 {
+			podEgressArgs = podSnatEgressArgs6
+		}
+	} else {
+		podEgressArgs = podMasqueradeEgressArgs4
+		if nrc.isIpv6 {
+			podEgressArgs = podMasqueradeEgressArgs6
+		}
+	}
+
+	var lastError error = nil
+
+	for _, args := range podEgressArgs {
+		exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", args...)
+		if err != nil {
+			lastError = errors.New("Failed to lookup iptables rule for outbound traffic from pods: " + err.Error())
+			continue
+		}
+
+		if exists {
+			err = iptablesCmdHandler.Delete("nat", "POSTROUTING", args...)
+			if err != nil {
+				lastError = errors.New("Failed to delete iptables rule for outbound traffic from pods: " +
+					err.Error() + ". Pod egress might still work...")
+				continue
+			}
+			glog.Infof("Deleted iptables rule for outbound traffic from pods.")
+		}
+	}
+
+	return lastError
 }
 
 func (nrc *NetworkRoutingController) deleteBadPodEgressRules() error {
@@ -83,23 +187,28 @@ func (nrc *NetworkRoutingController) deleteBadPodEgressRules() error {
 	if nrc.isIpv6 {
 		podEgressArgsBad = podEgressArgsBad6
 	}
+
+	var lastError error = nil
+
 	for _, args := range podEgressArgsBad {
 		exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", args...)
 		if err != nil {
-			return fmt.Errorf("Failed to lookup iptables rule: %s", err.Error())
+			lastError = fmt.Errorf("Failed to lookup iptables rule: %s", err.Error())
+			continue
 		}
 
 		if exists {
 			err = iptablesCmdHandler.Delete("nat", "POSTROUTING", args...)
 			if err != nil {
-				return fmt.Errorf("Failed to delete old/bad iptables rule to "+
+				lastError = fmt.Errorf("Failed to delete old/bad iptables rule to "+
 					"masquerade outbound traffic from pods: %s.\n"+
 					"Pod egress might still work, or bugs may persist after upgrade...",
 					err)
+				continue
 			}
 			glog.Infof("Deleted old/bad iptables rule to masquerade outbound traffic from pods.")
 		}
 	}
 
-	return nil
+	return lastError
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -24,6 +24,7 @@ type KubeRouterConfig struct {
 	ClusterAsn                     uint
 	ClusterCIDR                    string
 	DisableSrcDstCheck             bool
+	EgressIPAnnotation             string
 	EnableCNI                      bool
 	EnableiBGP                     bool
 	EnableOverlay                  bool
@@ -167,4 +168,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.OverrideNextHop, "override-nexthop", false, "Override the next-hop in bgp routes sent to peers with the local ip.")
 	fs.BoolVar(&s.DisableSrcDstCheck, "disable-source-dest-check", true,
 		"Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way.")
+	fs.StringVar(&s.EgressIPAnnotation, "pod-egress-ip-annotation", "kube-router.io/pod.egress.ip",
+		"Node annotation to determine the ip to use for pod egress. "+
+			"If no annotation is found on the node, the pod source ip will be masqueraded to the node ip if pod egress is enabled.")
 }

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"errors"
 	"fmt"
+	"github.com/golang/glog"
 	"net"
 	"os"
 
@@ -57,4 +58,21 @@ func GetNodeIP(node *apiv1.Node) (net.IP, error) {
 		return net.ParseIP(addresses[0].Address), nil
 	}
 	return nil, errors.New("host IP unknown")
+}
+
+//GetNodeEgressIP returns the node's egress ip or nil if no ip address was specified for the node
+func GetNodeEgressIP(node *apiv1.Node, egressIPAnnotation string) net.IP {
+	var egressIP net.IP
+
+	if egressIPString, found := node.ObjectMeta.Annotations[egressIPAnnotation]; found {
+		egressIP = net.ParseIP(egressIPString)
+		if egressIP == nil {
+			glog.Warningf("Egress IP annotation '%s' for node '%s' has invalid value '%s'. Using node ip for egress.",
+				egressIPAnnotation, node.Name, egressIPString)
+		}
+	} else {
+		glog.V(1).Infof("Egress IP annotation '%s' not found on node '%s'. Using node ip for egress.", egressIPAnnotation, node.Name)
+	}
+
+	return egressIP
 }

--- a/pkg/utils/node_test.go
+++ b/pkg/utils/node_test.go
@@ -189,3 +189,59 @@ func Test_GetNodeIP(t *testing.T) {
 		})
 	}
 }
+
+func Test_GetNodeEgressIP(t *testing.T) {
+	var nodeName, podEgressIPAnnotation = "test-node", "egress-ip"
+
+	testcases := []struct {
+		name     string
+		node     *apiv1.Node
+		egressIP net.IP
+	}{
+		{
+			"has node annotation",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						podEgressIPAnnotation: "10.10.10.10",
+					},
+				},
+			},
+			net.ParseIP("10.10.10.10"),
+		},
+		{
+			"missing pod egress IP annotation",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        nodeName,
+					Annotations: map[string]string{},
+				},
+			},
+			nil,
+		},
+		{
+			"unparseable egress IP annotation",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+					Annotations: map[string]string{
+						podEgressIPAnnotation: "this is not an IP",
+					},
+				},
+			},
+			nil,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			egressIP := GetNodeEgressIP(testcase.node, podEgressIPAnnotation)
+			if !egressIP.Equal(testcase.egressIP) {
+				t.Logf("actual egressIP: %s", egressIP.String())
+				t.Logf("expected egressIP: %s", testcase.egressIP.String())
+				t.Error("did not get expected node egressIP")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request implements following functionality:
- external ip is specified for a node using annotation
- kube-router sets up snat egress rules in iptables instead of masquerading using node's ip
- kube-router advertises route to this node for the external ip via bgp to peers so packets sent by remote host are routed back to the node (and pod)
- if the remote address is from 10.0.0.0/8 range just masquerade (internal communication knows about node's internal ip)

Signed-off-by: Jakub Drahos <jack.drahos@gmail.com>