### PR TITLE
set cniVersion in 10-kuberouter.conf

### DIFF
--- a/cni/10-kuberouter.conf
+++ b/cni/10-kuberouter.conf
@@ -1,4 +1,5 @@
 {
+    "cniVersion": "0.3.0",
     "name":"mynet",
     "type":"bridge",
     "bridge":"kube-bridge",


### PR DESCRIPTION
set `cniVersion` in `cni/10-kuberouter.conf`. `cnvVersion` is required in kubernetes 1.16 and is already set in all the manifests in the daemonset directory.