### PR TITLE
fix unhealthy on api server down

### DIFF
--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -21,7 +21,8 @@ func (nrc *NetworkRoutingController) AddPolicies() error {
 
 	cidr, err := utils.GetPodCidrFromNodeSpec(nrc.clientset, nrc.hostnameOverride)
 	if err != nil {
-		return err
+		glog.Errorf("Error add policies: %s", err.Error())
+		return nil
 	}
 
 	// creates prefix set to represent the assigned node's pod CIDR

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/table"
 	v1core "k8s.io/api/core/v1"
+	"github.com/golang/glog"
 )
 
 // First create all prefix and neighbor sets

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -8,7 +8,6 @@ import (
 	"github.com/osrg/gobgp/config"
 	"github.com/osrg/gobgp/table"
 	v1core "k8s.io/api/core/v1"
-	"github.com/golang/glog"
 )
 
 // First create all prefix and neighbor sets
@@ -20,18 +19,12 @@ func (nrc *NetworkRoutingController) AddPolicies() error {
 		return nil
 	}
 
-	cidr, err := utils.GetPodCidrFromNodeSpec(nrc.clientset, nrc.hostnameOverride)
-	if err != nil {
-		glog.Errorf("Error add policies: %s", err.Error())
-		return nil
-	}
-
 	// creates prefix set to represent the assigned node's pod CIDR
 	podCidrPrefixSet, err := table.NewPrefixSet(config.PrefixSet{
 		PrefixSetName: "podcidrprefixset",
 		PrefixList: []config.Prefix{
 			{
-				IpPrefix: cidr,
+				IpPrefix: nrc.podCidr,
 			},
 		},
 	})

--- a/pkg/controllers/routing/pbr.go
+++ b/pkg/controllers/routing/pbr.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/cloudnativelabs/kube-router/pkg/utils"
 )
 
 // setup a custom routing table that will be used for policy based routing to ensure traffic originating
@@ -24,7 +23,7 @@ func (nrc *NetworkRoutingController) enablePolicyBasedRouting() error {
 	}
 
 	if !strings.Contains(string(out), nrc.podCidr) {
-		err = exec.Command("ip", "rule", "add", "from", cidr, "lookup", customRouteTableID).Run()
+		err = exec.Command("ip", "rule", "add", "from", nrc.podCidr, "lookup", customRouteTableID).Run()
 		if err != nil {
 			return fmt.Errorf("Failed to add ip rule due to: %s", err.Error())
 		}
@@ -46,7 +45,7 @@ func (nrc *NetworkRoutingController) disablePolicyBasedRouting() error {
 	}
 
 	if strings.Contains(string(out), nrc.podCidr) {
-		err = exec.Command("ip", "rule", "del", "from", cidr, "table", customRouteTableID).Run()
+		err = exec.Command("ip", "rule", "del", "from", nrc.podCidr, "table", customRouteTableID).Run()
 		if err != nil {
 			return fmt.Errorf("Failed to delete ip rule: %s", err.Error())
 		}


### PR DESCRIPTION
The pods still work when api server is down, so need kube-router pod not be restart with live probe enabled. 
 https://github.com/cloudnativelabs/kube-router/issues/810