### PR TITLE
fix tolerations for >1.16

### DIFF
--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -136,13 +136,11 @@ spec:
           mountPath: /var/lib/kube-router          
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -132,13 +132,11 @@ spec:
           mountPath: /var/lib/kube-router          
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/generic-kuberouter-only-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-only-advertise-routes.yaml
@@ -56,13 +56,11 @@ spec:
           privileged: true
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
 
 ---

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -102,13 +102,11 @@ spec:
           name: kube-router-cfg       
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -101,13 +101,11 @@ spec:
           mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -93,13 +93,11 @@ spec:
           mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -93,13 +93,11 @@ spec:
           mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -93,13 +93,11 @@ spec:
           mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -111,13 +111,11 @@ spec:
       hostIPC: true
       hostPID: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -113,13 +113,11 @@ spec:
           mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -106,13 +106,11 @@ spec:
           mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -105,13 +105,11 @@ spec:
           name: kube-router-cfg
       hostNetwork: true
       tolerations:
+      - effect: NoSchedule
+        operator: Exists
       - key: CriticalAddonsOnly
         operator: Exists
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Exists
-      - effect: NoSchedule
-        key: node.kubernetes.io/not-ready
+      - effect: NoExecute
         operator: Exists
       volumes:
       - name: lib-modules


### PR DESCRIPTION
This PR sets tolerations:
```yaml
tolerations:
- effect: NoSchedule
  operator: Exists
- key: CriticalAddonsOnly
  operator: Exists
- effect: NoExecute
  operator: Exists
```

fixes https://github.com/cloudnativelabs/kube-router/issues/821