### PR TITLE
Make it possible to override node IP address

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -57,6 +57,7 @@ Usage of kube-router:
       --health-port uint16                            Health check port, 0 = Disabled (default 20244)
   -h, --help                                          Print usage information.
       --hostname-override string                      Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.
+      --ip-address-override ip                        Overrides the IP address of the node. Set this if kube-router is unable to determine your node IP address automatically.
       --iptables-sync-period duration                 The delay between iptables rule synchronizations (e.g. '5s', '1m'). Must be greater than 0. (default 5m0s)
       --ipvs-graceful-period duration                 The graceful period before removing destinations from IPVS services (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 30s)
       --ipvs-graceful-termination                     Enables the experimental IPVS graceful terminaton capability

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -2443,9 +2443,14 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 	}
 
 	nsc.nodeHostName = node.Name
-	NodeIP, err = utils.GetNodeIP(node)
-	if err != nil {
-		return nil, err
+
+	if !config.IPAddressOverride.IsUnspecified() {
+		NodeIP = config.IPAddressOverride
+	} else {
+		NodeIP, err = utils.GetNodeIP(node)
+		if err != nil {
+			return nil, err
+		}
 	}
 	nsc.nodeIP = NodeIP
 

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -880,9 +880,12 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 
 	nrc.nodeName = node.Name
 
-	nodeIP, err := utils.GetNodeIP(node)
-	if err != nil {
-		return nil, errors.New("Failed getting IP address from node object: " + err.Error())
+	nodeIP := kubeRouterConfig.IPAddressOverride
+	if kubeRouterConfig.IPAddressOverride.IsUnspecified() {
+		nodeIP, err = utils.GetNodeIP(node)
+		if err != nil {
+			return nil, errors.New("Failed getting IP address from node object: " + err.Error())
+		}
 	}
 	nrc.nodeIP = nodeIP
 	nrc.isIpv6 = nodeIP.To4() == nil

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -35,6 +35,7 @@ type KubeRouterConfig struct {
 	HealthPort                     uint16
 	HelpRequested                  bool
 	HostnameOverride               string
+	IPAddressOverride              net.IP
 	IPTablesSyncPeriod             time.Duration
 	IpvsSyncPeriod                 time.Duration
 	IpvsGracefulPeriod             time.Duration
@@ -146,6 +147,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers")
 	fs.StringVar(&s.HostnameOverride, "hostname-override", s.HostnameOverride,
 		"Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.")
+	fs.IPVar(&s.IPAddressOverride, "ip-address-override", s.IPAddressOverride,
+		"Overrides the IP address of the node. Set this if kube-router is unable to determine your node IP address automatically.")
 	fs.BoolVar(&s.GlobalHairpinMode, "hairpin-mode", false,
 		"Add iptables rules for every Service Endpoint to support hairpin traffic.")
 	fs.BoolVar(&s.NodePortBindOnAllIp, "nodeport-bindon-all-ip", false,


### PR DESCRIPTION
When a node has multiple IP addresses, it is useful to be able to specify which one kube-router should use. This adds a command line flag `--ip-address-override <ip>` to do that, and falls back to `utils.GetNodeIP()` if it is not specified.