### PR TITLE
Ignore deletion of unknown IPVS rules

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -53,6 +53,7 @@ Usage of kube-router:
       --enable-overlay                                When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastructure is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
       --enable-pod-egress                             SNAT traffic from Pods to destinations outside the cluster. (default true)
       --enable-pprof                                  Enables pprof for debugging performance and memory leak issues.
+      --excluded-cidrs strings                        Excluded CIDRs are used to exclude IPVS rules from deletion.
       --hairpin-mode                                  Add iptables rules for every Service Endpoint to support hairpin traffic.
       --health-port uint16                            Health check port, 0 = Disabled (default 20244)
   -h, --help                                          Print usage information.

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -209,6 +209,7 @@ type NetworkServicesController struct {
 	serviceMap          serviceInfoMap
 	endpointsMap        endpointsInfoMap
 	podCidr             string
+	excludedCidrs       []net.IPNet
 	masqueradeAll       bool
 	globalHairpin       bool
 	ipvsPermitAll       bool
@@ -2064,6 +2065,15 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 			return nil, fmt.Errorf("Failed to get pod CIDR details from Node.spec: %s", err.Error())
 		}
 		nsc.podCidr = cidr
+	}
+
+	nsc.excludedCidrs = make([]net.IPNet, len(config.ExcludedCidrs))
+	for i, excludedCidr := range config.ExcludedCidrs {
+		_, ipnet, err := net.ParseCIDR(excludedCidr)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to get excluded CIDR details: %s", err.Error())
+		}
+		nsc.excludedCidrs[i] = *ipnet
 	}
 
 	node, err := utils.GetNodeObject(clientset, config.HostnameOverride)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -29,6 +29,7 @@ type KubeRouterConfig struct {
 	EnableOverlay                  bool
 	EnablePodEgress                bool
 	EnablePprof                    bool
+	ExcludedCidrs                  []string
 	FullMeshMode                   bool
 	OverlayType                    string
 	GlobalHairpinMode              bool
@@ -99,6 +100,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"SNAT all traffic to cluster IP/node port.")
 	fs.StringVar(&s.ClusterCIDR, "cluster-cidr", s.ClusterCIDR,
 		"CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.")
+	fs.StringSliceVar(&s.ExcludedCidrs, "excluded-cidrs", s.ExcludedCidrs,
+		"Excluded CIDRs are used to exclude IPVS rules from deletion.")
 	fs.BoolVar(&s.EnablePodEgress, "enable-pod-egress", true,
 		"SNAT traffic from Pods to destinations outside the cluster.")
 	fs.DurationVar(&s.IPTablesSyncPeriod, "iptables-sync-period", s.IPTablesSyncPeriod,


### PR DESCRIPTION
Add a `--service-cidr` argument and ignore deletion of IPVS rules not in the service cidr.

Fixes #829 