### PR TITLE
fix .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,14 +8,15 @@ builds:
   - amd64
   env:
   - CGO_ENABLED=0
-archive:
-  format: tar.gz
-  name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
-    .Arm }}{{ end }}'
-  files:
-  - LICENSE*
-  - README*
-  - CHANGELOG*
-  - Documentation*
+archives:
+  -
+    format: tar.gz
+    name_template: '{{ .Binary }}_{{.Version}}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{
+      .Arm }}{{ end }}'
+    files:
+    - LICENSE*
+    - README*
+    - CHANGELOG*
+    - Documentation*
 snapshot:
   name_template: SNAPSHOT-{{ .Commit }}


### PR DESCRIPTION
go releaser failing with error `field archive not found in type config.Project` chaning it to `archives`