### PR TITLE
use endpoint (IP, port) tuple to track active endpoints of a service 

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -240,6 +240,7 @@ type serviceInfo struct {
 	namespace                string
 	clusterIP                net.IP
 	port                     int
+	targetPort               string
 	protocol                 string
 	nodePort                 int
 	sessionAffinity          bool
@@ -1033,6 +1034,7 @@ func (nsc *NetworkServicesController) buildServicesInfo() serviceInfoMap {
 			svcInfo := serviceInfo{
 				clusterIP:   net.ParseIP(svc.Spec.ClusterIP),
 				port:        int(port.Port),
+				targetPort:  port.TargetPort.String(),
 				protocol:    strings.ToLower(string(port.Protocol)),
 				nodePort:    int(port.NodePort),
 				name:        svc.ObjectMeta.Name,
@@ -1883,6 +1885,10 @@ func generateServiceId(namespace, svcName, port string) string {
 // unique identifier for a load-balanced service (namespace + name + portname)
 func generateIpPortId(ip, protocol, port string) string {
 	return ip + "-" + protocol + "-" + port
+}
+
+func generateEndpointId(ip, port string) string {
+	return ip + ":" + port
 }
 
 // returns all IP addresses found on any network address in the system, excluding dummy and docker interfaces


### PR DESCRIPTION
Currently only endpoint IP used so any change in port of the endpoint leaves stale ipvs server config. With this change (ip, port) tuple is used to track active endpoitns of service and to identify stale IPVS config of server of a service

also service info that is built does not carry `targetport` info, so any change to just `targetPort` in service spec was not trigerring sync

Fixes #841
