### PR TITLE
Enable ppc64le builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ Dockerfile.amd64.run
 Dockerfile.arm64.run
 Dockerfile.s390x.run
 Dockerfile.arm.run
+Dockerfile.ppc64le.run
 vendor/github.com/osrg/gobgp/gobgp/gobgp

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ else ifeq ($(GOARCH), s390x)
 ARCH_TAG_PREFIX=$(GOARCH)
 FILE_ARCH=IBM S/390
 DOCKERFILE_SED_EXPR?=
+else ifeq ($(GOARCH), ppc64le)
+ARCH_TAG_PREFIX=$(GOARCH)
+FILE_ARCH=64-bit PowerPC
+DOCKERFILE_SED_EXPR?=
 else
 ARCH_TAG_PREFIX=amd64
 DOCKERFILE_SED_EXPR?=
@@ -127,12 +131,12 @@ push-release: push
 push-manifest:
 	@echo Starting kube-router manifest push.
 	./manifest-tool push from-args \
-		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x \
+		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x,linux/ppc64le \
 		--template "$(REGISTRY):ARCH-${RELEASE_TAG}" \
 		--target "$(REGISTRY):$(RELEASE_TAG)"
 
 	./manifest-tool push from-args \
-		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x \
+		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x,linux/ppc64le \
 		--template "$(REGISTRY):ARCH-${RELEASE_TAG}" \
 		--target "$(REGISTRY):latest"
 

--- a/build/travis-deploy.sh
+++ b/build/travis-deploy.sh
@@ -18,6 +18,8 @@ if [ "${TRAVIS_EVENT_TYPE}" = "pull_request" ]; then
     make clean IMG_TAG="PR$TRAVIS_PULL_REQUEST" GOARCH=arm
     make push IMG_TAG="PR$TRAVIS_PULL_REQUEST" GOARCH=s390x
     make clean IMG_TAG="PR$TRAVIS_PULL_REQUEST" GOARCH=s390x
+    make push IMG_TAG="PR$TRAVIS_PULL_REQUEST" GOARCH=ppc64le
+    make clean IMG_TAG="PR$TRAVIS_PULL_REQUEST" GOARCH=ppc64le
     exit 0
 fi
 
@@ -32,6 +34,8 @@ if [ -n "$TRAVIS_TAG" ]; then
     make clean RELEASE_TAG="arm-$TRAVIS_TAG" GOARCH=arm
     make push-release RELEASE_TAG="s390x-$TRAVIS_TAG" GOARCH=s390x
     make clean RELEASE_TAG="s390x-$TRAVIS_TAG" GOARCH=s390x
+    make push-release RELEASE_TAG="ppc64le-$TRAVIS_TAG" GOARCH=ppc64le
+    make clean RELEASE_TAG="ppc64le-$TRAVIS_TAG" GOARCH=ppc64le
     echo "Pushing manifest on Travis"
     make push-manifest RELEASE_TAG="$TRAVIS_TAG"
     exit 0


### PR DESCRIPTION
We are running an environment mixed with amd64 and ppc64le machines.  Including ppc64le builds in the official multi-arch builds would be helpful.  Thanks!
