### PR TITLE
handle DeletedFinalStateUnknown objects in DeleteFunc handlers

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -211,6 +211,11 @@ func (npc *NetworkPolicyController) OnNamespaceUpdate(obj interface{}) {
 	}
 	glog.V(2).Infof("Received update for namespace: %s", namespace.Name)
 
+	if !npc.readyForUpdates {
+		glog.V(3).Infof("Skipping update to namespace: %s, controller still performing bootup full-sync", namespace.Name)
+		return
+	}
+
 	err := npc.Sync()
 	if err != nil {
 		glog.Errorf("Error syncing on namespace update: %s", err)
@@ -1712,6 +1717,11 @@ func (npc *NetworkPolicyController) handleNamespaceDelete(obj interface{}) {
 		return
 	}
 	glog.V(2).Infof("Received namespace: %s delete event", namespace.Name)
+
+	if !npc.readyForUpdates {
+		glog.V(3).Infof("Skipping update to namespace: %s, controller still performing bootup full-sync", namespace.Name)
+		return
+	}
 
 	err := npc.Sync()
 	if err != nil {

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -332,7 +332,18 @@ func (nrc *NetworkRoutingController) newNodeEventHandler() cache.ResourceEventHa
 
 		},
 		DeleteFunc: func(obj interface{}) {
-			node := obj.(*v1core.Node)
+			node, ok := obj.(*v1core.Node)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					glog.Errorf("unexpected object type: %v", obj)
+					return
+				}
+				if node, ok = tombstone.Obj.(*v1core.Node); !ok {
+					glog.Errorf("unexpected object type: %v", obj)
+					return
+				}
+			}
 			nodeIP, _ := utils.GetNodeIP(node)
 
 			glog.Infof("Received node %s removed update from watch API, so remove node from peer", nodeIP)

--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -128,10 +128,19 @@ func (nrc *NetworkRoutingController) tryHandleServiceUpdate(obj interface{}, log
 }
 
 func (nrc *NetworkRoutingController) tryHandleServiceDelete(obj interface{}, logMsgFormat string) {
-	if svc := getServiceObject(obj); svc != nil {
-		glog.V(1).Infof(logMsgFormat, svc.Namespace, svc.Name)
-		nrc.handleServiceDelete(svc)
+	svc, ok := obj.(*v1core.Service)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
+		if svc, ok = tombstone.Obj.(*v1core.Service); !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
 	}
+	nrc.handleServiceDelete(svc)
 }
 
 // OnServiceCreate handles new service create event from the kubernetes API server


### PR DESCRIPTION
in DeleteFunc handlers across the controllers handle the case where received object can be of type DeletedFinalStateUnknown

fixes one of the symptoms (panic on receiving DeletedFinalStateUnknown objects) reported in #712