### PR TITLE
add option to not masquerade pod cidrs

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -43,6 +43,7 @@ type KubeRouterConfig struct {
 	IpvsPermitAll                  bool
 	Kubeconfig                     string
 	MasqueradeAll                  bool
+	MasqueradePodCIDRs             bool
 	Master                         string
 	MetricsEnabled                 bool
 	MetricsPath                    string
@@ -98,6 +99,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Cleanup iptables rules, ipvs, ipset configuration and exit.")
 	fs.BoolVar(&s.MasqueradeAll, "masquerade-all", false,
 		"SNAT all traffic to cluster IP/node port.")
+	fs.BoolVar(&s.MasqueradePodCIDRs, "masquerade-pod-cidrs", true,
+		"SNAT all traffic to pod CIDRs.")
 	fs.StringVar(&s.ClusterCIDR, "cluster-cidr", s.ClusterCIDR,
 		"CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.")
 	fs.StringSliceVar(&s.ExcludedCidrs, "excluded-cidrs", s.ExcludedCidrs,


### PR DESCRIPTION
Add an option, masquerade-pod-cidrs, to allow pod cidrs to not be
masquerading is unnecessary (e.g. when pods CIDRs are routeable on a
network via BGP).

The new option defaults to true for backward compatibility.