### PR TITLE
read the necessary API objects from local cache instead of listing from the API server

### DIFF
--- a/pkg/controllers/routing/aws.go
+++ b/pkg/controllers/routing/aws.go
@@ -11,7 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/glog"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1core "k8s.io/api/core/v1"
 )
 
 // disableSourceDestinationCheck disables src-dst check of all the VM's when cluster
@@ -19,13 +20,10 @@ import (
 // to a VM with IP other than that of VM's ip. This check needs to be disabled so that
 // cross node pod-to-pod traffic can be sent and recived by a VM.
 func (nrc *NetworkRoutingController) disableSourceDestinationCheck() {
-	nodes, err := nrc.clientset.CoreV1().Nodes().List(metav1.ListOptions{})
-	if err != nil {
-		glog.Errorf("Failed to list nodes from API server due to: %s. Cannot perform BGP peer sync", err.Error())
-		return
-	}
+	nodes := nrc.nodeLister.List()
 
-	for _, node := range nodes.Items {
+	for _, obj := range nodes {
+		node := obj.(*v1core.Node)
 		if node.Spec.ProviderID == "" || !strings.HasPrefix(node.Spec.ProviderID, "aws") {
 			return
 		}


### PR DESCRIPTION
Fixes #862

this PR removes last and very few instances where API objects were directly read from the API server

