### PR TITLE
Handle missing routing tables

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1813,11 +1813,7 @@ func (ln *linuxNetworking) setupPolicyRoutingForDSR() error {
 		}
 	}
 	out, err := exec.Command("ip", "route", "list", "table", customDSRRouteTableID).Output()
-	if err != nil {
-		return errors.New("Failed to verify required default route exists. " +
-			"Failed to setup policy routing required for DSR due to " + err.Error())
-	}
-	if !strings.Contains(string(out), " lo ") {
+	if err != nil || !strings.Contains(string(out), " lo ") {
 		if err = exec.Command("ip", "route", "add", "local", "default", "dev", "lo", "table",
 			customDSRRouteTableID).Run(); err != nil {
 			return errors.New("Failed to add route in custom route table due to: " + err.Error())
@@ -1848,12 +1844,6 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 		}
 	}
 
-	_, err = exec.Command("ip", "route", "list", "table", externalIPRouteTableId).Output()
-	if err != nil {
-		return errors.New("Failed to verify required routing table for external IP's exists. " +
-			"Failed to setup policy routing required for DSR due to " + err.Error())
-	}
-
 	out, err := exec.Command("ip", "rule", "list").Output()
 	if err != nil {
 		return errors.New("Failed to verify if `ip rule add prio 32765 from all lookup external_ip` exists due to: " + err.Error())
@@ -1867,10 +1857,7 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 		}
 	}
 
-	out, err = exec.Command("ip", "route", "list", "table", externalIPRouteTableId).Output()
-	if err != nil {
-		return errors.New("Failed to get routes in external_ip table due to: " + err.Error())
-	}
+	out, _ = exec.Command("ip", "route", "list", "table", externalIPRouteTableId).Output()
 	outStr := string(out)
 	activeExternalIPs := make(map[string]bool)
 	for _, svc := range serviceInfoMap {


### PR DESCRIPTION
The behavior of iproute2 changed in 5.0 as described in #750: now if a
table has not been created, `ip route list table <table>` will produce a
non-zero exit code.

It's not really needed to check tables via `list` anyway, since they
will be created by iproute2 when needed on first use. So relax error
handling for `ip route list table`, and remove it completely when a
table might be missing.

This fixes #750