### PR TITLE
Add the possibility to specify CIDRs that will be skipped by the MASQUERADE iptables target

### DIFF
--- a/pkg/controllers/routing/pod_egress.go
+++ b/pkg/controllers/routing/pod_egress.go
@@ -13,16 +13,24 @@ var (
 	podEgressArgs4 = []string{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
 		"-m", "set", "!", "--match-set", nodeAddrsIPSetName, "dst",
+		"-m", "set", "!", "--match-set", otherSubnetsIPSetName, "dst",
 		"-j", "MASQUERADE"}
 	podEgressArgs6 = []string{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
 		"-m", "set", "!", "--match-set", "inet6:" + nodeAddrsIPSetName, "dst",
+		"-m", "set", "!", "--match-set", "inet6:" + otherSubnetsIPSetName, "dst",
 		"-j", "MASQUERADE"}
 	podEgressArgsBad4 = [][]string{{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
+		"-j", "MASQUERADE"},{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
+		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
+		"-m", "set", "!", "--match-set", nodeAddrsIPSetName, "dst",
 		"-j", "MASQUERADE"}}
 	podEgressArgsBad6 = [][]string{{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
+		"-j", "MASQUERADE"},{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
+		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
+		"-m", "set", "!", "--match-set", "inet6:" + nodeAddrsIPSetName, "dst",
 		"-j", "MASQUERADE"}}
 )
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -48,6 +48,7 @@ type KubeRouterConfig struct {
 	MetricsPath                    string
 	MetricsPort                    uint16
 	NodePortBindOnAllIp            bool
+	OtherKnownCidrs                []string
 	OverrideNextHop                bool
 	PeerASNs                       []uint
 	PeerMultihopTtl                uint8
@@ -102,6 +103,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.")
 	fs.StringSliceVar(&s.ExcludedCidrs, "excluded-cidrs", s.ExcludedCidrs,
 		"Excluded CIDRs are used to exclude IPVS rules from deletion.")
+	fs.StringSliceVar(&s.OtherKnownCidrs, "other-known-cidrs", s.OtherKnownCidrs,
+		"CIDRs excluded from masquerading by egress iptables rule.")
 	fs.BoolVar(&s.EnablePodEgress, "enable-pod-egress", true,
 		"SNAT traffic from Pods to destinations outside the cluster.")
 	fs.DurationVar(&s.IPTablesSyncPeriod, "iptables-sync-period", s.IPTablesSyncPeriod,


### PR DESCRIPTION
I'm using a tunnel to encapsulate traffic between two kubernetes clusters.

Unfortunately kube-router sets up an iptables rules that MASQUERADE traffic when trying to access remote targets.
 
Using --other-known-cidrs argument to configure cidrs will populate kube-router-other-ips ipset which will be skipped by the iptables rule.
The old iptables rule is cleaned as well.