### PR TITLE
Add the possibility to specify CIDRs that will be skipped by the MASQUERADE iptables target

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -667,10 +667,10 @@ func (npc *NetworkPolicyController) appendRuleToPolicyChain(iptablesCmdHandler *
 		args = append(args, "-m", "comment", "--comment", comment)
 	}
 	if srcIpSetName != "" {
-		args = append(args, "-m", "set", "--set", srcIpSetName, "src")
+		args = append(args, "-m", "set", "--match-set", srcIpSetName, "src")
 	}
 	if dstIpSetName != "" {
-		args = append(args, "-m", "set", "--set", dstIpSetName, "dst")
+		args = append(args, "-m", "set", "--match-set", dstIpSetName, "dst")
 	}
 	if protocol != "" {
 		args = append(args, "-p", protocol)

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -211,6 +211,11 @@ func (npc *NetworkPolicyController) OnNamespaceUpdate(obj interface{}) {
 	}
 	glog.V(2).Infof("Received update for namespace: %s", namespace.Name)
 
+	if !npc.readyForUpdates {
+		glog.V(3).Infof("Skipping update to namespace: %s, controller still performing bootup full-sync", namespace.Name)
+		return
+	}
+
 	err := npc.Sync()
 	if err != nil {
 		glog.Errorf("Error syncing on namespace update: %s", err)
@@ -1631,7 +1636,7 @@ func (npc *NetworkPolicyController) newPodEventHandler() cache.ResourceEventHand
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			npc.OnPodUpdate(obj)
+			npc.handlePodDelete(obj)
 		},
 	}
 }
@@ -1647,7 +1652,7 @@ func (npc *NetworkPolicyController) newNamespaceEventHandler() cache.ResourceEve
 
 		},
 		DeleteFunc: func(obj interface{}) {
-			npc.OnNamespaceUpdate(obj)
+			npc.handleNamespaceDelete(obj)
 
 		},
 	}
@@ -1663,9 +1668,90 @@ func (npc *NetworkPolicyController) newNetworkPolicyEventHandler() cache.Resourc
 			npc.OnNetworkPolicyUpdate(newObj)
 		},
 		DeleteFunc: func(obj interface{}) {
-			npc.OnNetworkPolicyUpdate(obj)
+			npc.handleNetworkPolicyDelete(obj)
 
 		},
+	}
+}
+
+func (npc *NetworkPolicyController) handlePodDelete(obj interface{}) {
+	pod, ok := obj.(*api.Pod)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
+		if pod, ok = tombstone.Obj.(*api.Pod); !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
+	}
+	glog.V(2).Infof("Received pod: %s/%s delete event", pod.Namespace, pod.Name)
+	if !npc.readyForUpdates {
+		glog.V(3).Infof("Skipping pod: %s/%s delete event, controller still performing bootup full-sync", pod.Namespace, pod.Name)
+		return
+	}
+
+	err := npc.Sync()
+	if err != nil {
+		glog.Errorf("Error syncing network policy for pod: %s/%s delete event Error: %s", pod.Namespace, pod.Name, err)
+	}
+}
+
+func (npc *NetworkPolicyController) handleNamespaceDelete(obj interface{}) {
+	namespace, ok := obj.(*api.Namespace)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
+		if namespace, ok = tombstone.Obj.(*api.Namespace); !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
+	}
+	// namespace (and annotations on it) has no significance in GA ver of network policy
+	if npc.v1NetworkPolicy {
+		return
+	}
+	glog.V(2).Infof("Received namespace: %s delete event", namespace.Name)
+
+	if !npc.readyForUpdates {
+		glog.V(3).Infof("Skipping update to namespace: %s, controller still performing bootup full-sync", namespace.Name)
+		return
+	}
+
+	err := npc.Sync()
+	if err != nil {
+		glog.Errorf("Error syncing network policies on namespace: %s delete event", err)
+	}
+}
+
+func (npc *NetworkPolicyController) handleNetworkPolicyDelete(obj interface{}) {
+	netpol, ok := obj.(*networking.NetworkPolicy)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
+		if netpol, ok = tombstone.Obj.(*networking.NetworkPolicy); !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
+	}
+	glog.V(2).Infof("Received network policy: %s/%s delete event", netpol.Namespace, netpol.Name)
+
+	if !npc.readyForUpdates {
+		glog.V(3).Infof("Skipping network policy: %s/%s delete event as controller still performing bootup full-sync", netpol.Namespace, netpol.Name)
+		return
+	}
+
+	err := npc.Sync()
+	if err != nil {
+		glog.Errorf("Error syncing network policy for the network policy: %s/%s delete event, Error: %s", netpol.Namespace, netpol.Name, err)
 	}
 }
 

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -332,7 +332,18 @@ func (nrc *NetworkRoutingController) newNodeEventHandler() cache.ResourceEventHa
 
 		},
 		DeleteFunc: func(obj interface{}) {
-			node := obj.(*v1core.Node)
+			node, ok := obj.(*v1core.Node)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					glog.Errorf("unexpected object type: %v", obj)
+					return
+				}
+				if node, ok = tombstone.Obj.(*v1core.Node); !ok {
+					glog.Errorf("unexpected object type: %v", obj)
+					return
+				}
+			}
 			nodeIP, _ := utils.GetNodeIP(node)
 
 			glog.Infof("Received node %s removed update from watch API, so remove node from peer", nodeIP)

--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -128,10 +128,19 @@ func (nrc *NetworkRoutingController) tryHandleServiceUpdate(obj interface{}, log
 }
 
 func (nrc *NetworkRoutingController) tryHandleServiceDelete(obj interface{}, logMsgFormat string) {
-	if svc := getServiceObject(obj); svc != nil {
-		glog.V(1).Infof(logMsgFormat, svc.Namespace, svc.Name)
-		nrc.handleServiceDelete(svc)
+	svc, ok := obj.(*v1core.Service)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
+		if svc, ok = tombstone.Obj.(*v1core.Service); !ok {
+			glog.Errorf("unexpected object type: %v", obj)
+			return
+		}
 	}
+	nrc.handleServiceDelete(svc)
 }
 
 // OnServiceCreate handles new service create event from the kubernetes API server

--- a/pkg/controllers/routing/pod_egress.go
+++ b/pkg/controllers/routing/pod_egress.go
@@ -13,16 +13,24 @@ var (
 	podEgressArgs4 = []string{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
 		"-m", "set", "!", "--match-set", nodeAddrsIPSetName, "dst",
+		"-m", "set", "!", "--match-set", otherSubnetsIPSetName, "dst",
 		"-j", "MASQUERADE"}
 	podEgressArgs6 = []string{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
 		"-m", "set", "!", "--match-set", "inet6:" + nodeAddrsIPSetName, "dst",
+		"-m", "set", "!", "--match-set", "inet6:" + otherSubnetsIPSetName, "dst",
 		"-j", "MASQUERADE"}
 	podEgressArgsBad4 = [][]string{{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
+		"-j", "MASQUERADE"},{"-m", "set", "--match-set", podSubnetsIPSetName, "src",
+		"-m", "set", "!", "--match-set", podSubnetsIPSetName, "dst",
+		"-m", "set", "!", "--match-set", nodeAddrsIPSetName, "dst",
 		"-j", "MASQUERADE"}}
 	podEgressArgsBad6 = [][]string{{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
 		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
+		"-j", "MASQUERADE"},{"-m", "set", "--match-set", "inet6:" + podSubnetsIPSetName, "src",
+		"-m", "set", "!", "--match-set", "inet6:" + podSubnetsIPSetName, "dst",
+		"-m", "set", "!", "--match-set", "inet6:" + nodeAddrsIPSetName, "dst",
 		"-j", "MASQUERADE"}}
 )
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -48,6 +48,7 @@ type KubeRouterConfig struct {
 	MetricsPath                    string
 	MetricsPort                    uint16
 	NodePortBindOnAllIp            bool
+	OtherKnownCidrs                []string
 	OverrideNextHop                bool
 	PeerASNs                       []uint
 	PeerMultihopTtl                uint8
@@ -102,6 +103,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.")
 	fs.StringSliceVar(&s.ExcludedCidrs, "excluded-cidrs", s.ExcludedCidrs,
 		"Excluded CIDRs are used to exclude IPVS rules from deletion.")
+	fs.StringSliceVar(&s.OtherKnownCidrs, "other-known-cidrs", s.OtherKnownCidrs,
+		"CIDRs excluded from masquerading by egress iptables rule.")
 	fs.BoolVar(&s.EnablePodEgress, "enable-pod-egress", true,
 		"SNAT traffic from Pods to destinations outside the cluster.")
 	fs.DurationVar(&s.IPTablesSyncPeriod, "iptables-sync-period", s.IPTablesSyncPeriod,


### PR DESCRIPTION
Using --other-known-cidrs argument to configure cidrs will populate kube-router-other-ips ipset which will be skipped by the iptables rule.
Previous iptables rule is cleaned as well.