### PR TITLE
Bgp policy fix

### DIFF
--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -256,10 +256,10 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 		}
 	} else {
 		// configure default BGP export policy to reject
-    err = nrc.bgpServer.SetDefaultPolicy("", table.POLICY_DIRECTION_EXPORT, table.ROUTE_TYPE_REJECT)
-    if err != nil {
-      return errors.New("Failed to set def export policy: " + err.Error())
-    }
+		err = nrc.bgpServer.SetDefaultPolicy("", table.POLICY_DIRECTION_EXPORT, table.ROUTE_TYPE_REJECT)
+		if err != nil {
+			return errors.New("Failed to set def export policy: " + err.Error())
+		}
 	}
 
 	return nil
@@ -329,10 +329,10 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 			return errors.New("Failed to add policy assignment: " + err.Error())
 		}
 	} else {
-    err = nrc.bgpServer.SetDefaultPolicy("", table.POLICY_DIRECTION_IMPORT, table.ROUTE_TYPE_ACCEPT)
-    if err != nil {
-      return errors.New("Failed to set def import policy: " + err.Error())
-    }
+		err = nrc.bgpServer.SetDefaultPolicy("", table.POLICY_DIRECTION_IMPORT, table.ROUTE_TYPE_ACCEPT)
+		if err != nil {
+			return errors.New("Failed to set def import policy: " + err.Error())
+		}
 	}
 
 	return nil

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -256,13 +256,10 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 		}
 	} else {
 		// configure default BGP export policy to reject
-		err = nrc.bgpServer.ReplacePolicyAssignment("",
-			table.POLICY_DIRECTION_EXPORT,
-			[]*config.PolicyDefinition{&definition},
-			table.ROUTE_TYPE_REJECT)
-		if err != nil {
-			return errors.New("Failed to replace policy assignment: " + err.Error())
-		}
+    err = nrc.bgpServer.SetDefaultPolicy("", table.POLICY_DIRECTION_EXPORT, table.ROUTE_TYPE_REJECT)
+    if err != nil {
+      return errors.New("Failed to set def export policy: " + err.Error())
+    }
 	}
 
 	return nil
@@ -332,13 +329,10 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 			return errors.New("Failed to add policy assignment: " + err.Error())
 		}
 	} else {
-		err = nrc.bgpServer.ReplacePolicyAssignment("",
-			table.POLICY_DIRECTION_IMPORT,
-			[]*config.PolicyDefinition{&definition},
-			table.ROUTE_TYPE_ACCEPT)
-		if err != nil {
-			return errors.New("Failed to replace policy assignment: " + err.Error())
-		}
+    err = nrc.bgpServer.SetDefaultPolicy("", table.POLICY_DIRECTION_IMPORT, table.ROUTE_TYPE_ACCEPT)
+    if err != nil {
+      return errors.New("Failed to set def import policy: " + err.Error())
+    }
 	}
 
 	return nil

--- a/vendor/github.com/osrg/gobgp/server/server.go
+++ b/vendor/github.com/osrg/gobgp/server/server.go
@@ -2558,6 +2558,16 @@ func (server *BgpServer) toPolicyInfo(name string, dir table.PolicyDirection) (s
 	}
 }
 
+func (s *BgpServer) SetDefaultPolicy(name string, dir table.PolicyDirection, def table.RouteType) error {
+        return s.mgmtOperation(func() error {
+                id, err := s.toPolicyInfo(name, dir)
+                if err != nil {
+                        return err
+                }
+                return s.policy.SetDefaultPolicy(id, dir, def)
+        }, false)
+}
+
 func (s *BgpServer) GetPolicyAssignment(name string, dir table.PolicyDirection) (rt table.RouteType, l []*config.PolicyDefinition, err error) {
 	err = s.mgmtOperation(func() error {
 		var id string

--- a/vendor/github.com/osrg/gobgp/server/server.go
+++ b/vendor/github.com/osrg/gobgp/server/server.go
@@ -1748,7 +1748,7 @@ func (s *BgpServer) DeleteVrf(name string) error {
 
 func (s *BgpServer) Stop() error {
 	return s.mgmtOperation(func() error {
-		for k, _ := range s.neighborMap {
+		for k := range s.neighborMap {
 			if err := s.deleteNeighbor(&config.Neighbor{Config: config.NeighborConfig{
 				NeighborAddress: k}}, bgp.BGP_ERROR_CEASE, bgp.BGP_ERROR_SUB_PEER_DECONFIGURED); err != nil {
 				return err
@@ -2559,13 +2559,13 @@ func (server *BgpServer) toPolicyInfo(name string, dir table.PolicyDirection) (s
 }
 
 func (s *BgpServer) SetDefaultPolicy(name string, dir table.PolicyDirection, def table.RouteType) error {
-        return s.mgmtOperation(func() error {
-                id, err := s.toPolicyInfo(name, dir)
-                if err != nil {
-                        return err
-                }
-                return s.policy.SetDefaultPolicy(id, dir, def)
-        }, false)
+	return s.mgmtOperation(func() error {
+		id, err := s.toPolicyInfo(name, dir)
+		if err != nil {
+			return err
+		}
+		return s.policy.SetDefaultPolicy(id, dir, def)
+	}, false)
 }
 
 func (s *BgpServer) GetPolicyAssignment(name string, dir table.PolicyDirection) (rt table.RouteType, l []*config.PolicyDefinition, err error) {

--- a/vendor/github.com/osrg/gobgp/table/policy.go
+++ b/vendor/github.com/osrg/gobgp/table/policy.go
@@ -3216,6 +3216,13 @@ func (r *RoutingPolicy) setDefaultPolicy(id string, dir PolicyDirection, typ Rou
 	return nil
 }
 
+/*
+ * We can start exporinting the set/getDefaultPolicy calls. This is temporary. 
+ */
+func (r *RoutingPolicy) SetDefaultPolicy(id string, dir PolicyDirection, typ RouteType) error {
+        return r.setDefaultPolicy(id, dir, typ)
+}
+
 func (r *RoutingPolicy) getAssignmentFromConfig(dir PolicyDirection, a config.ApplyPolicy) ([]*Policy, RouteType, error) {
 	var names []string
 	var cdef config.DefaultPolicyType

--- a/vendor/github.com/osrg/gobgp/table/policy.go
+++ b/vendor/github.com/osrg/gobgp/table/policy.go
@@ -3220,7 +3220,7 @@ func (r *RoutingPolicy) setDefaultPolicy(id string, dir PolicyDirection, typ Rou
  * We can start exporinting the set/getDefaultPolicy calls. This is temporary.
  */
 func (r *RoutingPolicy) SetDefaultPolicy(id string, dir PolicyDirection, typ RouteType) error {
-        return r.setDefaultPolicy(id, dir, typ)
+	return r.setDefaultPolicy(id, dir, typ)
 }
 
 func (r *RoutingPolicy) getAssignmentFromConfig(dir PolicyDirection, a config.ApplyPolicy) ([]*Policy, RouteType, error) {

--- a/vendor/github.com/osrg/gobgp/table/policy.go
+++ b/vendor/github.com/osrg/gobgp/table/policy.go
@@ -3217,7 +3217,7 @@ func (r *RoutingPolicy) setDefaultPolicy(id string, dir PolicyDirection, typ Rou
 }
 
 /*
- * We can start exporinting the set/getDefaultPolicy calls. This is temporary. 
+ * We can start exporinting the set/getDefaultPolicy calls. This is temporary.
  */
 func (r *RoutingPolicy) SetDefaultPolicy(id string, dir PolicyDirection, typ RouteType) error {
         return r.setDefaultPolicy(id, dir, typ)


### PR DESCRIPTION
Please refer to https://github.com/cloudnativelabs/kube-router/issues/748
In short, 
1. kuberouter creates bgp policies to control export and import of bgp routes to peers/other nodes etc.
2. This is done via a periodic sync where kr gets the list of advertisable IPs and calls a "ReplacePolicyAssignment" which flushes any policy that was not created by kube-router. 
3. Fix : Post an update, the code already updates the prefix and neighbor defined set objects pointed by the existing bgp policy (and thus updating the bgp policy). All it needs to do is to ensure the defaut policy is set to REJECT. It need not call "ReplacePolicyAssignment" .