### PR TITLE
switch --set to less ambiguous --match-set

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -667,10 +667,10 @@ func (npc *NetworkPolicyController) appendRuleToPolicyChain(iptablesCmdHandler *
 		args = append(args, "-m", "comment", "--comment", comment)
 	}
 	if srcIpSetName != "" {
-		args = append(args, "-m", "set", "--set", srcIpSetName, "src")
+		args = append(args, "-m", "set", "--match-set", srcIpSetName, "src")
 	}
 	if dstIpSetName != "" {
-		args = append(args, "-m", "set", "--set", dstIpSetName, "dst")
+		args = append(args, "-m", "set", "--match-set", dstIpSetName, "dst")
 	}
 	if protocol != "" {
 		args = append(args, "-p", protocol)


### PR DESCRIPTION
While --set is still ambiguous it can clash with other module options, so it is better to be more specific and use the --match-set option. This also more closely aligns with all other areas of the code that already use --match-set.

From iptables-extensions man page:
The option --match-set can be replaced by --set if that does not clash with an option of other extensions.