### PR TITLE
Add multi-arch support for container images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ RUN apk add --no-cache \
     curl -L -o /usr/local/share/bash-completion/bash-completion \
         https://raw.githubusercontent.com/scop/bash-completion/master/bash_completion
 
-ADD build/image-assets/bashrc /root/.bashrc
-ADD build/image-assets/profile /root/.profile
-ADD build/image-assets/vimrc /root/.vimrc
-ADD build/image-assets/motd-kube-router.sh /etc/motd-kube-router.sh
-ADD kube-router gobgp /usr/local/bin/
+COPY build/image-assets/bashrc /root/.bashrc
+COPY build/image-assets/profile /root/.profile
+COPY build/image-assets/vimrc /root/.vimrc
+COPY build/image-assets/motd-kube-router.sh /etc/motd-kube-router.sh
+COPY kube-router gobgp /usr/local/bin/
 
-WORKDIR "/root"
+WORKDIR /root
 ENTRYPOINT ["/usr/local/bin/kube-router"]


### PR DESCRIPTION
Currently we have a arch-specific binary that gets installed on an amd64
container. This change ensures that the container image matches the
arch-specific binary.

Using alpine archictecture-specific images as  mentioned under
https://hub.docker.com/_/alpine

To support architectures different from host architecture, this uses
qemu-static.