### PR TITLE
nflog the packet that will be dropped by network policy enforcement

### DIFF
--- a/docs/Observability.md
+++ b/docs/Observability.md
@@ -1,0 +1,5 @@
+# Observability
+
+## Observing dropped traffic due to network policy enforcements
+
+Traffic that gets rejected due to network policy enforcements gets logged by kube-route using iptables NFLOG target under the group 100. Simplest way to observe the dropped packets by kube-router is by running tcpdump on `nflog:100` interface for e.g. `tcpdump -i nflog:100 -n`. You can also configure ulogd to monitor dropped packets in desired output format. Please see https://kb.gtkc.net/iptables-with-ulogd-quick-howto/ for an example configuration to setup a stack to log packets.

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -817,6 +817,14 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(version string) (map[s
 			}
 		}
 
+		// add rule to log the packets that will be droopped due to network policy enforcement
+		comment = "rule to log dropped traffic POD name:" + pod.name + " namespace: " + pod.namespace
+		args = []string{"-m", "comment", "--comment", comment, "-j", "NFLOG", "--nflog-group", "100"}
+		err = iptablesCmdHandler.AppendUnique("filter", podFwChainName, args...)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())
+		}
+
 		// add default DROP rule at the end of chain
 		comment = "default rule to REJECT traffic destined for POD name:" + pod.name + " namespace: " + pod.namespace
 		args = []string{"-m", "comment", "--comment", comment, "-j", "REJECT"}
@@ -931,6 +939,14 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(version string) (map[s
 			if err != nil {
 				return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())
 			}
+		}
+
+		// add rule to log the packets that will be droopped due to network policy enforcement
+		comment = "rule to log dropped traffic POD name:" + pod.name + " namespace: " + pod.namespace
+		args = []string{"-m", "comment", "--comment", comment, "-j", "NFLOG", "--nflog-group", "100"}
+		err = iptablesCmdHandler.AppendUnique("filter", podFwChainName, args...)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())
 		}
 
 		// add default DROP rule at the end of chain

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -817,9 +817,9 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(version string) (map[s
 			}
 		}
 
-		// add rule to log the packets that will be droopped due to network policy enforcement
+		// add rule to log the packets that will be dropped due to network policy enforcement
 		comment = "rule to log dropped traffic POD name:" + pod.name + " namespace: " + pod.namespace
-		args = []string{"-m", "comment", "--comment", comment, "-j", "NFLOG", "--nflog-group", "100"}
+		args = []string{"-m", "comment", "--comment", comment, "-j", "NFLOG", "--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10"}
 		err = iptablesCmdHandler.AppendUnique("filter", podFwChainName, args...)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())
@@ -941,9 +941,9 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(version string) (map[s
 			}
 		}
 
-		// add rule to log the packets that will be droopped due to network policy enforcement
+		// add rule to log the packets that will be dropped due to network policy enforcement
 		comment = "rule to log dropped traffic POD name:" + pod.name + " namespace: " + pod.namespace
-		args = []string{"-m", "comment", "--comment", comment, "-j", "NFLOG", "--nflog-group", "100"}
+		args = []string{"-m", "comment", "--comment", comment, "-j", "NFLOG", "--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10"}
 		err = iptablesCmdHandler.AppendUnique("filter", podFwChainName, args...)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())


### PR DESCRIPTION
logged packets can be further by read by ulogd

Fix only works with kernel > 4.11 please see https://github.com/cloudnativelabs/kube-router/issues/505#issuecomment-619633699

Fixes #505

