### PR TITLE
fixes egress network policy enforcements

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -880,37 +880,23 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(version string) (map[s
 			}
 		}
 
-		// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
-		// this rule applies to the traffic getting forwarded/routed (traffic from the pod destinted
-		// to pod on a different node)
-		comment = "rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
-			" to chain " + podFwChainName
-		args = []string{"-m", "comment", "--comment", comment, "-s", pod.ip, "-j", podFwChainName}
-		exists, err = iptablesCmdHandler.Exists("filter", "FORWARD", args...)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())
-		}
-		if !exists {
-			err := iptablesCmdHandler.Insert("filter", "FORWARD", 1, args...)
+		egressFilterChains := []string{"FORWARD", "OUTPUT", "INPUT"}
+		for _, chain := range egressFilterChains {
+			// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
+			// this rule applies to the traffic getting forwarded/routed (traffic from the pod destinted
+			// to pod on a different node)
+			comment = "rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
+				" to chain " + podFwChainName
+			args = []string{"-m", "comment", "--comment", comment, "-s", pod.ip, "-j", podFwChainName}
+			exists, err = iptablesCmdHandler.Exists("filter", chain, args...)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())
 			}
-		}
-
-		// ensure there is rule in filter table and OUTPUT chain to jump to pod specific firewall chain
-		// this rule applies to the traffic getting proxied (traffic from the pod accessing service
-		// resulting in traffic DNAT'ed to a pod IP)
-		comment = "rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
-			" to chain " + podFwChainName
-		args = []string{"-m", "comment", "--comment", comment, "-s", pod.ip, "-j", podFwChainName}
-		exists, err = iptablesCmdHandler.Exists("filter", "OUTPUT", args...)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())
-		}
-		if !exists {
-			err := iptablesCmdHandler.Insert("filter", "OUTPUT", 1, args...)
-			if err != nil {
-				return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())
+			if !exists {
+				err := iptablesCmdHandler.Insert("filter", chain, 1, args...)
+				if err != nil {
+					return nil, fmt.Errorf("Failed to run iptables command: %s", err.Error())
+				}
 			}
 		}
 


### PR DESCRIPTION
- outbound traffic from pod should be intercepted in filter table INPUT chain (pod's traffic that is destined to node's local ip). with out this fix even with network policy to drop all egress traffic, pod can reach host IP's. Pod's can access any service hosted in host network as well

~~- rules to permit forwarding pod traffic should be appended at the end to the FORWARD chain. In some distro's default policy for FORWARD chain is drop. So explicit rule must be added in FORWARD chain for the traffic from the pods. These rules should be lower order than any network policy chains~~

removing the changes to network routing controller to append the rule to enable forwarding from the pods. Will address in seperate PR