### PR TITLE
service proxy: ensure hearbeats are sent during sync

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -375,6 +375,7 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 			}
 
 		case perform := <-nsc.syncChan:
+			healthcheck.SendHeartBeat(healthChan, "NSC")
 			switch perform {
 			case synctypeAll:
 				glog.V(1).Info("Performing requested full sync of services")
@@ -390,6 +391,9 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 				if err != nil {
 					glog.Errorf("Error during ipvs sync in network service controller. Error: " + err.Error())
 				}
+			}
+			if err == nil {
+				healthcheck.SendHeartBeat(healthChan, "NSC")
 			}
 
 		case <-t.C:


### PR DESCRIPTION
ensure heartbeats are sent when performing sync in both the cases of  periodic sync and on add/delete/update evernts corresponding to services and endpoints

this change just moves sending the hearbeat to method `syncIpvsServices` that is common method that is invoked in all cases.

Fixes #879