### PR TITLE
Fix Memory Consumption in network_policy_controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 /kube-router
 /gobgp
 _output

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -357,7 +357,7 @@ func TestNewNetworkPolicySelectors(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			np := test.netpol.findNetpolMatch(netpols)
+			np := test.netpol.findNetpolMatch(&netpols)
 			testForMissingOrUnwanted(t, "targetPods", tListOfPodsFromTargets(np.targetPods), test.targetPods)
 			for _, ingress := range np.ingressRules {
 				testForMissingOrUnwanted(t, "ingress srcPods", ingress.srcPods, test.inSourcePods)


### PR DESCRIPTION
FYI @murali-reddy @mrueg @filintod 

This is a fix for: #795 

This change does two things broken up by commit:
1) Converts networkPoliciesInfo to be a function variable rather than a variable on the npc struct. Through extensive testing I've found that this gives a relatively small memory performance gain, but still worth doing IMO since this variable isn't referenced outside of the Sync function and its dependency functions. Converting the variable allows the GC to free up cached data sooner.
2) Converts the `Sync()` method to use semaphores and converts all handlers to call the function asynchronously. Pausing the handler flow and waiting for the Sync method to finish is causing the k8s watchers to backup and hold on to pod, network policy, and namespace object metadata until the handlers finish doing a full sync.
In large clusters that have a high churn on pods, network policies, and/or namespaces it results in kube-router never being able to catch up to the amount of updates it is receiving and the streamwatcher's cache of k8s objects will grown unbound.
Because every sync is a full sync we need to limit ourselves to a single thread of execution, but utilize a semaphore so that if we try to acquire a lock and fail we can return quickly without blocking anything.

As an example, in our medium sized cluster it takes about 1.5 minutes for kube-router to perform a full iptables sync. However, in this cluster we have multiple small cronjobs that execute every minute. When this happens, kube-router is never able to catch up and slowly the queue containing these pod changes become longer and longer.

When testing kube-router-1.0.0-rc3 without this patch I find that over the course of an hour with 6 1 minutes cronjobs running I see a memory gain of ~50 MB / hour. With this patch memory stays constant with no noticeable increases.

Disclaimer, I spent about an hour trying to get `dep` to work to update the Gopkg.toml and Gopkg.lock files for `golang.org/x/sync` but wasn't able to get it to work correctly. Multiple packages failed to update while running the `dep ensure` step, and it consistently failed to import the package with an error like the following:
```
Solving failure: No versions of golang.org/x/sync met constraints:
	master: Could not introduce golang.org/x/sync@master, as its subpackage golang.org/x/sync does not contain usable Go code (*build.NoGoError).. (Package is required by (root)
```

So to save time I manually vendored the sync package. @murali-reddy let me know if you're able to get dep to work for you and I'll update my PR.

A special thanks to @liggitt for setting me on the right track and giving me some really good hints that allowed us to find the handler contention.