### PR TITLE
fix(ecmp_vip): check for nil nodename

### DIFF
--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -436,8 +436,14 @@ func (nrc *NetworkRoutingController) nodeHasEndpointsForService(svc *v1core.Serv
 
 	for _, subset := range ep.Subsets {
 		for _, address := range subset.Addresses {
-			if *address.NodeName == nrc.nodeName {
-				return true, nil
+			if address.NodeName != nil {
+				if *address.NodeName == nrc.nodeName {
+					return true, nil
+				}
+			} else {
+				if address.IP == nrc.nodeIP.String() {
+					return true, nil
+				}
 			}
 		}
 	}


### PR DESCRIPTION
@murali-reddy This goes towards fixing another rare, but outstanding bug with kube-router for the 1.0.0 release.

While rare that NodeName is missing it is not guaranteed to exist by the Kubernetes API (see link below). This retains checking via NodeName first if it exists, but if it's nil rather than segfaulting it evaluate via IP address.

Fixes #781

https://github.com/cloudnativelabs/kube-router/blob/master/vendor/k8s.io/api/core/v1/types.go#L3487