### PR TITLE
fix(network_routes): missing node ip -> error log

### DIFF
--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -2,7 +2,7 @@ package routing
 
 import (
 	"errors"
-	"fmt"
+	"github.com/golang/glog"
 
 	"github.com/cloudnativelabs/kube-router/pkg/utils"
 	"github.com/osrg/gobgp/config"
@@ -56,7 +56,8 @@ func (nrc *NetworkRoutingController) AddPolicies() error {
 			nodeObj := node.(*v1core.Node)
 			nodeIP, err := utils.GetNodeIP(nodeObj)
 			if err != nil {
-				return fmt.Errorf("Failed to find a node IP: %s", err)
+				glog.Errorf("Failed to find a node IP and therefore cannot add internal BGP Peer: %v", err)
+				continue
 			}
 			iBGPPeers = append(iBGPPeers, nodeIP.String())
 		}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -553,7 +553,8 @@ func (nrc *NetworkRoutingController) syncNodeIPSets() error {
 		currentPodCidrs = append(currentPodCidrs, podCIDR)
 		nodeIP, err := utils.GetNodeIP(node)
 		if err != nil {
-			return fmt.Errorf("Failed to find a node IP: %s", err)
+			glog.Errorf("Failed to find a node IP, cannot add to node ipset which could affect routing: %v", err)
+			continue
 		}
 		currentNodeIPs = append(currentNodeIPs, nodeIP.String())
 	}


### PR DESCRIPTION
@murali-reddy This goes towards fixing another rare, but outstanding bug with kube-router for the 1.0.0 release.

Before we used to raise an error when a node was missing an IP, but it turns out that this is not a required attribute of a node. And while it is rare that a node would be missing an IP address, a node doesn't require an IP address or a name or really much of anything in order to
exist.

This brings us to stronger conformance with the Kubernetes API and makes it so that kube-router logs errors rather than changing it's health status and potentially causing cascading failures across the fleet if a user adds a node like this.

Properly fixes #846 