### PR TITLE
whitelist traffic to cluster IP and node ports in INPUT chain to bypass netwrok policy enforcement

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -82,6 +82,8 @@ Usage of kube-router:
       --run-firewall                                  Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)
       --run-router                                    Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
       --run-service-proxy                             Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)
+      --service-cluster-ip-range string               CIDR value from which service cluster IPs are assigned. Default: 10.96.0.0/12 (default "10.96.0.0/12")
+      --service-node-port-range string                NodePort range. Default: 30000-32767 (default "30000:32767")
   -v, --v string                                      log level for V logs (default "0")
   -V, --version                                       Print version information.
 ```

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -210,14 +210,15 @@ func (npc *NetworkPolicyController) ensureTopLevelChains() {
 			glog.Fatalf("Failed to verify rule exists in %s chain due to %s", chain, err.Error())
 		}
 		if !exists {
-			err := iptablesCmdHandler.Insert("filter", chain, 1, ruleSpec...)
+			err := iptablesCmdHandler.Insert("filter", chain, position, ruleSpec...)
 			if err != nil {
 				glog.Fatalf("Failed to run iptables command to insert in %s chain %s", chain, err.Error())
 			}
+			return
 		}
 		var ruleNo int
 		for i, rule := range rules {
-			rule = strings.Replace(rule, "\"", "", 2)
+			rule = strings.Replace(rule, "\"", "", 2) //removes quote from comment string
 			if strings.Contains(rule, strings.Join(ruleSpec, " ")) {
 				ruleNo = i
 				break

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -23,6 +23,8 @@ type KubeRouterConfig struct {
 	CleanupConfig                  bool
 	ClusterAsn                     uint
 	ClusterCIDR                    string
+	ClusterIPCIDR                  string
+	NodePortRange                  string
 	DisableSrcDstCheck             bool
 	EnableCNI                      bool
 	EnableiBGP                     bool
@@ -74,6 +76,8 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		BGPGracefulRestartDeferralTime: 360 * time.Second,
 		EnableOverlay:                  true,
 		OverlayType:                    "subnet",
+		ClusterIPCIDR:                  "10.96.0.0/12",
+		NodePortRange:                  "30000:32767",
 	}
 }
 
@@ -102,6 +106,10 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.")
 	fs.StringSliceVar(&s.ExcludedCidrs, "excluded-cidrs", s.ExcludedCidrs,
 		"Excluded CIDRs are used to exclude IPVS rules from deletion.")
+	fs.StringVar(&s.ClusterIPCIDR, "service-cluster-ip-range", s.ClusterIPCIDR,
+		"CIDR value from which service cluster IPs are assigned.")
+	fs.StringVar(&s.NodePortRange, "service-node-port-range", s.NodePortRange,
+		"CIDR value from which service cluster IPs are assigned.")
 	fs.BoolVar(&s.EnablePodEgress, "enable-pod-egress", true,
 		"SNAT traffic from Pods to destinations outside the cluster.")
 	fs.DurationVar(&s.IPTablesSyncPeriod, "iptables-sync-period", s.IPTablesSyncPeriod,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -107,9 +107,9 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.ExcludedCidrs, "excluded-cidrs", s.ExcludedCidrs,
 		"Excluded CIDRs are used to exclude IPVS rules from deletion.")
 	fs.StringVar(&s.ClusterIPCIDR, "service-cluster-ip-range", s.ClusterIPCIDR,
-		"CIDR value from which service cluster IPs are assigned.")
+		"CIDR value from which service cluster IPs are assigned. Default: 10.96.0.0/12")
 	fs.StringVar(&s.NodePortRange, "service-node-port-range", s.NodePortRange,
-		"CIDR value from which service cluster IPs are assigned.")
+		"NodePort range. Default: 30000-32767")
 	fs.BoolVar(&s.EnablePodEgress, "enable-pod-egress", true,
 		"SNAT traffic from Pods to destinations outside the cluster.")
 	fs.DurationVar(&s.IPTablesSyncPeriod, "iptables-sync-period", s.IPTablesSyncPeriod,


### PR DESCRIPTION
Fixes #905

Following rules will be prepended in `KUBE-ROUTER-INPUT` chain. So traffic to cluster IP's and node port services are targetted to `RETURN`.

```
Chain KUBE-ROUTER-INPUT (1 references)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 RETURN     tcp  --  *      *       0.0.0.0/0            0.0.0.0/0            /* allow LOCAL traffic to node ports */ ADDRTYPE match dst-type LOCAL multiport dports 30000:32767
    0     0 RETURN     udp  --  *      *       0.0.0.0/0            0.0.0.0/0            /* allow LOCAL traffic to node ports */ ADDRTYPE match dst-type LOCAL multiport dports 30000:32767
   15  1464 RETURN     all  --  *      *       0.0.0.0/0            10.96.0.0/12         /* allow traffic to cluster IP */
    0     0 KUBE-POD-FW-VTNZYDWW3NHVYEUD  all  --  *      *       10.1.1.4             0.0.0.0/0            /* rule to jump traffic from POD name:frontend-56fc5b6b47-dvksf namespace: default to chain KUBE-POD-FW-VTNZYDWW3NHVYEUD */

```

Note: there is no dependency/assumptions on service proxy. Service proxy could add its filtering rules to filter traffic to services. Below is e.g. in case where kube-router is acting as service proxy and has setup filter rules to restrict traffic to service VIP's.

```
# iptables -t filter -L INPUT -n -v
Chain INPUT (policy ACCEPT 1483 packets, 419K bytes)
 pkts bytes target     prot opt in     out     source               destination         
 265K   75M KUBE-ROUTER-INPUT  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kube-router netpol */
 265K   75M KUBE-ROUTER-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* handle traffic to IPVS service IPs in custom chain */ match-set kube-router-service-ips dst
```