### PR TITLE
Dockerfile: Update to alpine:3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.11
 
 RUN apk add --no-cache \
       iptables \


### PR DESCRIPTION
Updated dockerfile to make use of alpine 3.11. Currently 3.9 version in dockerflle becomes end of life in November.

Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>