### PR TITLE
The bgp-holdtime function parameter of setting holdtime is added to adjust the holdtime of BGP negotiation with the connected network devices.

### DIFF
--- a/cmd/kube-router/kube-router_test.go
+++ b/cmd/kube-router/kube-router_test.go
@@ -53,4 +53,5 @@ func TestMainHelp(t *testing.T) {
 		t.Errorf("docs/user-guide.md 'command line options' section does not match `kube-router --help`.\nExpected:\n%s", exp)
 		t.Errorf("\nGot:\n%s", docBuf.Bytes())
 	}
+
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,7 +42,7 @@ Usage of kube-router:
       --advertise-pod-cidr                            Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
       --bgp-graceful-restart                          Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
       --bgp-graceful-restart-deferral-time duration   BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h. (default 6m0s)
-      --bgp-holdtime float                            This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube router goes down abnormally, the local saving time of BGP route will be affected. (default 90)
+      --bgp-holdtime float                            This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3 to 65536. (default 90)
       --bgp-port uint16                               The port open for incoming BGP connections and to use for connecting with other BGP peers. (default 179)
       --cache-sync-timeout duration                   The timeout for cache synchronization (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
       --cleanup-config                                Cleanup iptables rules, ipvs, ipset configuration and exit.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,6 +42,7 @@ Usage of kube-router:
       --advertise-pod-cidr                            Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
       --bgp-graceful-restart                          Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
       --bgp-graceful-restart-deferral-time duration   BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h. (default 6m0s)
+      --bgp-holdtime float                            This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube router goes down abnormally, the local saving time of BGP route will be affected. (default 90)
       --bgp-port uint16                               The port open for incoming BGP connections and to use for connecting with other BGP peers. (default 179)
       --cache-sync-timeout duration                   The timeout for cache synchronization (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
       --cleanup-config                                Cleanup iptables rules, ipvs, ipset configuration and exit.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -43,7 +43,7 @@ Usage of kube-router:
       --bgp-graceful-restart                          Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
       --bgp-graceful-restart-deferral-time duration   BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h. (default 6m0s)
       --bgp-graceful-restart-time duration            BGP Graceful restart time according to RFC4724 3, maximum 4095s. (default 1m30s)
-      --bgp-holdtime float                            This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube-router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3 to 65536. (default 90)
+      --bgp-holdtime duration                         This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube-router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3s to 18h12m16s. (default 1m30s)
       --bgp-port uint16                               The port open for incoming BGP connections and to use for connecting with other BGP peers. (default 179)
       --cache-sync-timeout duration                   The timeout for cache synchronization (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
       --cleanup-config                                Cleanup iptables rules, ipvs, ipset configuration and exit.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,7 +42,7 @@ Usage of kube-router:
       --advertise-pod-cidr                            Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
       --bgp-graceful-restart                          Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
       --bgp-graceful-restart-deferral-time duration   BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h. (default 6m0s)
-      --bgp-holdtime float                            This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3 to 65536. (default 90)
+      --bgp-holdtime float                            This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube-router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3 to 65536. (default 90)
       --bgp-port uint16                               The port open for incoming BGP connections and to use for connecting with other BGP peers. (default 179)
       --cache-sync-timeout duration                   The timeout for cache synchronization (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
       --cleanup-config                                Cleanup iptables rules, ipvs, ipset configuration and exit.

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -260,7 +260,7 @@ func connectToExternalBGPPeers(server *gobgp.BgpServer, peerNeighbors []*config.
 }
 
 // Does validation and returns neighbor configs
-func newGlobalPeers(ips []net.IP, ports []uint16, asns []uint32, passwords []string) (
+func newGlobalPeers(ips []net.IP, ports []uint16, asns []uint32, passwords []string, holdtime float64) (
 	[]*config.Neighbor, error) {
 	peers := make([]*config.Neighbor, 0)
 
@@ -300,6 +300,7 @@ func newGlobalPeers(ips []net.IP, ports []uint16, asns []uint32, passwords []str
 				NeighborAddress: ips[i].String(),
 				PeerAs:          asns[i],
 			},
+			Timers: config.Timers{Config: config.TimersConfig{HoldTime: holdtime}},
 			Transport: config.Transport{
 				Config: config.TransportConfig{
 					RemotePort: options.DEFAULT_BGP_PORT,

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -886,12 +886,11 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	nrc.bgpServerStarted = false
 	nrc.disableSrcDstCheck = kubeRouterConfig.DisableSrcDstCheck
 	nrc.initSrcDstCheckDone = false
-        if kubeRouterConfig.BGPHoldtime <= 65536 && kubeRouterConfig.BGPHoldtime >= 3 {
+	if kubeRouterConfig.BGPHoldtime <= 65536 && kubeRouterConfig.BGPHoldtime >= 3 {
 		nrc.bgpHoldtime = kubeRouterConfig.BGPHoldtime
-        } else {
-                return nil, errors.New("This is an incorrect BGP holdtime range, holdtime must be in the range 3 to 65536.")
-        }
-
+	} else {
+		return nil, errors.New("This is an incorrect BGP holdtime range, holdtime must be in the range 3 to 65536.")
+	}
 
 	nrc.hostnameOverride = kubeRouterConfig.HostnameOverride
 	node, err := utils.GetNodeObject(clientset, nrc.hostnameOverride)

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -886,7 +886,12 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	nrc.bgpServerStarted = false
 	nrc.disableSrcDstCheck = kubeRouterConfig.DisableSrcDstCheck
 	nrc.initSrcDstCheckDone = false
-	nrc.bgpHoldtime = kubeRouterConfig.BGPHoldtime
+        if kubeRouterConfig.BGPHoldtime <= 65536 && kubeRouterConfig.BGPHoldtime >= 3 {
+		nrc.bgpHoldtime = kubeRouterConfig.BGPHoldtime
+        } else {
+                return nil, errors.New("This is an incorrect BGP holdtime range, holdtime must be in the range 3 to 65536.")
+        }
+
 
 	nrc.hostnameOverride = kubeRouterConfig.HostnameOverride
 	node, err := utils.GetNodeObject(clientset, nrc.hostnameOverride)

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -889,10 +889,10 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	nrc.bgpServerStarted = false
 	nrc.disableSrcDstCheck = kubeRouterConfig.DisableSrcDstCheck
 	nrc.initSrcDstCheckDone = false
-	if kubeRouterConfig.BGPHoldtime <= 65536 && kubeRouterConfig.BGPHoldtime >= 3 {
-		nrc.bgpHoldtime = kubeRouterConfig.BGPHoldtime
-	} else {
-		return nil, errors.New("This is an incorrect BGP holdtime range, holdtime must be in the range 3 to 65536.")
+
+	nrc.bgpHoldtime = kubeRouterConfig.BGPHoldtime.Seconds()
+	if nrc.bgpHoldtime > 65536 || nrc.bgpHoldtime < 3 {
+		return nil, errors.New("This is an incorrect BGP holdtime range, holdtime must be in the range 3s to 18h12m16s.")
 	}
 
 	nrc.hostnameOverride = kubeRouterConfig.HostnameOverride

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -10,7 +10,7 @@ import (
 )
 
 const DEFAULT_BGP_PORT = 179
-const DEFAULT_BGP_HOLDTIME = 90
+const DEFAULT_BGP_HOLDTIME time.Duration = 90 * time.Second
 
 type KubeRouterConfig struct {
 	AdvertiseClusterIp             bool
@@ -20,7 +20,7 @@ type KubeRouterConfig struct {
 	BGPGracefulRestart             bool
 	BGPGracefulRestartTime         time.Duration
 	BGPGracefulRestartDeferralTime time.Duration
-	BGPHoldtime                    float64
+	BGPHoldtime                    time.Duration
 	BGPPort                        uint16
 	CacheSyncTimeout               time.Duration
 	CleanupConfig                  bool
@@ -77,6 +77,7 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		IpvsGracefulPeriod:             30 * time.Second,
 		RoutesSyncPeriod:               5 * time.Minute,
 		BGPGracefulRestartTime:         90 * time.Second,
+		BGPHoldtime:                    90 * time.Second,
 		BGPGracefulRestartDeferralTime: 360 * time.Second,
 		EnableOverlay:                  true,
 		OverlayType:                    "subnet",
@@ -154,8 +155,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"BGP Graceful restart time according to RFC4724 3, maximum 4095s.")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time", s.BGPGracefulRestartDeferralTime,
 		"BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h.")
-	fs.Float64Var(&s.BGPHoldtime, "bgp-holdtime", DEFAULT_BGP_HOLDTIME,
-		"This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube-router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3 to 65536.")
+	fs.DurationVar(&s.BGPHoldtime, "bgp-holdtime", DEFAULT_BGP_HOLDTIME,
+		"This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube-router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3s to 18h12m16s.")
 	fs.Uint16Var(&s.BGPPort, "bgp-port", DEFAULT_BGP_PORT,
 		"The port open for incoming BGP connections and to use for connecting with other BGP peers.")
 	fs.StringVar(&s.RouterId, "router-id", "", "BGP router-id. Must be specified in a ipv6 only cluster.")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -10,7 +10,7 @@ import (
 )
 
 const DEFAULT_BGP_PORT = 179
-const DEFAULT_HOLDTIME = 90
+const DEFAULT_BGP_HOLDTIME = 90
 
 type KubeRouterConfig struct {
 	AdvertiseClusterIp             bool
@@ -142,8 +142,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time", s.BGPGracefulRestartDeferralTime,
 		"BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h.")
-	fs.Float64Var(&s.BGPHoldtime, "bgp-holdtime", DEFAULT_HOLDTIME,
-		"This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3 to 65536.")
+	fs.Float64Var(&s.BGPHoldtime, "bgp-holdtime", DEFAULT_BGP_HOLDTIME,
+		"This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube-router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3 to 65536.")
 	fs.Uint16Var(&s.BGPPort, "bgp-port", DEFAULT_BGP_PORT,
 		"The port open for incoming BGP connections and to use for connecting with other BGP peers.")
 	fs.StringVar(&s.RouterId, "router-id", "", "BGP router-id. Must be specified in a ipv6 only cluster.")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -143,7 +143,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time", s.BGPGracefulRestartDeferralTime,
 		"BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h.")
 	fs.Float64Var(&s.BGPHoldtime, "bgp-holdtime", DEFAULT_HOLDTIME,
-		"This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube router goes down abnormally, the local saving time of BGP route will be affected.")
+		"This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube router goes down abnormally, the local saving time of BGP route will be affected.Holdtime must be in the range 3 to 65536.")
 	fs.Uint16Var(&s.BGPPort, "bgp-port", DEFAULT_BGP_PORT,
 		"The port open for incoming BGP connections and to use for connecting with other BGP peers.")
 	fs.StringVar(&s.RouterId, "router-id", "", "BGP router-id. Must be specified in a ipv6 only cluster.")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -10,6 +10,7 @@ import (
 )
 
 const DEFAULT_BGP_PORT = 179
+const DEFAULT_HOLDTIME = 90
 
 type KubeRouterConfig struct {
 	AdvertiseClusterIp             bool
@@ -18,6 +19,7 @@ type KubeRouterConfig struct {
 	AdvertiseLoadBalancerIp        bool
 	BGPGracefulRestart             bool
 	BGPGracefulRestartDeferralTime time.Duration
+	BGPHoldtime                    float64
 	BGPPort                        uint16
 	CacheSyncTimeout               time.Duration
 	CleanupConfig                  bool
@@ -140,6 +142,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time", s.BGPGracefulRestartDeferralTime,
 		"BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h.")
+	fs.Float64Var(&s.BGPHoldtime, "bgp-holdtime", DEFAULT_HOLDTIME,
+		"This parameter is mainly used to modify the holdtime declared to BGP peer. When Kube router goes down abnormally, the local saving time of BGP route will be affected.")
 	fs.Uint16Var(&s.BGPPort, "bgp-port", DEFAULT_BGP_PORT,
 		"The port open for incoming BGP connections and to use for connecting with other BGP peers.")
 	fs.StringVar(&s.RouterId, "router-id", "", "BGP router-id. Must be specified in a ipv6 only cluster.")


### PR DESCRIPTION
In some scenarios, the holdtime of BGP needs to be adjusted.
(1) If you want the BGP neighbor route to disappear as soon as possible after the kube-router goes down, you should set the holdtime to be smaller.
(2) In some scenarios, after the kube-router goes down, the pod network is normal and can still communicate with the outside world. You want BGP neighbor routing to last longer, so in this case you can set the holdtime to be larger.