### PR TITLE
fix unintentional Sprint of two-argument generateFwmark() call

### DIFF
--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -337,7 +337,12 @@ func (nsc *NetworkServicesController) setupExternalIPServices(serviceInfoMap ser
 				externalIpServiceId = generateIpPortId(externalIP, svc.protocol, strconv.Itoa(svc.port))
 
 				// ensure there is NO iptables mangle table rule to FWMARK the packet
-				fwMark := fmt.Sprint(generateFwmark(externalIP, svc.protocol, strconv.Itoa(svc.port)))
+				fwmark, err := generateFwmark(externalIP, svc.protocol, strconv.Itoa(svc.port))
+				if err != nil {
+					glog.Errorf("Failed to generate a fwmark due to " + err.Error())
+					continue
+				}
+				fwMark := fmt.Sprint(fwmark)
 				err = nsc.ln.cleanupMangleTableRule(externalIP, svc.protocol, strconv.Itoa(svc.port), fwMark)
 				if err != nil {
 					glog.Errorf("Failed to verify and cleanup any mangle table rule to FMWARD the traffic to external IP due to " + err.Error())


### PR DESCRIPTION
The `setupExternalIPServices()` function fails due to blindly calling `fmt.Sprint` on the return values of `generateFwmark()`, ignoring the fact that 2 values are returned. This results in errors like the following:

```
E0614 14:03:47.293710       1 service_endpoints_sync.go:343] Failed to verify and cleanup any mangle table rule to FMWARD the traffic to external IP due to Failed to cleanup iptables command to set up FWMARK due to running [/sbin/iptables -t mangle -C PREROUTING -d {REDACTED} -m tcp -p tcp --dport 80 -j MARK --set-mark 4951 <nil> --wait]: exit status 2: iptables v1.8.3 (legacy): MARK: trailing garbage after value for option "--set-mark".
```

This patch corrects this issue.