### PR TITLE
fix(nsc): update IPVS svc when timeout changes

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1615,10 +1615,6 @@ func (ln *linuxNetworking) ipvsAddService(svcs []*ipvs.Service, vip net.IP, prot
 				svc.Timeout != uint32(persistentTimeout) {
 				ipvsSetPersistence(svc, persistent, persistentTimeout)
 
-				if changedIpvsSchedFlags(svc, flags) {
-					ipvsSetSchedFlags(svc, flags)
-				}
-
 				err = ln.ipvsUpdateService(svc)
 				if err != nil {
 					return nil, err

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1611,7 +1611,8 @@ func (ln *linuxNetworking) ipvsAddService(svcs []*ipvs.Service, vip net.IP, prot
 	var err error
 	for _, svc := range svcs {
 		if vip.Equal(svc.Address) && protocol == svc.Protocol && port == svc.Port {
-			if (persistent && (svc.Flags&0x0001) == 0) || (!persistent && (svc.Flags&0x0001) != 0) {
+			if (persistent && (svc.Flags&0x0001) == 0) || (!persistent && (svc.Flags&0x0001) != 0) ||
+				svc.Timeout != uint32(persistentTimeout) {
 				ipvsSetPersistence(svc, persistent, persistentTimeout)
 
 				if changedIpvsSchedFlags(svc, flags) {


### PR DESCRIPTION
@murali-reddy this is a small fix for #910

We weren't checking the equality for `persistentTimeout` as part of checking to see if the persistence settings needed to be updated in the IPVS service.

I also removed a double handling of the ipvs flag changes.