### PR TITLE
add /etc/nsswitch.conf in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,9 @@ COPY build/image-assets/vimrc /root/.vimrc
 COPY build/image-assets/motd-kube-router.sh /etc/motd-kube-router.sh
 COPY kube-router gobgp /usr/local/bin/
 
+# Since alpine image doesn't contain /etc/nsswitch.conf, the hosts in /etc/hosts (e.g. localhost)
+# cannot be used. So manually add /etc/nsswitch.conf to work around this issue.
+RUN echo "hosts: files dns" > /etc/nsswitch.conf
+
 WORKDIR /root
 ENTRYPOINT ["/usr/local/bin/kube-router"]


### PR DESCRIPTION
When localhost is used as the cluster server in kubeconfig, it cannot be resolved due to missing /etc/nsswitch.conf in the image. https://github.com/kubernetes-sigs/kubespray/issues/6175 is caused by this issue.

A common workaround is to add `echo "hosts: files dns" > /etc/nsswitch.conf` in Docker file as mentioned by https://github.com/golang/go/issues/22846#issuecomment-380809416.
