### PR TITLE
.goreleaser.yml: Add LDFLAGS

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,10 @@ builds:
   - 7
   env:
   - CGO_ENABLED=0
+  ldflags:
+  - "-X github.com/cloudnativelabs/kube-router/pkg/cmd.version={{.Version}}"
+  - "-X github.com/cloudnativelabs/kube-router/pkg/cmd.buildDate={{.Date}}"
+
 archives:
   -
     format: tar.gz


### PR DESCRIPTION
goreleaser was missing ldflags, so the binaries produced and added to
the release did not include version information.