### PR TITLE
fix(options): remove deprecated cluster-cidr option

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -48,7 +48,6 @@ Usage of kube-router:
       --cache-sync-timeout duration                   The timeout for cache synchronization (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
       --cleanup-config                                Cleanup iptables rules, ipvs, ipset configuration and exit.
       --cluster-asn uint                              ASN number under which cluster nodes will run iBGP.
-      --cluster-cidr string                           CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.
       --disable-source-dest-check                     Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way. (default true)
       --enable-cni                                    Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin. (default true)
       --enable-ibgp                                   Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -25,7 +25,6 @@ type KubeRouterConfig struct {
 	CacheSyncTimeout               time.Duration
 	CleanupConfig                  bool
 	ClusterAsn                     uint
-	ClusterCIDR                    string
 	ClusterIPCIDR                  string
 	NodePortRange                  string
 	DisableSrcDstCheck             bool
@@ -107,8 +106,6 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Cleanup iptables rules, ipvs, ipset configuration and exit.")
 	fs.BoolVar(&s.MasqueradeAll, "masquerade-all", false,
 		"SNAT all traffic to cluster IP/node port.")
-	fs.StringVar(&s.ClusterCIDR, "cluster-cidr", s.ClusterCIDR,
-		"CIDR range of pods in the cluster. It is used to identify traffic originating from and destinated to pods.")
 	fs.StringSliceVar(&s.ExcludedCidrs, "excluded-cidrs", s.ExcludedCidrs,
 		"Excluded CIDRs are used to exclude IPVS rules from deletion.")
 	fs.StringVar(&s.ClusterIPCIDR, "service-cluster-ip-range", s.ClusterIPCIDR,


### PR DESCRIPTION
@murali-reddy 

In Slack the presence of this option confused a user that tried to use it to set their cluster-cidr instead of setting it on `kube-controller-manager`. I didn't realize that we still had this option around any longer, but it looks like it's functionality was ripped out here: https://github.com/cloudnativelabs/kube-router/pull/111 but then the option was never removed, so now users can set it, but it's effectively a no-op.