### PR TITLE
Setup Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+**What happened?**
+A clear and concise description of what the bug is.
+
+**What did you expect to happen?**
+A clear and concise description of what you expected to happen.
+
+**How can we reproduce the behavior you experienced?**
+Steps to reproduce the behavior:
+1. Step 1
+2. Step 2
+3. Step 3
+4. Step 4
+
+**Screenshots / Architecture Diagrams / Network Topologies **
+If applicable, add those here to help explain your problem.
+
+** System Information (please complete the following information):**
+ - Kube-Router Version (`kube-router --version`): [e.g. 1.0.1]
+ - Kubernetes Version (`kubectl version`) : [e.g. 1.18.3]
+ - Cloud Type: [e.g. AWS, GCP, Azure, on premise]
+ - Kubernetes Deployment Type: [e.g. EKS, GKE, Kops, Kubeadm, etc.]
+ - Kube-Router Deployment Type: [e.g. DaemonSet, System Service]
+ - Cluster Size: [e.g. 200 Nodes]
+
+** Logs, other output, metrics **
+Please provide logs, other kind of output or observed metrics here.
+
+**Additional context**
+Add any other context about the problem here.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Kube-Router Channel on Kubernetes Slack
+    url: https://kubernetes.slack.com/messages/C8DCQGTSB
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is and what the feature provides.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
@murali-reddy @aauren I would suggest to set up Issue Templates in Github as in https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates#issue-templates these would allow us to gather important information in the initial issue report (e.g. kube-router version, kubernetes version, deployment type, size of cluster)
See also:
https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository

Unfortunately, I lack permission to set it up in the settings page as mentioned in above docs. @murali-reddy can you take a look and maybe set it up yourself?