### PR TITLE
Improve ipset performance with large sets

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -389,7 +389,7 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to create ipset: %s", err.Error())
 			}
-			err = targetDestPodIPSet.Refresh(currnetPodIps, utils.OptionTimeout, "0")
+			err = targetDestPodIPSet.Refresh(currnetPodIps)
 			if err != nil {
 				glog.Errorf("failed to refresh targetDestPodIPSet,: " + err.Error())
 			}
@@ -407,7 +407,7 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to create ipset: %s", err.Error())
 			}
-			err = targetSourcePodIPSet.Refresh(currnetPodIps, utils.OptionTimeout, "0")
+			err = targetSourcePodIPSet.Refresh(currnetPodIps)
 			if err != nil {
 				glog.Errorf("failed to refresh targetSourcePodIPSet: " + err.Error())
 			}
@@ -458,7 +458,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 			for _, pod := range ingressRule.srcPods {
 				ingressRuleSrcPodIPs = append(ingressRuleSrcPodIPs, pod.ip)
 			}
-			err = srcPodIPSet.Refresh(ingressRuleSrcPodIPs, utils.OptionTimeout, "0")
+			err = srcPodIPSet.Refresh(ingressRuleSrcPodIPs)
 			if err != nil {
 				glog.Errorf("failed to refresh srcPodIPSet: " + err.Error())
 			}
@@ -483,7 +483,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 						return fmt.Errorf("failed to create ipset: %s", err.Error())
 					}
 					activePolicyIPSets[namedPortIPSet.Name] = true
-					err = namedPortIPSet.Refresh(endPoints.ips, utils.OptionTimeout, "0")
+					err = namedPortIPSet.Refresh(endPoints.ips)
 					if err != nil {
 						glog.Errorf("failed to refresh namedPortIPSet: " + err.Error())
 					}
@@ -526,7 +526,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 
 				activePolicyIPSets[namedPortIPSet.Name] = true
 
-				err = namedPortIPSet.Refresh(endPoints.ips, utils.OptionTimeout, "0")
+				err = namedPortIPSet.Refresh(endPoints.ips)
 				if err != nil {
 					glog.Errorf("failed to refresh namedPortIPSet: " + err.Error())
 				}
@@ -577,7 +577,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 
 					activePolicyIPSets[namedPortIPSet.Name] = true
 
-					err = namedPortIPSet.Refresh(endPoints.ips, utils.OptionTimeout, "0")
+					err = namedPortIPSet.Refresh(endPoints.ips)
 					if err != nil {
 						glog.Errorf("failed to refresh namedPortIPSet: " + err.Error())
 					}
@@ -634,7 +634,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 			for _, pod := range egressRule.dstPods {
 				egressRuleDstPodIps = append(egressRuleDstPodIps, pod.ip)
 			}
-			err = dstPodIPSet.Refresh(egressRuleDstPodIps, utils.OptionTimeout, "0")
+			err = dstPodIPSet.Refresh(egressRuleDstPodIps)
 			if err != nil {
 				glog.Errorf("failed to refresh dstPodIPSet: " + err.Error())
 			}
@@ -660,7 +660,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 
 					activePolicyIPSets[namedPortIPSet.Name] = true
 
-					err = namedPortIPSet.Refresh(endPoints.ips, utils.OptionTimeout, "0")
+					err = namedPortIPSet.Refresh(endPoints.ips)
 					if err != nil {
 						glog.Errorf("failed to refresh namedPortIPSet: " + err.Error())
 					}

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -658,7 +658,7 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 	for _, addr := range addrs {
 		localIPsSets = append(localIPsSets, addr.IP.String())
 	}
-	err = localIPsIPSet.Refresh(localIPsSets, utils.OptionTimeout, "0")
+	err = localIPsIPSet.Refresh(localIPsSets)
 	if err != nil {
 		return fmt.Errorf("failed to sync ipset: %s", err.Error())
 	}
@@ -702,13 +702,13 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 	}
 
 	serviceIPsIPSet := nsc.ipsetMap[serviceIPsIPSetName]
-	err = serviceIPsIPSet.Refresh(serviceIPsSets, utils.OptionTimeout, "0")
+	err = serviceIPsIPSet.Refresh(serviceIPsSets)
 	if err != nil {
 		return fmt.Errorf("failed to sync ipset: %s", err.Error())
 	}
 
 	ipvsServicesIPSet := nsc.ipsetMap[ipvsServicesIPSetName]
-	err = ipvsServicesIPSet.Refresh(ipvsServicesSets, utils.OptionTimeout, "0")
+	err = ipvsServicesIPSet.Refresh(ipvsServicesSets)
 	if err != nil {
 		return fmt.Errorf("failed to sync ipset: %s", err.Error())
 	}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -568,7 +568,7 @@ func (nrc *NetworkRoutingController) syncNodeIPSets() error {
 				podSubnetsIPSetName)
 		}
 	}
-	err = psSet.Refresh(currentPodCidrs, psSet.Options...)
+	err = psSet.Refresh(currentPodCidrs)
 	if err != nil {
 		return fmt.Errorf("Failed to sync Pod Subnets ipset: %s", err)
 	}
@@ -583,7 +583,7 @@ func (nrc *NetworkRoutingController) syncNodeIPSets() error {
 				nodeAddrsIPSetName)
 		}
 	}
-	err = naSet.Refresh(currentNodeIPs, naSet.Options...)
+	err = naSet.Refresh(currentNodeIPs)
 	if err != nil {
 		return fmt.Errorf("Failed to sync Node Addresses ipset: %s", err)
 	}

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -213,7 +213,10 @@ func (ipset *IPSet) Add(set *Set) error {
 		options[index] = entry.Options
 	}
 
-	ipset.Get(set.Name).BatchAdd(options)
+	err = ipset.Get(set.Name).BatchAdd(options)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -208,18 +208,20 @@ func (ipset *IPSet) Add(set *Set) error {
 		return err
 	}
 
-	for _, entry := range set.Entries {
-		_, err := ipset.Get(set.Name).Add(entry.Options...)
-		if err != nil {
-			return err
-		}
+	options := make([][]string, len(set.Entries))
+	for index, entry := range set.Entries {
+		options[index] = entry.Options
 	}
+
+	ipset.Get(set.Name).BatchAdd(options)
 
 	return nil
 }
 
 // Add a given entry to the set. If the -exist option is specified, ipset
 // ignores if the entry already added to the set.
+// Note: if you need to add multiple entries (e.g., in a loop), use BatchAdd instead,
+// as it’s much more performant.
 func (set *Set) Add(addOptions ...string) (*Entry, error) {
 	entry := &Entry{
 		Set:     set,
@@ -231,6 +233,35 @@ func (set *Set) Add(addOptions ...string) (*Entry, error) {
 		return nil, err
 	}
 	return entry, nil
+}
+
+// Adds given entries (with their options) to the set.
+// For multiple items, this is much faster than Add().
+func (set *Set) BatchAdd(addOptions [][]string) error {
+	newEntries := make([]*Entry, len(addOptions))
+	for index, options := range addOptions {
+		entry := &Entry{
+			Set:     set,
+			Options: options,
+		}
+		newEntries[index] = entry
+	}
+	set.Entries = append(set.Entries, newEntries...)
+
+	// Build the `restore` command contents
+	var builder strings.Builder
+	for _, options := range addOptions {
+		line := strings.Join(append([]string{"add", "-exist", set.name()}, options...), " ")
+		builder.WriteString(line + "\n")
+	}
+	restoreContents := builder.String()
+
+	// Invoke the command
+	_, err := set.Parent.runWithStdin(bytes.NewBufferString(restoreContents), "restore")
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Del an entry from a set. If the -exist option is specified and the entry is
@@ -441,7 +472,19 @@ func (set *Set) Swap(setTo *Set) error {
 
 // Refresh a Set with new entries.
 func (set *Set) Refresh(entries []string, extraOptions ...string) error {
+	entriesWithOptions := make([][]string, len(entries))
+
+	for index, entry := range entries {
+		entriesWithOptions[index] = append([]string{entry}, extraOptions...)
+	}
+
+	return set.RefreshWithBuiltinOptions(entriesWithOptions)
+}
+
+// Refresh a Set with new entries with built-in options.
+func (set *Set) RefreshWithBuiltinOptions(entries [][]string) error {
 	var err error
+
 	// The set-name must be < 32 characters!
 	tempName := set.Name + "-"
 
@@ -456,46 +499,9 @@ func (set *Set) Refresh(entries []string, extraOptions ...string) error {
 		return err
 	}
 
-	for _, entry := range entries {
-		_, err = newSet.Add(entry)
-		if err != nil {
-			return err
-		}
-	}
-
-	err = set.Swap(newSet)
+	err = newSet.BatchAdd(entries)
 	if err != nil {
 		return err
-	}
-
-	err = set.Parent.Destroy(tempName)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Refresh a Set with new entries with built-in options.
-func (set *Set) RefreshWithBuiltinOptions(entries [][]string) error {
-	var err error
-	tempName := set.Name + "-temp"
-	newSet := &Set{
-		Parent:  set.Parent,
-		Name:    tempName,
-		Options: set.Options,
-	}
-
-	err = set.Parent.Add(newSet)
-	if err != nil {
-		return err
-	}
-
-	for _, entry := range entries {
-		_, err = newSet.Add(entry...)
-		if err != nil {
-			return err
-		}
 	}
 
 	err = set.Swap(newSet)


### PR DESCRIPTION
This PR updates `kube-router` to use `ipset restore` instead of calling `ipset add` multiple times in a row. This significantly improves its performance when working with large sets of rules.

For me, with ~2K ClusterIP services in a minikube cluster, this improves the `syncIpvsFirewall()` speed from ~3.5s to ~0.3s.

Ref: https://github.com/cloudnativelabs/kube-router/issues/962