### PR TITLE
Add hairpin support for externalIps

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -212,6 +212,11 @@ To enable hairpin traffic for Service `my-service`:
 kubectl annotate service my-service "kube-router.io/service.hairpin="
 ```
 
+If you want hairpin also apply on externalIPs declared for Service `my-service`:
+```
+kubectl annotate service my-service "kube-router.io/service.hairpin.externalips="
+```
+
 ## Direct server return
 
 Please read below blog on how to user DSR in combination with `--advertise-external-ip` to build highly scalable and available ingress.

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -46,12 +46,13 @@ const (
 	IpvsSvcFSched2    = "flag-2"
 	IpvsSvcFSched3    = "flag-3"
 
-	svcDSRAnnotation        = "kube-router.io/service.dsr"
-	svcSchedulerAnnotation  = "kube-router.io/service.scheduler"
-	svcHairpinAnnotation    = "kube-router.io/service.hairpin"
-	svcLocalAnnotation      = "kube-router.io/service.local"
-	svcSkipLbIpsAnnotation  = "kube-router.io/service.skiplbips"
-	svcSchedFlagsAnnotation = "kube-router.io/service.schedflags"
+	svcDSRAnnotation                = "kube-router.io/service.dsr"
+	svcSchedulerAnnotation          = "kube-router.io/service.scheduler"
+	svcHairpinAnnotation            = "kube-router.io/service.hairpin"
+	svcHairpinExternalIPsAnnotation = "kube-router.io/service.hairpin.externalips"
+	svcLocalAnnotation              = "kube-router.io/service.local"
+	svcSkipLbIpsAnnotation          = "kube-router.io/service.skiplbips"
+	svcSchedFlagsAnnotation         = "kube-router.io/service.schedflags"
 
 	LeaderElectionRecordAnnotationKey = "control-plane.alpha.kubernetes.io/leader"
 	localIPsIPSetName                 = "kube-router-local-ips"
@@ -250,6 +251,7 @@ type serviceInfo struct {
 	scheduler                     string
 	directServerReturnMethod      string
 	hairpin                       bool
+	hairpinExternalIPs            bool
 	skipLbIps                     bool
 	externalIPs                   []string
 	loadBalancerIPs               []string
@@ -1152,6 +1154,7 @@ func (nsc *NetworkServicesController) buildServicesInfo() serviceInfoMap {
 				svcInfo.sessionAffinityTimeoutSeconds = *svc.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds
 			}
 			_, svcInfo.hairpin = svc.ObjectMeta.Annotations[svcHairpinAnnotation]
+			_, svcInfo.hairpinExternalIPs = svc.ObjectMeta.Annotations[svcHairpinExternalIPsAnnotation]
 			_, svcInfo.local = svc.ObjectMeta.Annotations[svcLocalAnnotation]
 			_, svcInfo.skipLbIps = svc.ObjectMeta.Annotations[svcSkipLbIpsAnnotation]
 			if svc.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyTypeLocal {
@@ -1326,6 +1329,14 @@ func (nsc *NetworkServicesController) syncHairpinIptablesRules() error {
 				// Handle ClusterIP Service
 				rule, ruleArgs := hairpinRuleFrom(svcInfo.clusterIP.String(), ep.ip, svcInfo.port)
 				rulesNeeded[rule] = ruleArgs
+
+				// Handle ExternalIPs if requested
+				if svcInfo.hairpinExternalIPs {
+					for _, extip := range svcInfo.externalIPs {
+						rule, ruleArgs := hairpinRuleFrom(extip, ep.ip, svcInfo.port)
+						rulesNeeded[rule] = ruleArgs
+					}
+				}
 
 				// Handle NodePort Service
 				if svcInfo.nodePort != 0 {


### PR DESCRIPTION
Hello,

This pull request add support for externalIps hairpin rules, via an annotation on service in order to add extra NAT rules only when requested.

My use case is the following, I have a Consul server on K8S and exposed to hosts outside the cluster via an external IP. The server is configured to advertise the external IP instead of the pod one (or clusterIP), to let other Consul agent gossip with him, even if they're outside the K8S cluster.
Until now, there no problem, but the Consul server periodically check other servers, including himself, as part of the Consul autopilot feature and the lack of hairpin NAT rules for externalIPs make this self-check fail with a timeout.