### PR TITLE
Permit ExternalIP on input

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -84,7 +84,7 @@ Usage of kube-router:
       --run-router                                    Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
       --run-service-proxy                             Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)
       --service-cluster-ip-range string               CIDR value from which service cluster IPs are assigned. Default: 10.96.0.0/12 (default "10.96.0.0/12")
-      --service-node-port-range string                NodePort range. Default: 30000-32767 (default "30000:32767")
+      --service-node-port-range string                NodePort range specified with either a hyphen or colon (default "30000-32767")
   -v, --v string                                      log level for V logs (default "0")
   -V, --version                                       Print version information.
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -84,6 +84,7 @@ Usage of kube-router:
       --run-router                                    Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
       --run-service-proxy                             Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)
       --service-cluster-ip-range string               CIDR value from which service cluster IPs are assigned. Default: 10.96.0.0/12 (default "10.96.0.0/12")
+      --service-external-ip-range strings             Specify external IP CIDRs that are used for inter-cluster communication (can be specified multiple times)
       --service-node-port-range string                NodePort range specified with either a hyphen or colon (default "30000-32767")
   -v, --v string                                      log level for V logs (default "0")
   -V, --version                                       Print version information.

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -1820,7 +1820,27 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 		return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: %s", err.Error())
 	}
 	npc.serviceClusterIPRange = *ipnet
-	npc.serviceNodePortRange = config.NodePortRange
+
+	nodePortValidator := regexp.MustCompile(`^([0-9]+)[:-]{1}([0-9]+)$`)
+	if matched := nodePortValidator.MatchString(config.NodePortRange); !matched {
+		return nil, fmt.Errorf("failed to parse node port range given: '%s' please see specification in help text", config.NodePortRange)
+	}
+	matches := nodePortValidator.FindStringSubmatch(config.NodePortRange)
+	if len(matches) != 3 {
+		return nil, fmt.Errorf("could not parse port number from range given: '%s'", config.NodePortRange)
+	}
+	port1, err := strconv.ParseInt(matches[1], 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse first port number from range given: '%s'", config.NodePortRange)
+	}
+	port2, err := strconv.ParseInt(matches[2], 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse second port number from range given: '%s'", config.NodePortRange)
+	}
+	if port1 >= port2 {
+		return nil, fmt.Errorf("port 1 is greater than or equal to port 2 in range given: '%s'", config.NodePortRange)
+	}
+	npc.serviceNodePortRange = fmt.Sprintf("%d:%d", port1, port2)
 
 	if config.MetricsEnabled {
 		//Register the metrics for this controller

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -218,11 +218,18 @@ func (npc *NetworkPolicyController) ensureTopLevelChains() {
 			glog.Fatalf("failed to list rules in filter table %s chain due to %s", chain, err.Error())
 		}
 
-		var ruleNo int
+		var ruleNo, ruleIndexOffset int
 		for i, rule := range rules {
 			rule = strings.Replace(rule, "\"", "", 2) //removes quote from comment string
-			if strings.Contains(rule, strings.Join(ruleSpec, " ")) {
-				ruleNo = i
+			if strings.HasPrefix(rule, "-P") || strings.HasPrefix(rule, "-N") {
+				// if this chain has a default policy, then it will show as rule #1 from iptablesCmdHandler.List so we
+				// need to account for this offset
+				ruleIndexOffset += 1
+				continue
+			}
+			if strings.Contains(rule, uuid) {
+				// range uses a 0 index, but iptables uses a 1 index so we need to increase ruleNo by 1
+				ruleNo = i+1-ruleIndexOffset
 				break
 			}
 		}

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -2,6 +2,7 @@ package netpol
 
 import (
 	"context"
+	"github.com/cloudnativelabs/kube-router/pkg/options"
 	"net"
 	"strings"
 	"testing"
@@ -246,6 +247,27 @@ func testForMissingOrUnwanted(t *testing.T, targetMsg string, got []podInfo, wan
 	}
 }
 
+func newMinimalKubeRouterConfig(clusterIPCIDR string, nodePortRange string, hostNameOverride string) *options.KubeRouterConfig {
+	kubeConfig := options.NewKubeRouterConfig()
+	if clusterIPCIDR != "" {
+		kubeConfig.ClusterIPCIDR = clusterIPCIDR
+	}
+	if nodePortRange != "" {
+		kubeConfig.NodePortRange = nodePortRange
+	}
+	if hostNameOverride != "" {
+		kubeConfig.HostnameOverride = hostNameOverride
+	}
+	return kubeConfig
+}
+
+type tNetPolConfigTestCase struct {
+	name        string
+	config      *options.KubeRouterConfig
+	expectError bool
+	errorText   string
+}
+
 func TestNewNetworkPolicySelectors(t *testing.T) {
 	testCases := []tNetpolTestCase{
 		{
@@ -365,6 +387,115 @@ func TestNewNetworkPolicySelectors(t *testing.T) {
 			}
 			for _, egress := range np.egressRules {
 				testForMissingOrUnwanted(t, "egress dstPods", egress.dstPods, test.outDestPods)
+			}
+		})
+	}
+}
+
+func TestNetworkPolicyController(t *testing.T) {
+	testCases := []tNetPolConfigTestCase{
+		{
+			"Default options are successful",
+			newMinimalKubeRouterConfig("", "", "node"),
+			false,
+			"",
+		},
+		{
+			"Missing nodename fails appropriately",
+			newMinimalKubeRouterConfig("", "", ""),
+			true,
+			"Failed to identify the node by NODE_NAME, hostname or --hostname-override",
+		},
+		{
+			"Test bad cluster CIDR (not properly formatting ip address)",
+			newMinimalKubeRouterConfig("10.10.10", "", "node"),
+			true,
+			"failed to get parse --service-cluster-ip-range parameter: invalid CIDR address: 10.10.10",
+		},
+		{
+			"Test bad cluster CIDR (not using an ip address)",
+			newMinimalKubeRouterConfig("foo", "", "node"),
+			true,
+			"failed to get parse --service-cluster-ip-range parameter: invalid CIDR address: foo",
+		},
+		{
+			"Test bad cluster CIDR (using an ip address that is not a CIDR)",
+			newMinimalKubeRouterConfig("10.10.10.10", "", "node"),
+			true,
+			"failed to get parse --service-cluster-ip-range parameter: invalid CIDR address: 10.10.10.10",
+		},
+		{
+			"Test good cluster CIDR (using single IP with a /32)",
+			newMinimalKubeRouterConfig("10.10.10.10/32", "", "node"),
+			false,
+			"",
+		},
+		{
+			"Test good cluster CIDR (using normal range with /24)",
+			newMinimalKubeRouterConfig("10.10.10.0/24", "", "node"),
+			false,
+			"",
+		},
+		{
+			"Test bad node port specification (using commas)",
+			newMinimalKubeRouterConfig("", "8080,8081", "node"),
+			true,
+			"failed to parse node port range given: '8080,8081' please see specification in help text",
+		},
+		{
+			"Test bad node port specification (not using numbers)",
+			newMinimalKubeRouterConfig("", "foo:bar", "node"),
+			true,
+			"failed to parse node port range given: 'foo:bar' please see specification in help text",
+		},
+		{
+			"Test bad node port specification (using anything in addition to range)",
+			newMinimalKubeRouterConfig("", "8080,8081-8090", "node"),
+			true,
+			"failed to parse node port range given: '8080,8081-8090' please see specification in help text",
+		},
+		{
+			"Test bad node port specification (using reversed range)",
+			newMinimalKubeRouterConfig("", "8090-8080", "node"),
+			true,
+			"port 1 is greater than or equal to port 2 in range given: '8090-8080'",
+		},
+		{
+			"Test bad node port specification (port out of available range)",
+			newMinimalKubeRouterConfig("", "132000-132001", "node"),
+			true,
+			"could not parse first port number from range given: '132000-132001'",
+		},
+		{
+			"Test good node port specification (using colon separator)",
+			newMinimalKubeRouterConfig("", "8080:8090", "node"),
+			false,
+			"",
+		},
+		{
+			"Test good node port specification (using hyphen separator)",
+			newMinimalKubeRouterConfig("", "8080-8090", "node"),
+			false,
+			"",
+		},
+	}
+	client := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{*newFakeNode("node", "10.10.10.10")}})
+	_, podInformer, nsInformer, netpolInformer := newFakeInformersFromClient(client)
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer)
+			if err == nil && test.expectError {
+				t.Error("This config should have failed, but it was successful instead")
+			} else if err != nil {
+				// Unfortunately without doing a ton of extra refactoring work, we can't remove this reference easily
+				// from the controllers start up. Luckily it's one of the last items to be processed in the controller
+				// so for now we'll consider that if we hit this error that we essentially didn't hit an error at all
+				// TODO: refactor NPC to use an injectable interface for ipset operations
+				if !test.expectError && err.Error() != "Ipset utility not found" {
+					t.Errorf("This config should have been successful, but it failed instead. Error: %s", err)
+				} else if test.expectError && err.Error() != test.errorText {
+					t.Errorf("Expected error: '%s' but instead got: '%s'", test.errorText, err)
+				}
 			}
 		})
 	}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -78,7 +78,7 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		IPTablesSyncPeriod:             5 * time.Minute,
 		IpvsGracefulPeriod:             30 * time.Second,
 		IpvsSyncPeriod:                 5 * time.Minute,
-		NodePortRange:                  "30000:32767",
+		NodePortRange:                  "30000-32767",
 		OverlayType:                    "subnet",
 		RoutesSyncPeriod:               5 * time.Minute,
 	}
@@ -180,7 +180,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ClusterIPCIDR, "service-cluster-ip-range", s.ClusterIPCIDR,
 		"CIDR value from which service cluster IPs are assigned. Default: 10.96.0.0/12")
 	fs.StringVar(&s.NodePortRange, "service-node-port-range", s.NodePortRange,
-		"NodePort range. Default: 30000-32767")
+		"NodePort range specified with either a hyphen or colon")
 	fs.StringVarP(&s.VLevel, "v", "v", "0", "log level for V logs")
 	fs.BoolVarP(&s.Version, "version", "V", false,
 		"Print version information.")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -32,6 +32,7 @@ type KubeRouterConfig struct {
 	EnablePodEgress                bool
 	EnablePprof                    bool
 	ExcludedCidrs                  []string
+	ExternalIPCIDRs                []string
 	FullMeshMode                   bool
 	GlobalHairpinMode              bool
 	HealthPort                     uint16
@@ -179,6 +180,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enables Service Proxy -- sets up IPVS for Kubernetes Services.")
 	fs.StringVar(&s.ClusterIPCIDR, "service-cluster-ip-range", s.ClusterIPCIDR,
 		"CIDR value from which service cluster IPs are assigned. Default: 10.96.0.0/12")
+	fs.StringSliceVar(&s.ExternalIPCIDRs, "service-external-ip-range", s.ExternalIPCIDRs,
+		"Specify external IP CIDRs that are used for inter-cluster communication (can be specified multiple times)")
 	fs.StringVar(&s.NodePortRange, "service-node-port-range", s.NodePortRange,
 		"NodePort range specified with either a hyphen or colon")
 	fs.StringVarP(&s.VLevel, "v", "v", "0", "log level for V logs")


### PR DESCRIPTION
This PR contains a couple of things:
1) Parse ClusterIP service range CIDR as a CIDR instead of as a string before passing it to iptables
2) Parse and validate NodePort ranges before before passing it to iptables
3) A side-effect of the above is that we can now allow ranges specified with a hyphen as well as the of the iptables colon `8080-8090` vs `8080:8090`. The hyphen form is a more k8s cohesive way to specify the NodePort range as it's the same format that kube-apiserver uses
4) Added support for defining ExternalIP ranges which addresses the problem found in #934 
5) I added unit tests for all of the above