### PR TITLE
add IfaceHasNoAddr check for external ip delete error

### DIFF
--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -309,7 +309,7 @@ func (nsc *NetworkServicesController) setupExternalIPServices(serviceInfoMap ser
 
 				// ensure VIP less director. we dont assign VIP to any interface
 				err = nsc.ln.ipAddrDel(dummyVipInterface, externalIP)
-				if err != nil {
+				if err != nil && err.Error() != IfaceHasNoAddr {
 					glog.Errorf("Failed to delete external ip address from dummyVipInterface due to %s", err)
 					continue
 				}


### PR DESCRIPTION
When creating externlIP service with DSR tunnel, I got the following error log, and kube-router failed to create the related IPVS tunnel.

> 0813 23:38:37.465953 1642001 network_services_controller.go:1762] Successfully added service: TCP:<nil>:80 (Flags: )
> E0813 23:38:37.469536 1642001 service_endpoints_sync.go:313] Failed to delete external ip adress from dummyVipInterface due to cannot assign requested address

This is because when the externalIP service is created for the first time, the externalIP didn't exist on the dummy interface before, the `nsc.ln.ipAddrDel` call above my change would result in IfaceHasNoAddr error, preventing `routeVIPTrafficToDirector` function below to create the IPVS tunnel. Therefore, the IfaceHasNoAddr error should be ignored.