### PR TITLE
Fix unnecessary conversions

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -722,7 +722,7 @@ func (nsc *NetworkServicesController) publishMetrics(serviceInfoMap serviceInfoM
 		endTime := time.Since(start)
 		glog.V(2).Infof("Publishing IPVS metrics took %v", endTime)
 		if nsc.MetricsEnabled {
-			metrics.ControllerIpvsMetricsExportTime.Observe(float64(endTime.Seconds()))
+			metrics.ControllerIpvsMetricsExportTime.Observe(endTime.Seconds())
 		}
 	}()
 

--- a/pkg/healthcheck/health_controller.go
+++ b/pkg/healthcheck/health_controller.go
@@ -110,7 +110,7 @@ func (hc *HealthController) HandleHeartbeat(beat *ControllerHeartbeat) {
 // CheckHealth evaluates the time since last heartbeat to decide if the controller is running or not
 func (hc *HealthController) CheckHealth() bool {
 	health := true
-	graceTime := time.Duration(1500 * time.Millisecond)
+	graceTime := time.Duration(1500) * time.Millisecond
 
 	if hc.Config.RunFirewall {
 		if time.Since(hc.Status.NetworkPolicyControllerAlive) > hc.Config.IPTablesSyncPeriod+hc.Status.NetworkPolicyControllerAliveTTL+graceTime {


### PR DESCRIPTION
I tested https://github.com/quasilyte/go-ruleguard with https://github.com/dgryski/semgrep-go today and run it against kube-router's code base, it detected those two small improvements.