### PR TITLE
Add Support for Reading Peer Passwords via a File

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -77,6 +77,7 @@ Usage of kube-router:
       --peer-router-ips ipSlice                       The ip address of the external router to which all nodes will peer and advertise the cluster ip and pod cidr's. (default [])
       --peer-router-multihop-ttl uint8                Enable eBGP multihop supports -- sets multihop-ttl. (Relevant only if ttl >= 2)
       --peer-router-passwords strings                 Password for authenticating against the BGP peer defined with "--peer-router-ips".
+      --peer-router-passwords-file string             Path to file containing password for authenticating against the BGP peer defined with "--peer-router-ips". --peer-router-passwords will be preferred if both are set.
       --peer-router-ports uints                       The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used. (default [])
       --router-id string                              BGP router-id. Must be specified in a ipv6 only cluster.
       --routes-sync-period duration                   The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -1050,12 +1050,23 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		peerPorts = append(peerPorts, uint32(i))
 	}
 
-	// Decode base64 passwords
+	// PeerPasswords as cli params take precedence over password file
 	peerPasswords := make([]string, 0)
 	if len(kubeRouterConfig.PeerPasswords) != 0 {
 		peerPasswords, err = stringSliceB64Decode(kubeRouterConfig.PeerPasswords)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to parse CLI Peer Passwords flag: %s", err)
+		}
+	} else if len(kubeRouterConfig.PeerPasswordsFile) != 0 {
+		// Contents of the pw file should be in the same format as pw from CLI arg
+		pwfileBytes, err := ioutil.ReadFile(kubeRouterConfig.PeerPasswordsFile)
+		if err != nil {
+			return nil, fmt.Errorf("Error loading Peer Passwords File : %s", err)
+		}
+		pws := strings.Split(string(pwfileBytes), ",")
+		peerPasswords, err = stringSliceB64Decode(pws)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to decode CLI Peer Passwords file: %s", err)
 		}
 	}
 

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -1059,11 +1059,11 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		}
 	} else if len(kubeRouterConfig.PeerPasswordsFile) != 0 {
 		// Contents of the pw file should be in the same format as pw from CLI arg
-		pwfileBytes, err := ioutil.ReadFile(kubeRouterConfig.PeerPasswordsFile)
+		pwFileBytes, err := ioutil.ReadFile(kubeRouterConfig.PeerPasswordsFile)
 		if err != nil {
 			return nil, fmt.Errorf("Error loading Peer Passwords File : %s", err)
 		}
-		pws := strings.Split(string(pwfileBytes), ",")
+		pws := strings.Split(string(pwFileBytes), ",")
 		peerPasswords, err = stringSliceB64Decode(pws)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to decode CLI Peer Passwords file: %s", err)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -56,6 +56,7 @@ type KubeRouterConfig struct {
 	PeerASNs                       []uint
 	PeerMultihopTTL                uint8
 	PeerPasswords                  []string
+	PeerPasswordsFile              string
 	PeerPorts                      []uint
 	PeerRouters                    []net.IP
 	RouterID                       string
@@ -167,6 +168,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enable eBGP multihop supports -- sets multihop-ttl. (Relevant only if ttl >= 2)")
 	fs.StringSliceVar(&s.PeerPasswords, "peer-router-passwords", s.PeerPasswords,
 		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
+	fs.StringVar(&s.PeerPasswordsFile, "peer-router-passwords-file", s.PeerPasswordsFile,
+		"Path to file containing password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
 	fs.UintSliceVar(&s.PeerPorts, "peer-router-ports", s.PeerPorts,
 		"The remote port of the external BGP to which all nodes will peer. If not set, default BGP port ("+strconv.Itoa(DefaultBgpPort)+") will be used.")
 	fs.StringVar(&s.RouterID, "router-id", "", "BGP router-id. Must be specified in a ipv6 only cluster.")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -169,7 +169,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.PeerPasswords, "peer-router-passwords", s.PeerPasswords,
 		"Password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
 	fs.StringVar(&s.PeerPasswordsFile, "peer-router-passwords-file", s.PeerPasswordsFile,
-		"Path to file containing password for authenticating against the BGP peer defined with \"--peer-router-ips\".")
+		"Path to file containing password for authenticating against the BGP peer defined with \"--peer-router-ips\". --peer-router-passwords will be preferred if both are set.")
 	fs.UintSliceVar(&s.PeerPorts, "peer-router-ports", s.PeerPorts,
 		"The remote port of the external BGP to which all nodes will peer. If not set, default BGP port ("+strconv.Itoa(DefaultBgpPort)+") will be used.")
 	fs.StringVar(&s.RouterID, "router-id", "", "BGP router-id. Must be specified in a ipv6 only cluster.")


### PR DESCRIPTION
This is an update to the PR previously submitted by @jraby in #800, it just needed some rebasing (since the options.go file has changed significantly since he previously submitted) and some extra linting.

This is based on #982 and is meant to be merged after that is merged into the master branch. I've verified that it builds and that all unit tests are currently passing. Additionally, I've deployed into a test cluster and verified the password file functionality.

This is the last PR needed to satisfy issue #794 