### PR TITLE
auto configure MTU

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -40,6 +40,7 @@ Usage of kube-router:
       --advertise-external-ip                         Add External IP of service to the RIB so that it gets advertised to the BGP peers.
       --advertise-loadbalancer-ip                     Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
       --advertise-pod-cidr                            Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
+      --auto-mtu                                      Auto detect and set the largest possible MTU for pod interfaces. (default true)
       --bgp-graceful-restart                          Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
       --bgp-graceful-restart-deferral-time duration   BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h. (default 6m0s)
       --bgp-graceful-restart-time duration            BGP Graceful restart time according to RFC4724 3, maximum 4095s. (default 1m30s)
@@ -308,6 +309,30 @@ As of 0.2.6 we support experimental graceful termination of IPVS destinations. W
 the fallback period is 30 seconds and can be adjusted with `--ipvs-graceful-period` cli-opt
 
 graceful termination works in such a way that when kube-router receives a delete endpoint notification for a service it's weight is adjusted to 0 before getting deleted after he termination grace period has passed or the Active & Inactive connections goes down to 0.
+
+## MTU
+
+The maximum transmission unit (MTU) determines the largest packet size that can be transmitted through your network. MTU for the pod interfaces should be set appropriately to prevent fragmentation and packet drops thereby achieving maximum performance. If you set `auto-mtu` to true kube-router will determine right MTU for both `kube-bridge` and pod interfaces. If you set `auto-mtu` to false kube-router will not attempt to configure MTU. However you can choose the right MTU and set in the `cni-conf.json` section of the `10-kuberouter.conflist` in the kube-router [daemonsets](../daemonset/). For e.g.
+
+```
+  cni-conf.json: |
+    {
+       "cniVersion":"0.3.0",
+       "name":"mynet",
+       "plugins":[
+          {
+             "name":"kubernetes",
+             "type":"bridge",
+             "mtu": 1400,
+             "bridge":"kube-bridge",
+             "isDefaultGateway":true,
+             "ipam":{
+                "type":"host-local"
+             }
+          }
+       ]
+    }
+```
 
 ## BGP configuration
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -312,7 +312,7 @@ graceful termination works in such a way that when kube-router receives a delete
 
 ## MTU
 
-The maximum transmission unit (MTU) determines the largest packet size that can be transmitted through your network. MTU for the pod interfaces should be set appropriately to prevent fragmentation and packet drops thereby achieving maximum performance. If you set `auto-mtu` to true kube-router will determine right MTU for both `kube-bridge` and pod interfaces. If you set `auto-mtu` to false kube-router will not attempt to configure MTU. However you can choose the right MTU and set in the `cni-conf.json` section of the `10-kuberouter.conflist` in the kube-router [daemonsets](../daemonset/). For e.g.
+The maximum transmission unit (MTU) determines the largest packet size that can be transmitted through your network. MTU for the pod interfaces should be set appropriately to prevent fragmentation and packet drops thereby achieving maximum performance. If `auto-mtu` is set to true (`auto-mtu` is set to true by default as of kube-router 1.1), kube-router will determine right MTU for both `kube-bridge` and pod interfaces. If you set `auto-mtu` to false kube-router will not attempt to configure MTU. However you can choose the right MTU and set in the `cni-conf.json` section of the `10-kuberouter.conflist` in the kube-router [daemonsets](../daemonset/). For e.g.
 
 ```
   cni-conf.json: |
@@ -333,6 +333,8 @@ The maximum transmission unit (MTU) determines the largest packet size that can 
        ]
     }
 ```
+
+ If you set MTU yourself via the CNI config, you'll also need to set MTU of `kube-bridge` manually to the right value to avoid packet fragmentation in case of existing nodes on which `kube-bridge` is already created. On node reboot or in case of new nodes joining the cluster both the pod's interface and `kube-bridge` will be setup with specified MTU value.
 
 ## BGP configuration
 

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -351,14 +351,17 @@ func (nrc *NetworkRoutingController) updateCNIConfig() {
 
 func (nrc *NetworkRoutingController) autoConfigureMTU() error {
 	mtu, err := getMTUFromNodeIP(nrc.nodeIP)
+	if err != nil {
+		return fmt.Errorf("failed to generate MTU: %s", err.Error())
+	}
 	file, err := ioutil.ReadFile(nrc.cniConfFile)
 	if err != nil {
-		return fmt.Errorf("Failed to load CNI conf file: %s", err.Error())
+		return fmt.Errorf("failed to load CNI conf file: %s", err.Error())
 	}
 	var config interface{}
 	err = json.Unmarshal(file, &config)
 	if err != nil {
-		return fmt.Errorf("Failed to parse JSON from CNI conf file: %s", err.Error())
+		return fmt.Errorf("failed to parse JSON from CNI conf file: %s", err.Error())
 	}
 	if strings.HasSuffix(nrc.cniConfFile, ".conflist") {
 		configMap := config.(map[string]interface{})
@@ -379,7 +382,7 @@ func (nrc *NetworkRoutingController) autoConfigureMTU() error {
 	configJSON, _ := json.Marshal(config)
 	err = ioutil.WriteFile(nrc.cniConfFile, configJSON, 0644)
 	if err != nil {
-		return fmt.Errorf("Failed to insert `mtu` into CNI conf file: %s", err.Error())
+		return fmt.Errorf("failed to insert `mtu` into CNI conf file: %s", err.Error())
 	}
 	return nil
 }

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -362,7 +362,7 @@ func (nrc *NetworkRoutingController) updateCNIConfig() {
 	if nrc.autoMTU {
 		err = nrc.autoConfigureMTU()
 		if err != nil {
-			glog.Fatalf("Failed to auto-configure MTU: %s", err.Error())
+			glog.Errorf("Failed to auto-configure MTU due to: %s", err.Error())
 		}
 	}
 }

--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -120,7 +120,7 @@ func getNodeSubnet(nodeIP net.IP) (net.IPNet, string, error) {
 	return net.IPNet{}, "", errors.New("Failed to find interface with specified node ip")
 }
 
-func getMTUFromNodeIP(nodeIP net.IP) (int, error) {
+func getMTUFromNodeIP(nodeIP net.IP, overlayEnabled bool) (int, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
 		return 0, errors.New("Failed to get list of links")
@@ -132,8 +132,11 @@ func getMTUFromNodeIP(nodeIP net.IP) (int, error) {
 		}
 		for _, addr := range addresses {
 			if addr.IPNet.IP.Equal(nodeIP) {
-				lintMTU := link.Attrs().MTU
-				return lintMTU - 20, nil // -20 to accommodate IPIP header
+				linkMTU := link.Attrs().MTU
+				if overlayEnabled {
+					return linkMTU - 20, nil // -20 to accommodate IPIP header
+				}
+				return linkMTU, nil
 			}
 		}
 	}

--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -120,6 +120,26 @@ func getNodeSubnet(nodeIP net.IP) (net.IPNet, string, error) {
 	return net.IPNet{}, "", errors.New("Failed to find interface with specified node ip")
 }
 
+func getMTUFromNodeIP(nodeIP net.IP) (int, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return 0, errors.New("Failed to get list of links")
+	}
+	for _, link := range links {
+		addresses, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			return 0, errors.New("Failed to get list of addr")
+		}
+		for _, addr := range addresses {
+			if addr.IPNet.IP.Equal(nodeIP) {
+				lintMTU := link.Attrs().MTU
+				return lintMTU - 20, nil // -20 to accommodate IPIP header
+			}
+		}
+	}
+	return 0, errors.New("Failed to find interface with specified node ip")
+}
+
 // generateTunnelName will generate a name for a tunnel interface given a node IP
 // for example, if the node IP is 10.0.0.1 the tunnel interface will be named tun-10001
 // Since linux restricts interface names to 15 characters, if length of a node IP

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -16,6 +16,7 @@ type KubeRouterConfig struct {
 	AdvertiseExternalIP            bool
 	AdvertiseLoadBalancerIP        bool
 	AdvertiseNodePodCidr           bool
+	AutoMTU                        bool
 	BGPGracefulRestart             bool
 	BGPGracefulRestartDeferralTime time.Duration
 	BGPGracefulRestartTime         time.Duration
@@ -95,6 +96,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.")
 	fs.BoolVar(&s.AdvertiseNodePodCidr, "advertise-pod-cidr", true,
 		"Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers.")
+	fs.BoolVar(&s.AutoMTU, "auto-mtu", true,
+		"Auto detect and set the largest possible MTU for pod interfaces.")
 	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time", s.BGPGracefulRestartDeferralTime,


### PR DESCRIPTION
set `mtu` in cni spec to auto configure MTU's of the pod's veth's and kube-bridge interfaces

simple approach to pick the MTU associated with interface associated with node's IP as MTU. This should work fine for most cases.

Please see https://github.com/containernetworking/plugins/tree/master/plugins/main/bridge#network-configuration-reference for further details on how `bridge` CNI works

Fixes #165