### PR TITLE
.gitignore: Drop vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ Dockerfile.arm64.run
 Dockerfile.s390x.run
 Dockerfile.arm.run
 Dockerfile.ppc64le.run
-vendor/github.com/osrg/gobgp/gobgp/gobgp


### PR DESCRIPTION
This was likely required for old-style vendoring and shouldn't be
necessary for the current version of kube-router

@murali-reddy 