### PR TITLE
Cleanup non-DSR externalIPs

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1946,12 +1946,13 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 	activeExternalIPs := make(map[string]bool)
 	for _, svc := range serviceInfoMap {
 		for _, externalIP := range svc.externalIPs {
-			activeExternalIPs[externalIP] = true
 			// Verify the DSR annotation exists
 			if !svc.directServerReturn {
 				glog.V(1).Infof("Skipping service %s/%s as it does not have DSR annotation\n", svc.namespace, svc.name)
 				continue
 			}
+
+			activeExternalIPs[externalIP] = true
 
 			if !strings.Contains(outStr, externalIP) {
 				if err = exec.Command("ip", "route", "add", externalIP, "dev", "kube-bridge", "table",


### PR DESCRIPTION
We had some stale IPs in table 79 that gave me quite the headache.

Currently, any `externalIP` is added to the `activeExternalIPs` map, while only DSR `externalIP`s are added to the routing table. Only routes for deleted `externalIP`s will be removed from the table afterwards. `externalIP`s that no longer carry the DSR annotation will remain.

This PR updates the `activeExternalIPs` map to carry only those IPs that we are also actively enforcing routes for.