### PR TITLE
use custom pod informer to reduce the memory footprint in large scale clusters

### DIFF
--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cloudnativelabs/kube-router/pkg/metrics"
 	"github.com/cloudnativelabs/kube-router/pkg/options"
 	"github.com/cloudnativelabs/kube-router/pkg/version"
+	"github.com/cloudnativelabs/kube-router/pkg/utils"
 	"k8s.io/klog/v2"
 
 	"time"
@@ -21,6 +22,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -92,10 +94,10 @@ func (kr *KubeRouter) Run() error {
 	informerFactory := informers.NewSharedInformerFactory(kr.Client, 0)
 	svcInformer := informerFactory.Core().V1().Services().Informer()
 	epInformer := informerFactory.Core().V1().Endpoints().Informer()
-	podInformer := informerFactory.Core().V1().Pods().Informer()
 	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 	nsInformer := informerFactory.Core().V1().Namespaces().Informer()
 	npInformer := informerFactory.Networking().V1().NetworkPolicies().Informer()
+
 	informerFactory.Start(stopCh)
 
 	err = kr.CacheSyncOrTimeout(informerFactory, stopCh)
@@ -161,6 +163,7 @@ func (kr *KubeRouter) Run() error {
 	}
 
 	if kr.Config.RunServiceProxy {
+		podInformer, _ := utils.NewCustomPodInformer(kr.Client, cache.ResourceEventHandlerFuncs{})
 		nsc, err := proxy.NewNetworkServicesController(kr.Client, kr.Config,
 			svcInformer, epInformer, podInformer)
 		if err != nil {
@@ -183,17 +186,22 @@ func (kr *KubeRouter) Run() error {
 
 	if kr.Config.RunFirewall {
 		npc, err := netpol.NewNetworkPolicyController(kr.Client,
-			kr.Config, podInformer, npInformer, nsInformer)
+			kr.Config, nil, npInformer, nsInformer)
 		if err != nil {
 			return errors.New("Failed to create network policy controller: " + err.Error())
 		}
 
-		podInformer.AddEventHandler(npc.PodEventHandler)
+		// use custom pod informer to reduce the memory footprint in large clusters
+		podIndexer, podController := utils.NewCustomPodInformer(kr.Client, npc.PodEventHandler)
+		npc.SetPodIndexer(podIndexer)
+
 		nsInformer.AddEventHandler(npc.NamespaceEventHandler)
 		npInformer.AddEventHandler(npc.NetworkPolicyEventHandler)
 
 		wg.Add(1)
 		go npc.Run(healthChan, stopCh, &wg)
+
+		podController.Run(stopCh)
 	}
 
 	// Handle SIGINT and SIGTERM

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -582,9 +582,14 @@ func (npc *NetworkPolicyController) Cleanup() {
 	klog.Infof("Successfully cleaned the iptables configuration done by kube-router")
 }
 
+// SetPodIndexer sets the indexer used to list the pods
+func (npc *NetworkPolicyController) SetPodIndexer(indexer cache.Indexer) {
+	npc.podLister = indexer
+}
+
 // NewNetworkPolicyController returns new NetworkPolicyController object
 func NewNetworkPolicyController(clientset kubernetes.Interface,
-	config *options.KubeRouterConfig, podInformer cache.SharedIndexInformer,
+	config *options.KubeRouterConfig, podInformer cache.Indexer,
 	npInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer) (*NetworkPolicyController, error) {
 	npc := NetworkPolicyController{}
 
@@ -655,7 +660,7 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	}
 	npc.nodeIP = nodeIP
 
-	npc.podLister = podInformer.GetIndexer()
+	npc.podLister = podInformer
 	npc.PodEventHandler = npc.newPodEventHandler()
 
 	npc.nsLister = nsInformer.GetIndexer()

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -519,10 +519,10 @@ func TestNetworkPolicyController(t *testing.T) {
 		},
 	}
 	client := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{*newFakeNode("node", "10.10.10.10")}})
-	_, podInformer, nsInformer, netpolInformer := newFakeInformersFromClient(client)
+	_, _, nsInformer, netpolInformer := newFakeInformersFromClient(client)
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer)
+			_, err := NewNetworkPolicyController(client, test.config, nil, netpolInformer, nsInformer)
 			if err == nil && test.expectError {
 				t.Error("This config should have failed, but it was successful instead")
 			} else if err != nil {

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -2465,7 +2465,7 @@ func (nsc *NetworkServicesController) handleServiceDelete(obj interface{}) {
 // NewNetworkServicesController returns NetworkServicesController object
 func NewNetworkServicesController(clientset kubernetes.Interface,
 	config *options.KubeRouterConfig, svcInformer cache.SharedIndexInformer,
-	epInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer) (*NetworkServicesController, error) {
+	epInformer cache.SharedIndexInformer, podInformer cache.Indexer) (*NetworkServicesController, error) {
 
 	var err error
 	ln, err := newLinuxNetworking()
@@ -2543,7 +2543,7 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 	}
 	nsc.nodeIP = NodeIP
 
-	nsc.podLister = podInformer.GetIndexer()
+	nsc.podLister = podInformer
 
 	nsc.svcLister = svcInformer.GetIndexer()
 	nsc.ServiceEventHandler = nsc.newSvcEventHandler()

--- a/pkg/utils/custom_pod_informer.go
+++ b/pkg/utils/custom_pod_informer.go
@@ -1,0 +1,101 @@
+package utils
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewCustomPodInformer is custom controller https://github.com/kubernetes/client-go/blob/master/tools/cache/controller.go
+// to provide alternate pod informer https://github.com/kubernetes/client-go/blob/master/informers/core/v1/pod.go
+// which persist pod object in the cache with just enough information required for kube-router
+func NewCustomPodInformer(client kubernetes.Interface, h cache.ResourceEventHandler) (cache.Indexer, cache.Controller) {
+	clientState := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	lw := cache.NewListWatchFromClient(client.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything())
+	fifo := cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, clientState)
+	cfg := &cache.Config{
+		Queue:            fifo,
+		ListerWatcher:    lw,
+		ObjectType:       &v1.Pod{},
+		FullResyncPeriod: 0,
+		RetryOnError:     false,
+
+		Process: func(obj interface{}) error {
+			for _, d := range obj.(cache.Deltas) {
+				var obj interface{}
+				obj = convertToCustomPod(d.Object)
+				switch d.Type {
+				case cache.Sync, cache.Added, cache.Updated:
+					if old, exists, err := clientState.Get(obj); err == nil && exists {
+						if err := clientState.Update(obj); err != nil {
+							return err
+						}
+						h.OnUpdate(old, obj)
+					} else {
+						if err := clientState.Add(obj); err != nil {
+							return err
+						}
+						h.OnAdd(obj)
+					}
+				case cache.Deleted:
+					if err := clientState.Delete(obj); err != nil {
+						return err
+					}
+					h.OnDelete(obj)
+				}
+			}
+			return nil
+		},
+	}
+	return clientState, cache.New(cfg)
+}
+
+// convertToCustomPod stores a stripped down version of pod with just
+// enough details needed for kube-router
+func convertToCustomPod(obj interface{}) interface{} {
+	switch concreteObj := obj.(type) {
+	case *v1.Pod:
+		p := &v1.Pod{
+			TypeMeta: concreteObj.TypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            concreteObj.Name,
+				Namespace:       concreteObj.Namespace,
+				ResourceVersion: concreteObj.ResourceVersion,
+			},
+			Status: v1.PodStatus{
+				Phase:  concreteObj.Status.Phase,
+				HostIP: concreteObj.Status.HostIP,
+				PodIP:  concreteObj.Status.PodIP,
+			},
+		}
+		*concreteObj = v1.Pod{}
+		return p
+	case cache.DeletedFinalStateUnknown:
+		pod, ok := concreteObj.Obj.(*v1.Pod)
+		if !ok {
+			return obj
+		}
+		dfsu := cache.DeletedFinalStateUnknown{
+			Key: concreteObj.Key,
+			Obj: &v1.Pod{
+				TypeMeta: pod.TypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            pod.Name,
+					Namespace:       pod.Namespace,
+					ResourceVersion: pod.ResourceVersion,
+				},
+				Status: v1.PodStatus{
+					Phase:  pod.Status.Phase,
+					HostIP: pod.Status.HostIP,
+					PodIP:  pod.Status.PodIP,
+				},
+			},
+		}
+		*pod = v1.Pod{}
+		return dfsu
+	default:
+		return obj
+	}
+}

--- a/pkg/utils/custom_pod_informer.go
+++ b/pkg/utils/custom_pod_informer.go
@@ -14,7 +14,10 @@ import (
 func NewCustomPodInformer(client kubernetes.Interface, h cache.ResourceEventHandler) (cache.Indexer, cache.Controller) {
 	clientState := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	lw := cache.NewListWatchFromClient(client.CoreV1().RESTClient(), "pods", v1.NamespaceAll, fields.Everything())
-	fifo := cache.NewDeltaFIFO(cache.MetaNamespaceKeyFunc, clientState)
+	fifo := cache.NewDeltaFIFOWithOptions(cache.DeltaFIFOOptions{
+		KeyFunction:  cache.MetaNamespaceKeyFunc,
+		KnownObjects: clientState,
+	})
 	cfg := &cache.Config{
 		Queue:            fifo,
 		ListerWatcher:    lw,


### PR DESCRIPTION
Adds a custom pod informer to reduce the memory footprint of storing full detailed pod objects returned by client-go pod informer. stripped down pod object with just enough details needed for kube-router is store in the cache

In fairly large cluster with > 800 nodes and with 15K pods, it is observed that client-go's [pod informer](https://github.com/kubernetes/client-go/blob/master/informers/core/v1/pod.go) takes about > 200MB just to store the pod objects in local cache. Also there seems to be unbounded memory growth as reported in https://github.com/kubernetes/client-go/issues/871

Also see https://github.com/kubernetes/client-go/issues/832, there is metadat informer but kube-router needs additional details of the pod from pod's `Status` so can not be used.
