### PR TITLE
remove deprecated netpol beta API support

### DIFF
--- a/pkg/controllers/netpol/namespace.go
+++ b/pkg/controllers/netpol/namespace.go
@@ -34,7 +34,7 @@ func (npc *NetworkPolicyController) newNamespaceEventHandler() cache.ResourceEve
 }
 
 func (npc *NetworkPolicyController) handleNamespaceAdd(obj *api.Namespace) {
-	if npc.v1NetworkPolicy && obj.Labels == nil {
+	if obj.Labels == nil {
 		return
 	}
 	glog.V(2).Infof("Received update for namespace: %s", obj.Name)
@@ -43,7 +43,7 @@ func (npc *NetworkPolicyController) handleNamespaceAdd(obj *api.Namespace) {
 }
 
 func (npc *NetworkPolicyController) handleNamespaceUpdate(oldObj, newObj *api.Namespace) {
-	if npc.v1NetworkPolicy && reflect.DeepEqual(oldObj.Labels, newObj.Labels) {
+	if reflect.DeepEqual(oldObj.Labels, newObj.Labels) {
 		return
 	}
 	glog.V(2).Infof("Received update for namespace: %s", newObj.Name)
@@ -52,7 +52,7 @@ func (npc *NetworkPolicyController) handleNamespaceUpdate(oldObj, newObj *api.Na
 }
 
 func (npc *NetworkPolicyController) handleNamespaceDelete(obj *api.Namespace) {
-	if npc.v1NetworkPolicy && obj.Labels == nil {
+	if obj.Labels == nil {
 		return
 	}
 	glog.V(2).Infof("Received namespace: %s delete event", obj.Name)

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -63,7 +63,6 @@ type NetworkPolicyController struct {
 	mu                      sync.Mutex
 	syncPeriod              time.Duration
 	MetricsEnabled          bool
-	v1NetworkPolicy         bool
 	healthChan              chan<- *healthcheck.ControllerHeartbeat
 	fullSyncRequestChan     chan struct{}
 
@@ -356,19 +355,10 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 	// ensure kube-router specific top level chains and corresponding rules exist
 	npc.ensureTopLevelChains()
 
-	if npc.v1NetworkPolicy {
-		networkPoliciesInfo, err = npc.buildNetworkPoliciesInfo()
-		if err != nil {
-			glog.Errorf("Aborting sync. Failed to build network policies: %v", err.Error())
-			return
-		}
-	} else {
-		// TODO remove the Beta support
-		networkPoliciesInfo, err = npc.buildBetaNetworkPoliciesInfo()
-		if err != nil {
-			glog.Errorf("Aborting sync. Failed to build network policies: %v", err.Error())
-			return
-		}
+	networkPoliciesInfo, err = npc.buildNetworkPoliciesInfo()
+	if err != nil {
+		glog.Errorf("Aborting sync. Failed to build network policies: %v", err.Error())
+		return
 	}
 
 	activePolicyChains, activePolicyIPSets, err := npc.syncNetworkPolicyChains(networkPoliciesInfo, syncVersion)
@@ -1550,67 +1540,6 @@ func (npc *NetworkPolicyController) grabNamedPortFromPod(pod *api.Pod, namedPort
 	}
 }
 
-func (npc *NetworkPolicyController) buildBetaNetworkPoliciesInfo() ([]networkPolicyInfo, error) {
-
-	NetworkPolicies := make([]networkPolicyInfo, 0)
-
-	for _, policyObj := range npc.npLister.List() {
-
-		policy, _ := policyObj.(*apiextensions.NetworkPolicy)
-		podSelector, _ := v1.LabelSelectorAsSelector(&policy.Spec.PodSelector)
-		newPolicy := networkPolicyInfo{
-			name:        policy.Name,
-			namespace:   policy.Namespace,
-			podSelector: podSelector,
-		}
-		matchingPods, err := npc.ListPodsByNamespaceAndLabels(policy.Namespace, podSelector)
-		newPolicy.targetPods = make(map[string]podInfo)
-		newPolicy.ingressRules = make([]ingressRule, 0)
-		namedPort2IngressEps := make(namedPort2eps)
-		if err == nil {
-			for _, matchingPod := range matchingPods {
-				if matchingPod.Status.PodIP == "" {
-					continue
-				}
-				newPolicy.targetPods[matchingPod.Status.PodIP] = podInfo{ip: matchingPod.Status.PodIP,
-					name:      matchingPod.ObjectMeta.Name,
-					namespace: matchingPod.ObjectMeta.Namespace,
-					labels:    matchingPod.ObjectMeta.Labels}
-				npc.grabNamedPortFromPod(matchingPod, &namedPort2IngressEps)
-			}
-		}
-
-		for _, specIngressRule := range policy.Spec.Ingress {
-			ingressRule := ingressRule{}
-
-			ingressRule.ports = make([]protocolAndPort, 0)
-			ingressRule.namedPorts = make([]endPoints, 0)
-			ingressRule.ports, ingressRule.namedPorts = npc.processBetaNetworkPolicyPorts(specIngressRule.Ports, namedPort2IngressEps)
-			ingressRule.srcPods = make([]podInfo, 0)
-			for _, peer := range specIngressRule.From {
-				podSelector, _ := v1.LabelSelectorAsSelector(peer.PodSelector)
-				matchingPods, err := npc.ListPodsByNamespaceAndLabels(policy.Namespace, podSelector)
-				if err == nil {
-					for _, matchingPod := range matchingPods {
-						if matchingPod.Status.PodIP == "" {
-							continue
-						}
-						ingressRule.srcPods = append(ingressRule.srcPods,
-							podInfo{ip: matchingPod.Status.PodIP,
-								name:      matchingPod.ObjectMeta.Name,
-								namespace: matchingPod.ObjectMeta.Namespace,
-								labels:    matchingPod.ObjectMeta.Labels})
-					}
-				}
-			}
-			newPolicy.ingressRules = append(newPolicy.ingressRules, ingressRule)
-		}
-		NetworkPolicies = append(NetworkPolicies, newPolicy)
-	}
-
-	return NetworkPolicies, nil
-}
-
 func podFirewallChainName(namespace, podName string, version string) string {
 	hash := sha256.Sum256([]byte(namespace + podName + version))
 	encoded := base32.StdEncoding.EncodeToString(hash[:])
@@ -1906,15 +1835,6 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	}
 
 	npc.syncPeriod = config.IPTablesSyncPeriod
-
-	npc.v1NetworkPolicy = true
-	v, _ := clientset.Discovery().ServerVersion()
-	valid := regexp.MustCompile("[0-9]")
-	v.Minor = strings.Join(valid.FindAllString(v.Minor, -1), "")
-	minorVer, _ := strconv.Atoi(v.Minor)
-	if v.Major == "1" && minorVer < 7 {
-		npc.v1NetworkPolicy = false
-	}
 
 	node, err := utils.GetNodeObject(clientset, config.HostnameOverride)
 	if err != nil {

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -24,7 +24,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	api "k8s.io/api/core/v1"
-	apiextensions "k8s.io/api/extensions/v1beta1"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -1253,26 +1252,6 @@ func (npc *NetworkPolicyController) getEgressNetworkPolicyEnabledPods(networkPol
 }
 
 func (npc *NetworkPolicyController) processNetworkPolicyPorts(npPorts []networking.NetworkPolicyPort, namedPort2eps namedPort2eps) (numericPorts []protocolAndPort, namedPorts []endPoints) {
-	numericPorts, namedPorts = make([]protocolAndPort, 0), make([]endPoints, 0)
-	for _, npPort := range npPorts {
-		if npPort.Port == nil {
-			numericPorts = append(numericPorts, protocolAndPort{port: "", protocol: string(*npPort.Protocol)})
-		} else if npPort.Port.Type == intstr.Int {
-			numericPorts = append(numericPorts, protocolAndPort{port: npPort.Port.String(), protocol: string(*npPort.Protocol)})
-		} else {
-			if protocol2eps, ok := namedPort2eps[npPort.Port.String()]; ok {
-				if numericPort2eps, ok := protocol2eps[string(*npPort.Protocol)]; ok {
-					for _, eps := range numericPort2eps {
-						namedPorts = append(namedPorts, *eps)
-					}
-				}
-			}
-		}
-	}
-	return
-}
-
-func (npc *NetworkPolicyController) processBetaNetworkPolicyPorts(npPorts []apiextensions.NetworkPolicyPort, namedPort2eps namedPort2eps) (numericPorts []protocolAndPort, namedPorts []endPoints) {
 	numericPorts, namedPorts = make([]protocolAndPort, 0), make([]endPoints, 0)
 	for _, npPort := range npPorts {
 		if npPort.Port == nil {

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -189,7 +189,6 @@ func newUneventfulNetworkPolicyController(podInformer cache.SharedIndexInformer,
 	npc := NetworkPolicyController{}
 	npc.syncPeriod = time.Hour
 
-	npc.v1NetworkPolicy = true
 	npc.nodeHostName = "node"
 	npc.nodeIP = net.IPv4(10, 10, 10, 10)
 	npc.podLister = podInformer.GetIndexer()


### PR DESCRIPTION
Cleaning up the network policy code

NetworkPolicy in the extensions/v1beta1 API version is no longer served
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/