### PR TITLE
Improve the examples

### DIFF
--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -9,19 +9,27 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
-       "name":"mynet",
-       "plugins":[
-          {
-             "name":"kubernetes",
-             "type":"bridge",
-             "bridge":"kube-bridge",
-             "isDefaultGateway":true,
-             "ipam":{
-                "type":"host-local"
-             }
+      "cniVersion":"0.3.0",
+      "name":"mynet",
+      "plugins":[
+        {
+          "name":"kubernetes",
+          "type":"bridge",
+          "bridge":"kube-bridge",
+          "isDefaultGateway":true,
+          "ipam":{
+            "type":"host-local"
           }
-       ]
+        },
+        {
+          "type":"portmap",
+          "conditionsV4": ["!", "-d", "10.43.0.0/16"],
+          "capabilities":{
+            "snat": true,
+            "portMappings":true
+          }
+        }
+      ]
     }
   kubeconfig: |
     apiVersion: v1
@@ -75,6 +83,7 @@ spec:
         - "--run-service-proxy=true"
         - "--bgp-graceful-restart=true"
         - "--kubeconfig=/var/lib/kube-router/kubeconfig"
+        - "--nodeport-bindon-all-ip"
         env:
         - name: NODE_NAME
           valueFrom:

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -80,6 +80,9 @@ spec:
       labels:
         k8s-app: kube-router
         tier: node
+      annotations:
+        prometheus.io/port: '20245'
+        prometheus.io/scrape: 'true'
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
@@ -93,6 +96,7 @@ spec:
         - "--run-service-proxy=true"
         - "--bgp-graceful-restart=true"
         - "--nodeport-bindon-all-ip"
+        - "--metrics-port=20245"
         - "--kubeconfig=/etc/kube-router/kubeconfig"
         env:
         - name: NODE_NAME

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -1,3 +1,12 @@
+# - Replace 10.43.0.0/16 with your service CIDR in the portmap cni plugin
+# - Replace 10.42.0.0/16 with your cluster CIDR in the kubeconfig
+# - Replace https://localhost:6443 with a hostname where kubernetes is accessible. This
+#   hostname must not be a service within the cluster as kube-router needs to access
+#   it before any service route is set up.
+# - For production use, you might want to use a fix version when pulling the docker image
+#   image: docker.io/cloudnativelabs/kube-router:v1.1.1
+#   imagePullPolicy: Always
+#
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,15 +40,16 @@ data:
         }
       ]
     }
+
   kubeconfig: |
     apiVersion: v1
     kind: Config
-    clusterCIDR: "%CLUSTERCIDR%"
+    clusterCIDR: "10.42.0.0/16"
     clusters:
     - name: cluster
       cluster:
         certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        server: %APISERVER%
+        server: https://localhost:6443
     users:
     - name: kube-router
       user:
@@ -82,8 +92,8 @@ spec:
         - "--run-firewall=true"
         - "--run-service-proxy=true"
         - "--bgp-graceful-restart=true"
-        - "--kubeconfig=/var/lib/kube-router/kubeconfig"
         - "--nodeport-bindon-all-ip"
+        - "--kubeconfig=/etc/kube-router/kubeconfig"
         env:
         - name: NODE_NAME
           valueFrom:
@@ -109,8 +119,8 @@ spec:
           readOnly: true
         - name: cni-conf-dir
           mountPath: /etc/cni/net.d
-        - name: kubeconfig
-          mountPath: /var/lib/kube-router
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
           readOnly: true
         - name: xtables-lock
           mountPath: /run/xtables.lock
@@ -131,18 +141,11 @@ spec:
             cp /etc/kube-router/cni-conf.json ${TMP};
             mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi;
-          if [ ! -f /var/lib/kube-router/kubeconfig ]; then
-            TMP=/var/lib/kube-router/.tmp-kubeconfig;
-            cp /etc/kube-router/kubeconfig ${TMP};
-            mv ${TMP} /var/lib/kube-router/kubeconfig;
-          fi
         volumeMounts:
-        - mountPath: /etc/cni/net.d
-          name: cni-conf-dir
-        - mountPath: /etc/kube-router
-          name: kube-router-cfg
-        - name: kubeconfig
-          mountPath: /var/lib/kube-router
+        - name: cni-conf-dir
+          mountPath: /etc/cni/net.d
+        - name: kube-router-cfg
+          mountPath: /etc/kube-router
       hostNetwork: true
       tolerations:
       - effect: NoSchedule
@@ -161,9 +164,6 @@ spec:
       - name: kube-router-cfg
         configMap:
           name: kube-router-cfg
-      - name: kubeconfig
-        hostPath:
-          path: /var/lib/kube-router
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
@@ -211,6 +211,7 @@ rules:
       - get
       - list
       - watch
+
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -137,10 +137,10 @@ spec:
             if [ -f /etc/cni/net.d/*.conf ]; then
               rm -f /etc/cni/net.d/*.conf;
             fi;
-            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
-            cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
           fi;
+          TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
+          cp /etc/kube-router/cni-conf.json ${TMP};
+          mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
         volumeMounts:
         - name: cni-conf-dir
           mountPath: /etc/cni/net.d

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -273,7 +273,7 @@ kubectl annotate service my-service "kube-router.io/service.scheduler=dh"
 If you would like to use `HostPort` functionality below changes are required in the manifest.
 
 - By default kube-router assumes CNI conf file to be `/etc/cni/net.d/10-kuberouter.conf`. Add an environment variable `KUBE_ROUTER_CNI_CONF_FILE` to kube-router manifest and set it to `/etc/cni/net.d/10-kuberouter.conflist`
-- Modify `kube-router-cfg` ConfigMap with CNI config that supports `portmap` as additional plug-in
+- Modify `kube-router-cfg` ConfigMap with CNI config that supports `portmap` as additional plug-in. Please modify the `10.43.0.0/16` to represent your service CIDR.
 ```
     {
        "cniVersion":"0.3.0",
@@ -290,6 +290,7 @@ If you would like to use `HostPort` functionality below changes are required in 
           },
           {
              "type":"portmap",
+             "conditionsV4": ["!", "-d", "10.43.0.0/16"],
              "capabilities":{
                 "snat":true,
                 "portMappings":true


### PR DESCRIPTION
While setting up kube-router on k3s, I ran into some issues with the `portmap` cni plugin as it blocked traffic against service ips which had used a same port that's exposed in the hostPort declaration itself.
I've extended the configuration to fix that.


I've also simplified the mount of the kubeconfig and the default address of the kubernetes host: `localhost:6443`.
On k3s that address will work out of the box as they expose a proxy on all the hosts. It will also work on kubernetes masters of other distributions.

Then I've also extended the example with some prometheus annotation.

Please let me know if you want to apply the same changes to some other files... but this could also be done in another PR.