### PR TITLE
making IPIP/tunnel independent of override-nexthop config

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -560,9 +560,8 @@ out:
 	}
 
 	// create IPIP tunnels only when node is not in same subnet or overlay-type is set to 'full'
-	// prevent creation when --override-nextHop=true as well
 	// if the user has disabled overlays, don't create tunnels
-	if (!sameSubnet || nrc.overlayType == "full") && !nrc.overrideNextHop && nrc.enableOverlays {
+	if (!sameSubnet || nrc.overlayType == "full") && nrc.enableOverlays {
 		// create ip-in-ip tunnel and inject route as overlay is enabled
 		var link netlink.Link
 		var err error


### PR DESCRIPTION
Since the IPIP/tennel and the override-nexthop have their own parameters to enable/disable. we should make these two setting independent of each other. This is to support the case that have multiple group of nodes in different group of nodes while each node also need to peer with multiple upsteam BGP routers.

The initial depedency/restriction was introduce by https://github.com/cloudnativelabs/kube-router/pull/518. the reason/context/rational behind is lost. A solution should be proposed to fix any potential issue if there is any, instead of limiting the features. 