### PR TITLE
It appears as though this line is no longer relevant

### DIFF
--- a/docs/bgp.md
+++ b/docs/bgp.md
@@ -14,7 +14,6 @@ the cluster).  There is no configuration required in this mode. All the nodes in
 the cluster are associated with private ASN 64512 implicitly (which can be
 configured with `--cluster-asn` flag). Users are transparent to use of iBGP.
 This mode is suitable in public cloud environments or small cluster deployments.
-In this mode all the nodes are expected to be L2 adjacent.
 
 ### Node-To-Node Peering Without Full Mesh
 


### PR DESCRIPTION
As a result of the work added in https://github.com/cloudnativelabs/kube-router/pull/106, nodes that are not layer 2 adjacent will use IPIP tunnels to communicate to each other. While testing a cluster spanning multiple networks, I found that things worked properly, but was concerned about this line in the docs. Looking at git history, this line predates kube-router's ability to run across multiple networks using IPIP tunnels. I suspect this line is no longer correct, and should be removed from the docs.