### PR TITLE
metrics: Add build_info metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ ifeq "$(BUILD_IN_DOCKER)" "true"
 	$(DOCKER) run -v $(PWD):/go/src/github.com/cloudnativelabs/kube-router -w /go/src/github.com/cloudnativelabs/kube-router $(DOCKER_BUILD_IMAGE) \
 	    sh -c ' \
 	    GOARCH=$(GOARCH) CGO_ENABLED=0 go build -mod vendor \
-		-ldflags "-X github.com/cloudnativelabs/kube-router/pkg/cmd.version=$(GIT_COMMIT) -X github.com/cloudnativelabs/kube-router/pkg/cmd.buildDate=$(BUILD_DATE)" \
+		-ldflags "-X github.com/cloudnativelabs/kube-router/pkg/version.Version=$(GIT_COMMIT) -X github.com/cloudnativelabs/kube-router/pkg/version.BuildDate=$(BUILD_DATE)" \
 		-o kube-router cmd/kube-router/kube-router.go'
 	@echo Finished kube-router binary build.
 else

--- a/cmd/kube-router/kube-router.go
+++ b/cmd/kube-router/kube-router.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cloudnativelabs/kube-router/pkg/cmd"
 	"github.com/cloudnativelabs/kube-router/pkg/options"
+	"github.com/cloudnativelabs/kube-router/pkg/version"
 	"github.com/spf13/pflag"
 )
 
@@ -47,7 +48,7 @@ func Main() error {
 	}
 
 	if config.Version {
-		cmd.PrintVersion(false)
+		version.PrintVersion(false)
 		return nil
 	}
 

--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/signal"
-	"runtime"
 	"sync"
 	"syscall"
 
@@ -15,6 +13,7 @@ import (
 	"github.com/cloudnativelabs/kube-router/pkg/healthcheck"
 	"github.com/cloudnativelabs/kube-router/pkg/metrics"
 	"github.com/cloudnativelabs/kube-router/pkg/options"
+	"github.com/cloudnativelabs/kube-router/pkg/version"
 	"github.com/golang/glog"
 
 	"time"
@@ -24,10 +23,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
-
-// These get set at build time via -ldflags magic
-var version string
-var buildDate string
 
 // KubeRouter holds the information needed to run server
 type KubeRouter struct {
@@ -40,7 +35,7 @@ func NewKubeRouterDefault(config *options.KubeRouterConfig) (*KubeRouter, error)
 
 	var clientconfig *rest.Config
 	var err error
-	PrintVersion(true)
+	version.PrintVersion(true)
 	// Use out of cluster config if the URL or kubeconfig have been specified. Otherwise use incluster config.
 	if len(config.Master) != 0 || len(config.Kubeconfig) != 0 {
 		clientconfig, err = clientcmd.BuildConfigFromFlags(config.Master, config.Kubeconfig)
@@ -219,15 +214,5 @@ func (kr *KubeRouter) CacheSyncOrTimeout(informerFactory informers.SharedInforme
 		return errors.New(kr.Config.CacheSyncTimeout.String() + " timeout")
 	case <-syncOverCh:
 		return nil
-	}
-}
-
-func PrintVersion(logOutput bool) {
-	output := fmt.Sprintf("Running %v version %s, built on %s, %s\n", os.Args[0], version, buildDate, runtime.Version())
-
-	if !logOutput {
-		fmt.Fprintf(os.Stderr, "%s", output)
-	} else {
-		glog.Info(output)
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,23 @@
+package version
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/golang/glog"
+)
+
+// Version and BuildDate are injected at build time via ldflags
+var Version string
+var BuildDate string
+
+func PrintVersion(logOutput bool) {
+	output := fmt.Sprintf("Running %v version %s, built on %s, %s\n", os.Args[0], Version, BuildDate, runtime.Version())
+
+	if !logOutput {
+		fmt.Fprintf(os.Stderr, "%s", output)
+	} else {
+		glog.Info(output)
+	}
+}


### PR DESCRIPTION
This should add build_info metrics that can be consumed by prometheus to identify which version of kube-router is running.