### PR TITLE
use iptables-save and iptables-restore for npc sync

### DIFF
--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -151,6 +151,13 @@ func (kr *KubeRouter) Run() error {
 
 		wg.Add(1)
 		go nrc.Run(healthChan, stopCh, &wg)
+
+		// wait for the pod networking related firewall rules to be setup before network policies
+		if kr.Config.RunFirewall {
+			nrc.CNIFirewallSetup.L.Lock()
+			nrc.CNIFirewallSetup.Wait()
+			nrc.CNIFirewallSetup.L.Unlock()
+		}
 	}
 
 	if kr.Config.RunServiceProxy {

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -208,6 +208,8 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		endTime := time.Since(start)
 		if npc.MetricsEnabled {
 			metrics.ControllerIptablesSyncTime.Observe(endTime.Seconds())
+			metrics.ControllerIptablesSyncTotalTime.Add(endTime.Seconds())
+			metrics.ControllerIptablesSyncTotalCount.Add(1)
 		}
 		glog.V(1).Infof("sync iptables took %v", endTime)
 	}()
@@ -633,6 +635,8 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 		//Register the metrics for this controller
 		prometheus.MustRegister(metrics.ControllerIptablesSyncTime)
 		prometheus.MustRegister(metrics.ControllerPolicyChainsSyncTime)
+		prometheus.MustRegister(metrics.ControllerIptablesSyncTotalTime)
+		prometheus.MustRegister(metrics.ControllerIptablesSyncTotalCount)
 		npc.MetricsEnabled = true
 	}
 

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -247,7 +247,6 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		return
 	}
 
-	fmt.Println(npc.filterTableRules.String())
 	if err := utils.Restore("filter", npc.filterTableRules.Bytes()); err != nil {
 		glog.Errorf("Aborting sync. Failed to run iptables-restore: %v" + err.Error())
 		return
@@ -651,16 +650,6 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 		return nil, err
 	}
 	npc.nodeIP = nodeIP
-
-	ipset, err := utils.NewIPSet(false)
-	if err != nil {
-		return nil, err
-	}
-	err = ipset.Save()
-	if err != nil {
-		return nil, err
-	}
-	npc.ipSetHandler = ipset
 
 	npc.podLister = podInformer.GetIndexer()
 	npc.PodEventHandler = npc.newPodEventHandler()

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -64,6 +64,10 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 		// add rule to log the packets that will be dropped due to network policy enforcement
 		comment := "\"rule to log dropped traffic POD name:" + podName + " namespace: " + podNamespace + "\""
 		args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment, "-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "NFLOG", "--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10", "\n"}
+		// This used to be AppendUnique when we were using iptables directly, this checks to make sure we didn't drop unmarked for this chain already
+		if strings.Contains(npc.filterTableRules.String(), strings.Join(args, " ")) {
+			return nil
+		}
 		npc.filterTableRules.WriteString(strings.Join(args, " "))
 
 		// add rule to DROP if no applicable network policy permits the traffic

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -131,7 +131,7 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 		// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
 		// this rule applies to the traffic getting switched (coming for same node pods)
 		comment = "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
-			" to chain " + podFwChainName + "\n"
+			" to chain " + podFwChainName + "\""
 		args = []string{"-I", kubeForwardChainName, "1", "-m", "physdev", "--physdev-is-bridged",
 			"-m", "comment", "--comment", comment,
 			"-d", pod.ip,
@@ -167,7 +167,7 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 		// add entries in pod firewall to run through required network policies
 		for _, policy := range networkPoliciesInfo {
 			if _, ok := policy.targetPods[pod.ip]; ok {
-				comment := "\"run through nw policy " + policy.name + "\n"
+				comment := "\"run through nw policy " + policy.name + "\""
 				policyChainName := networkPolicyChainName(policy.namespace, policy.name, version)
 				args := []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment, "-j", policyChainName, "\n"}
 				npc.filterTableRules.WriteString(strings.Join(args, " "))

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -100,6 +100,18 @@ var (
 		Name:      "controller_iptables_sync_time",
 		Help:      "Time it took for controller to sync iptables",
 	})
+	// ControllerIptablesSyncTotalTime Time it took for controller to sync iptables
+	ControllerIptablesSyncTotalTime = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "controller_iptables_sync_total_time",
+		Help:      "Time it took for controller to sync iptables as a counter",
+	})
+	// ControllerIptablesSyncTotalCount Number of times the controller synced iptables for individual pods
+	ControllerIptablesSyncTotalCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Name:      "controller_iptables_sync_total_count",
+		Help:      "Total number of times kube-router synced iptables",
+	})
 	// ControllerIpvsServicesSyncTime Time it took for controller to sync ipvs services
 	ControllerIpvsServicesSyncTime = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: namespace,

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -222,11 +222,11 @@ func (ipset *IPSet) Add(set *Set) error {
 }
 
 // RefreshSet add/update internal Sets with a Set of entries but does not run restore command
-func (ipset *IPSet) RefreshSet(setName string, entriesWithOptions [][]string) {
+func (ipset *IPSet) RefreshSet(setName string, entriesWithOptions [][]string, setType string) {
 	if ipset.Get(setName) == nil {
 		ipset.Sets[setName] = &Set{
 			Name:    setName,
-			Options: []string{TypeHashIP, OptionTimeout, "0"},
+			Options: []string{setType, OptionTimeout, "0"},
 			Parent:  ipset,
 		}
 	}

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -221,6 +221,22 @@ func (ipset *IPSet) Add(set *Set) error {
 	return nil
 }
 
+// RefreshSet add/update internal Sets with a Set of entries but does not run restore command
+func (ipset *IPSet) RefreshSet(setName string, entriesWithOptions [][]string) {
+	if ipset.Get(setName) == nil {
+		ipset.Sets[setName] = &Set{
+			Name:    setName,
+			Options: []string{TypeHashIP, OptionTimeout, "0"},
+			Parent:  ipset,
+		}
+	}
+	entries := make([]*Entry, len(entriesWithOptions))
+	for i, entry := range entriesWithOptions {
+		entries[i] = &Entry{Set: ipset.Sets[setName], Options: entry}
+	}
+	ipset.Get(setName).Entries = entries
+}
+
 // Add a given entry to the set. If the -exist option is specified, ipset
 // ignores if the entry already added to the set.
 // Note: if you need to add multiple entries (e.g., in a loop), use BatchAdd instead,

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -403,6 +403,7 @@ func buildIPSetRestore(ipset *IPSet) string {
 	ipSetRestore := ""
 	for _, set := range ipset.Sets {
 		ipSetRestore += fmt.Sprintf("create %s %s\n", set.Name, strings.Join(set.Options[:], " "))
+		ipSetRestore += fmt.Sprintf("flush %s\n", set.Name)
 		for _, entry := range set.Entries {
 			ipSetRestore += fmt.Sprintf("add %s %s\n", set.Name, strings.Join(entry.Options[:], " "))
 		}

--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+)
+
+// SaveInto calls `iptables-save` for given table and stores result in a given buffer.
+func SaveInto(table string, buffer *bytes.Buffer) error {
+	path, err := exec.LookPath("iptables-save")
+	if err != nil {
+		return err
+	}
+	stderrBuffer := bytes.NewBuffer(nil)
+	args := []string{"iptables-save", "-t", table}
+	cmd := exec.Cmd{
+		Path:   path,
+		Args:   args,
+		Stdout: buffer,
+		Stderr: stderrBuffer,
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%v (%s)", err, stderrBuffer)
+	}
+	return nil
+}
+
+// Restore runs `iptables-restore` passing data through []byte.
+func Restore(table string, data []byte) error {
+	path, err := exec.LookPath("iptables-restore")
+	if err != nil {
+		return err
+	}
+	args := []string{"iptables-restore", "-T", table}
+	cmd := exec.Cmd{
+		Path:  path,
+		Args:  args,
+		Stdin: bytes.NewBuffer(data),
+	}
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v (%s)", err, b)
+	}
+
+	return nil
+}


### PR DESCRIPTION
replace all individual iptables command that are run during full network policies sync into `iptables-save` and `iptables-restore`

This PR is intend to replace #1010

In #1010 I tried to refactor the code so that on pod add/delete/update kube-router performs iptables, ipset updates that are only constrained to corresponding pod. However after spendig time refactoring code it truned out it is not right approach.

In general kube-router should stick to `level-triggered` sync (Please see [1] [2]) i.e.) consider whole current state and desired state as a whole. 

Please use the image `cloudnativelabs/kube-router-git:amd64-iptables-save-restore` if any testing.

[1] https://speakerdeck.com/thockin/kubernetes-controllers-are-they-loops-or-events?slide=38
[2] https://speakerdeck.com/thockin/edge-vs-level-triggered-logic

