### PR TITLE
fix ipv6 eor conflict

### DIFF
--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -183,7 +183,7 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 }
 
 // connectToExternalBGPPeers adds all the configured eBGP peers (global or node specific) as neighbours// connectToExternalBGPPeers adds all the configured eBGP peers (global or node specific) as neighbours
-func connectToExternalBGPPeers(server *gobgp.BgpServer, peerNeighbors []*gobgpapi.Peer, bgpGracefulRestart bool, bgpGracefulRestartDeferralTime time.Duration,
+func connectToExternalBGPPeers(server *gobgp.BgpServer, peerNeighbors []*gobgpapi.Peer, bgpGracefulRestart bool, bgpGracefulRestartIpv6 bool, bgpGracefulRestartDeferralTime time.Duration,
 	bgpGracefulRestartTime time.Duration, peerMultihopTTL uint8) error {
 	for _, n := range peerNeighbors {
 
@@ -214,7 +214,7 @@ func connectToExternalBGPPeers(server *gobgp.BgpServer, peerNeighbors []*gobgpap
 					},
 					MpGracefulRestart: &gobgpapi.MpGracefulRestart{
 						Config: &gobgpapi.MpGracefulRestartConfig{
-							Enabled: true,
+							Enabled: bgpGracefulRestartIpv6,
 						},
 					},
 				},

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -92,6 +92,7 @@ type NetworkRoutingController struct {
 	bgpFullMeshMode                bool
 	bgpEnableInternal              bool
 	bgpGracefulRestart             bool
+	bgpGracefulRestartIpv6         bool
 	bgpGracefulRestartTime         time.Duration
 	bgpGracefulRestartDeferralTime time.Duration
 	ipSetHandler                   *utils.IPSet
@@ -957,7 +958,7 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 
 	if len(nrc.globalPeerRouters) != 0 {
 		err := connectToExternalBGPPeers(nrc.bgpServer, nrc.globalPeerRouters, nrc.bgpGracefulRestart,
-			nrc.bgpGracefulRestartDeferralTime, nrc.bgpGracefulRestartTime, nrc.peerMultihopTTL)
+			nrc.bgpGracefulRestartIpv6, nrc.bgpGracefulRestartDeferralTime, nrc.bgpGracefulRestartTime, nrc.peerMultihopTTL)
 		if err != nil {
 			err2 := nrc.bgpServer.StopBgp(context.Background(), &gobgpapi.StopBgpRequest{})
 			if err2 != nil {
@@ -998,6 +999,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	nrc.enableCNI = kubeRouterConfig.EnableCNI
 	nrc.bgpEnableInternal = kubeRouterConfig.EnableiBGP
 	nrc.bgpGracefulRestart = kubeRouterConfig.BGPGracefulRestart
+	nrc.bgpGracefulRestartIpv6 = kubeRouterConfig.BGPGracefulRestartIpv6
 	nrc.bgpGracefulRestartDeferralTime = kubeRouterConfig.BGPGracefulRestartDeferralTime
 	nrc.bgpGracefulRestartTime = kubeRouterConfig.BGPGracefulRestartTime
 	nrc.peerMultihopTTL = kubeRouterConfig.PeerMultihopTTL

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -18,6 +18,7 @@ type KubeRouterConfig struct {
 	AdvertiseNodePodCidr           bool
 	AutoMTU                        bool
 	BGPGracefulRestart             bool
+	BGPGracefulRestartIpv6         bool
 	BGPGracefulRestartDeferralTime time.Duration
 	BGPGracefulRestartTime         time.Duration
 	BGPHoldTime                    time.Duration
@@ -101,6 +102,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Auto detect and set the largest possible MTU for pod interfaces.")
 	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
+	fs.BoolVar(&s.BGPGracefulRestartIpv6, "bgp-graceful-restart-ipv6", true,
+		"Enables the BGP Graceful Restart capability for ipv6 so that routes are preserved on unexpected restarts")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time", s.BGPGracefulRestartDeferralTime,
 		"BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h.")
 	fs.DurationVar(&s.BGPGracefulRestartTime, "bgp-graceful-restart-time", s.BGPGracefulRestartTime,


### PR DESCRIPTION
This patch add an option to disable ipv6 configuration when bgp graceful restart is enabled in kube-router.

kube-router enable both ipv4-unicast and ipv6-unicast when bgp graceful restart is enabled. This can cause trouble when kube-router is peering with a switch without ipv6 enabled. According to **RFC 4724 4.1**:

>// Once the session between the Restarting Speaker and the Receiving
// Speaker is re-established, ...snip... it MUST defer route
// selection for an address family until it either (a) receives the 
// End-of-RIB marker from all its peers (excluding the ones with the 
// "Restart State" bit set in the received capability and excluding the 
// ones that do not advertise the graceful restart capability) or (b) 
// the Selection_Deferral_Timer referred to below has expired.

The switch without ipv6 enabled will fail to pass checks in condition (a) and kube-router will fall through to condition (b), that means it will wait until `Selection_Deferral_Timmer` timeout before it can send the first bgp update message, this is a big problem for system with high qos requirements. Following is the detail analysis:

we assume that:

1. kube-router is peering with a switch with ipv6 support disabled
2. bgp graceful restart is enabled in kube-router
 
check in `kube-router/vendor/github.com/osrg/gobgp/pkg/server/fsm.go:1382-1396` will faild to set GracefulRestart.State.Enabled of ipv6 route family to true:

```go
if fsm.pConf.GracefulRestart.Config.LongLivedEnabled && ok && ok2 {
    fsm.pConf.GracefulRestart.State.LongLivedEnabled = true
    cap := llgr[len(llgr)-1].(*bgp.CapLongLivedGracefulRestart)
    for _, t := range cap.Tuples {
        n := bgp.AddressFamilyNameMap[bgp.AfiSafiToRouteFamily(t.AFI, t.SAFI)]
        for i, a := range fsm.pConf.AfiSafis {
            if string(a.Config.AfiSafiName) == n {
                fsm.pConf.AfiSafis[i].LongLivedGracefulRestart.State.Enabled = true
                fsm.pConf.AfiSafis[i].LongLivedGracefulRestart.State.Received = true
                fsm.pConf.AfiSafis[i].LongLivedGracefulRestart.State.PeerRestartTime = t.RestartTime
                break               
            }
        }
    }
}
```

therefore the `p.recvedAllEOR()` check in `kube-router/vendor/github.com/osrg/gobgp/pkg/server/server.go:1485:1501` will fail:

```go
else {
// RFC 4724 4.1
// Once the session between the Restarting Speaker and the Receiving
// Speaker is re-established, ...snip... it MUST defer route
// selection for an address family until it either (a) receives the
// End-of-RIB marker from all its peers (excluding the ones with the
// "Restart State" bit set in the received capability and excluding the
// ones that do not advertise the graceful restart capability) or (b)
// the Selection_Deferral_Timer referred to below has expired.
allEnd := func() bool {
    for _, p := range s.neighborMap { 
        if !p.recvedAllEOR() {
            return false    
        }
    }
    return true
}()
```

thus kube-router will fall through to wait for the `Selection_Deferral_Timmer` to timeout.