### PR TITLE
Handle headless services

### DIFF
--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -258,11 +258,6 @@ func (nrc *NetworkRoutingController) OnEndpointsAdd(obj interface{}) {
 		return
 	}
 
-	err := nrc.AddPolicies()
-	if err != nil {
-		glog.Errorf("error adding BGP policies: %s", err)
-	}
-
 	nrc.OnEndpointsUpdate(obj)
 }
 

--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -197,6 +197,7 @@ func (nrc *NetworkRoutingController) tryHandleServiceDelete(obj interface{}, log
 			return
 		}
 	}
+	glog.V(1).Infof(logMsgFormat, svc.Namespace, svc.Name)
 
 	// If the service is headless skip processing as we only work with VIPs in the next section.
 	if utils.ServiceIsHeadless(obj) {

--- a/pkg/utils/service.go
+++ b/pkg/utils/service.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	v1core "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func ServiceForEndpoints(ci *cache.Indexer, ep *v1core.Endpoints) (interface{}, error) {
+	key, err := cache.MetaNamespaceKeyFunc(ep)
+	if err != nil {
+		return nil, err
+	}
+
+	item, exists, err := (*ci).GetByKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	if !exists {
+		return nil, fmt.Errorf("service resource doesn't exist for endpoints: %q", ep.Name)
+	}
+
+	return item, nil
+}
+
+// ServiceIsHeadless decides whether or not the this service is a headless service which is often useful to kube-router
+// as there is no need to execute logic on most headless changes. Function takes a generic interface as its input
+// parameter so that it can be used more easily in early processing if needed. If a non-service object is given,
+// function will return false.
+func ServiceIsHeadless(obj interface{}) bool {
+	if svc, _ := obj.(*v1core.Service); svc != nil {
+		if svc.Spec.Type == v1core.ServiceTypeClusterIP {
+			if ClusterIPIsNone(svc.Spec.ClusterIP) && containsOnlyNone(svc.Spec.ClusterIPs) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ClusterIPIsNone checks to see whether the ClusterIP contains "None" which would indicate that it is headless
+func ClusterIPIsNone(clusterIP string) bool {
+	return strings.ToLower(clusterIP) == "none"
+}
+
+func ClusterIPIsNoneOrBlank(clusterIP string) bool {
+	return ClusterIPIsNone(clusterIP) || clusterIP == ""
+}
+
+func containsOnlyNone(clusterIPs []string) bool {
+	for _, clusterIP := range clusterIPs {
+		if !ClusterIPIsNone(clusterIP) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Fixes #978 

The main purpose of this PR is to make the network_routes_controller and network_services_controller more performant by detecting when services (or related endpoints) are headless and stop processing early.

In both NRC and NSC we are only concerned with VIPs and endpoints related to those VIPs. Since headless services have neither we can save a lot of extra cycles if we catch creates, updates, and deletes of headless services and make them a noop.

This PR also:
* Adds some extra comments around confusing logic
* Removes a superfluous call to AddPolicies
* Adds the logging statement back to tryHandleServiceDelete