### PR TITLE
Provide PodCIDR range as argument

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -2515,7 +2515,7 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 	}
 
 	if config.RunRouter {
-		cidr, err := utils.GetPodCidrFromNodeSpec(nsc.client, config.HostnameOverride)
+		cidr, err := utils.GetPodCidrFromNodeSpec(nsc.client, config.HostnameOverride, config.PodCIDR)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get pod CIDR details from Node.spec: %s", err.Error())
 		}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -1057,7 +1057,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		}
 	}
 
-	cidr, err := utils.GetPodCidrFromNodeSpec(clientset, nrc.hostnameOverride)
+	cidr, err := utils.GetPodCidrFromNodeSpec(clientset, nrc.hostnameOverride, kubeRouterConfig.PodCIDR)
 	if err != nil {
 		glog.Fatalf("Failed to get pod CIDR from node spec. kube-router relies on kube-controller-manager to allocate pod CIDR for the node or an annotation `kube-router.io/pod-cidr`. Error: %v", err)
 		return nil, fmt.Errorf("Failed to get pod CIDR details from Node.spec: %s", err.Error())

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -69,6 +69,9 @@ type KubeRouterConfig struct {
 	Version                        bool
 	VLevel                         string
 	// FullMeshPassword    string
+
+	// Pelion additions
+	PodCIDR string
 }
 
 func NewKubeRouterConfig() *KubeRouterConfig {
@@ -196,4 +199,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVarP(&s.VLevel, "v", "v", "0", "log level for V logs")
 	fs.BoolVarP(&s.Version, "version", "V", false,
 		"Print version information.")
+
+	// Pelion addition
+	fs.StringVar(&s.PodCIDR, "pod-cidr", "",
+		"Specify the CIDR ranged used for pods, will override values fetched from kube-controller and Node annotation")
 }

--- a/pkg/utils/pod_cidr.go
+++ b/pkg/utils/pod_cidr.go
@@ -121,7 +121,12 @@ func InsertPodCidrInCniSpec(cniConfFilePath string, cidr string) error {
 }
 
 // GetPodCidrFromNodeSpec reads the pod CIDR allocated to the node from API node object and returns it
-func GetPodCidrFromNodeSpec(clientset kubernetes.Interface, hostnameOverride string) (string, error) {
+func GetPodCidrFromNodeSpec(clientset kubernetes.Interface, hostnameOverride, podCIDR string) (string, error) {
+	// Use podCIDR provided in argument
+	if podCIDR != "" {
+		return podCIDR, nil
+	}
+
 	node, err := GetNodeObject(clientset, hostnameOverride)
 	if err != nil {
 		return "", fmt.Errorf("Failed to get pod CIDR allocated for the node due to: " + err.Error())

--- a/pkg/utils/pod_cidr_test.go
+++ b/pkg/utils/pod_cidr_test.go
@@ -183,7 +183,7 @@ func Test_GetPodCidrFromNodeSpec(t *testing.T) {
 				t.Fatalf("failed to create existing nodes for test: %v", err)
 			}
 
-			podCIDR, err := GetPodCidrFromNodeSpec(clientset, testcase.hostnameOverride)
+			podCIDR, err := GetPodCidrFromNodeSpec(clientset, testcase.hostnameOverride, "")
 			if !reflect.DeepEqual(err, testcase.err) {
 				t.Logf("actual error: %v", err)
 				t.Logf("expected error: %v", testcase.err)


### PR DESCRIPTION
In addition to fetching the PodCIDR from apiserver or from Node annotation, provide the startup argument `--pod-cidr` which takes precedence over the other alternatives.