### PR TITLE
Set DSR TCPMSS Based on Link MTU

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -89,7 +89,7 @@ type netlinkCalls interface {
 	getKubeDummyInterface() (netlink.Link, error)
 	setupRoutesForExternalIPForDSR(serviceInfoMap) error
 	setupPolicyRoutingForDSR() error
-	cleanupMangleTableRule(ip string, protocol string, port string, fwmark string) error
+	cleanupMangleTableRule(ip string, protocol string, port string, fwmark string, tcpMSS int) error
 }
 
 // LinuxNetworking interface contains all linux networking subsystem calls
@@ -236,6 +236,7 @@ type NetworkServicesController struct {
 	gracefulTermination bool
 	syncChan            chan int
 	dsr                 *dsrOpt
+	dsrTCPMSS           int
 }
 
 // DSR related options
@@ -2025,8 +2026,8 @@ const (
 	externalIPRouteTableName = "external_ip"
 )
 
-// setupMangleTableRule: setsup iptables rule to FWMARK the traffic to exteranl IP vip
-func setupMangleTableRule(ip string, protocol string, port string, fwmark string) error {
+// setupMangleTableRule: sets up iptables rule to FWMARK the traffic to external IP vip
+func setupMangleTableRule(ip string, protocol string, port string, fwmark string, tcpMSS int) error {
 	iptablesCmdHandler, err := iptables.New()
 	if err != nil {
 		return errors.New("Failed to initialize iptables executor" + err.Error())
@@ -2042,7 +2043,8 @@ func setupMangleTableRule(ip string, protocol string, port string, fwmark string
 	}
 
 	// setup iptables rule TCPMSS for DSR mode to fix mtu problem
-	mtuArgs := []string{"-d", ip, "-m", "tcp", "-p", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", "1440"}
+	mtuArgs := []string{"-d", ip, "-m", "tcp", "-p", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS",
+		"--set-mss", strconv.Itoa(tcpMSS)}
 	err = iptablesCmdHandler.AppendUnique("mangle", "PREROUTING", mtuArgs...)
 	if err != nil {
 		return errors.New("Failed to run iptables command to set up TCPMSS due to " + err.Error())
@@ -2055,7 +2057,7 @@ func setupMangleTableRule(ip string, protocol string, port string, fwmark string
 	return nil
 }
 
-func (ln *linuxNetworking) cleanupMangleTableRule(ip string, protocol string, port string, fwmark string) error {
+func (ln *linuxNetworking) cleanupMangleTableRule(ip string, protocol string, port string, fwmark string, tcpMSS int) error {
 	iptablesCmdHandler, err := iptables.New()
 	if err != nil {
 		return errors.New("Failed to initialize iptables executor" + err.Error())
@@ -2083,7 +2085,8 @@ func (ln *linuxNetworking) cleanupMangleTableRule(ip string, protocol string, po
 	}
 
 	// cleanup iptables rule TCPMSS
-	mtuArgs := []string{"-d", ip, "-m", "tcp", "-p", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", "1440"}
+	mtuArgs := []string{"-d", ip, "-m", "tcp", "-p", "tcp", "--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS",
+		"--set-mss", strconv.Itoa(tcpMSS)}
 	exists, err = iptablesCmdHandler.Exists("mangle", "PREROUTING", mtuArgs...)
 	if err != nil {
 		return errors.New("Failed to cleanup iptables command to set up TCPMSS due to " + err.Error())
@@ -2536,6 +2539,14 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 		return nil, err
 	}
 	nsc.nodeIP = NodeIP
+	automtu, err := utils.GetMTUFromNodeIP(nsc.nodeIP, config.EnableOverlay)
+	if err != nil {
+		return nil, err
+	}
+	// Sets it to 20 bytes less than the auto-detected MTU to account for additional ip-ip headers needed for DSR, above
+	// method GetMTUFromNodeIP() already accounts for the overhead of ip-ip overlay networking, so we only need to
+	// remove 20 bytes
+	nsc.dsrTCPMSS = automtu - 20
 
 	nsc.podLister = podInformer.GetIndexer()
 

--- a/pkg/controllers/proxy/network_services_controller_moq.go
+++ b/pkg/controllers/proxy/network_services_controller_moq.go
@@ -82,7 +82,7 @@ var _ LinuxNetworking = &LinuxNetworkingMock{}
 // 	}
 type LinuxNetworkingMock struct {
 	// cleanupMangleTableRuleFunc mocks the cleanupMangleTableRule method.
-	cleanupMangleTableRuleFunc func(ip string, protocol string, port string, fwmark string) error
+	cleanupMangleTableRuleFunc func(ip string, protocol string, port string, fwmark string, tcpMSS int) error
 
 	// getKubeDummyInterfaceFunc mocks the getKubeDummyInterface method.
 	getKubeDummyInterfaceFunc func() (netlink.Link, error)
@@ -293,7 +293,7 @@ type LinuxNetworkingMock struct {
 }
 
 // cleanupMangleTableRule calls cleanupMangleTableRuleFunc.
-func (mock *LinuxNetworkingMock) cleanupMangleTableRule(ip string, protocol string, port string, fwmark string) error {
+func (mock *LinuxNetworkingMock) cleanupMangleTableRule(ip string, protocol string, port string, fwmark string, tcpMSS int) error {
 	if mock.cleanupMangleTableRuleFunc == nil {
 		panic("LinuxNetworkingMock.cleanupMangleTableRuleFunc: method is nil but LinuxNetworking.cleanupMangleTableRule was just called")
 	}
@@ -311,7 +311,7 @@ func (mock *LinuxNetworkingMock) cleanupMangleTableRule(ip string, protocol stri
 	mock.lockcleanupMangleTableRule.Lock()
 	mock.calls.cleanupMangleTableRule = append(mock.calls.cleanupMangleTableRule, callInfo)
 	mock.lockcleanupMangleTableRule.Unlock()
-	return mock.cleanupMangleTableRuleFunc(ip, protocol, port, fwmark)
+	return mock.cleanupMangleTableRuleFunc(ip, protocol, port, fwmark, tcpMSS)
 }
 
 // cleanupMangleTableRuleCalls gets all the calls that were made to cleanupMangleTableRule.

--- a/pkg/controllers/proxy/network_services_controller_test.go
+++ b/pkg/controllers/proxy/network_services_controller_test.go
@@ -74,7 +74,7 @@ func (lnm *LinuxNetworkingMockImpl) ipvsDelService(ipvsSvc *ipvs.Service) error 
 func (lnm *LinuxNetworkingMockImpl) ipvsGetDestinations(ipvsSvc *ipvs.Service) ([]*ipvs.Destination, error) {
 	return []*ipvs.Destination{}, nil
 }
-func (lnm *LinuxNetworkingMockImpl) cleanupMangleTableRule(ip string, protocol string, port string, fwmark string) error {
+func (lnm *LinuxNetworkingMockImpl) cleanupMangleTableRule(ip string, protocol string, port string, fwmark string, tcpMSS int) error {
 	return nil
 }
 

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -311,7 +311,7 @@ func (nsc *NetworkServicesController) setupExternalIPServices(serviceInfoMap ser
 				externalIPServiceID = fmt.Sprint(fwMark)
 
 				// ensure there is iptables mangle table rule to FWMARK the packet
-				err = setupMangleTableRule(externalIP, svc.protocol, strconv.Itoa(svc.port), externalIPServiceID)
+				err = setupMangleTableRule(externalIP, svc.protocol, strconv.Itoa(svc.port), externalIPServiceID, nsc.dsrTCPMSS)
 				if err != nil {
 					klog.Errorf("Failed to setup mangle table rule to FMWARD the traffic to external IP")
 					continue
@@ -355,7 +355,7 @@ func (nsc *NetworkServicesController) setupExternalIPServices(serviceInfoMap ser
 				fwMark := fmt.Sprint(fwmark)
 				for _, mangleTableRule := range mangleTableRules {
 					if strings.Contains(mangleTableRule, externalIP) && strings.Contains(mangleTableRule, fwMark) {
-						err = nsc.ln.cleanupMangleTableRule(externalIP, svc.protocol, strconv.Itoa(svc.port), fwMark)
+						err = nsc.ln.cleanupMangleTableRule(externalIP, svc.protocol, strconv.Itoa(svc.port), fwMark, nsc.dsrTCPMSS)
 						if err != nil {
 							klog.Errorf("Failed to verify and cleanup any mangle table rule to FMWARD the traffic to external IP due to " + err.Error())
 							continue

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -215,7 +215,7 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 	}
 
 	if nrc.autoMTU {
-		mtu, err := getMTUFromNodeIP(nrc.nodeIP, nrc.enableOverlays)
+		mtu, err := utils.GetMTUFromNodeIP(nrc.nodeIP, nrc.enableOverlays)
 		if err != nil {
 			klog.Errorf("Failed to find MTU for node IP: %s for intelligently setting the kube-bridge MTU due to %s.", nrc.nodeIP, err.Error())
 		}
@@ -373,7 +373,7 @@ func (nrc *NetworkRoutingController) updateCNIConfig() {
 }
 
 func (nrc *NetworkRoutingController) autoConfigureMTU() error {
-	mtu, err := getMTUFromNodeIP(nrc.nodeIP, nrc.enableOverlays)
+	mtu, err := utils.GetMTUFromNodeIP(nrc.nodeIP, nrc.enableOverlays)
 	if err != nil {
 		return fmt.Errorf("failed to generate MTU: %s", err.Error())
 	}

--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -109,29 +109,6 @@ func getNodeSubnet(nodeIP net.IP) (net.IPNet, string, error) {
 	return net.IPNet{}, "", errors.New("failed to find interface with specified node ip")
 }
 
-func getMTUFromNodeIP(nodeIP net.IP, overlayEnabled bool) (int, error) {
-	links, err := netlink.LinkList()
-	if err != nil {
-		return 0, errors.New("failed to get list of links")
-	}
-	for _, link := range links {
-		addresses, err := netlink.AddrList(link, netlink.FAMILY_ALL)
-		if err != nil {
-			return 0, errors.New("failed to get list of addr")
-		}
-		for _, addr := range addresses {
-			if addr.IPNet.IP.Equal(nodeIP) {
-				linkMTU := link.Attrs().MTU
-				if overlayEnabled {
-					return linkMTU - 20, nil // -20 to accommodate IPIP header
-				}
-				return linkMTU, nil
-			}
-		}
-	}
-	return 0, errors.New("failed to find interface with specified node ip")
-}
-
 // generateTunnelName will generate a name for a tunnel interface given a node IP
 // for example, if the node IP is 10.0.0.1 the tunnel interface will be named tun-10001
 // Since linux restricts interface names to 15 characters, if length of a node IP

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"os"
 
+	"github.com/vishvananda/netlink"
+
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -58,4 +60,28 @@ func GetNodeIP(node *apiv1.Node) (net.IP, error) {
 		return net.ParseIP(addresses[0].Address), nil
 	}
 	return nil, errors.New("host IP unknown")
+}
+
+// GetMTUFromNodeIP returns the MTU by detecting it from the IP on the node and figuring in tunneling configurations
+func GetMTUFromNodeIP(nodeIP net.IP, overlayEnabled bool) (int, error) {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return 0, errors.New("failed to get list of links")
+	}
+	for _, link := range links {
+		addresses, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+		if err != nil {
+			return 0, errors.New("failed to get list of addr")
+		}
+		for _, addr := range addresses {
+			if addr.IPNet.IP.Equal(nodeIP) {
+				linkMTU := link.Attrs().MTU
+				if overlayEnabled {
+					return linkMTU - 20, nil // -20 to accommodate IPIP header
+				}
+				return linkMTU, nil
+			}
+		}
+	}
+	return 0, errors.New("failed to find interface with specified node IP")
 }


### PR DESCRIPTION
Heavily based on #769, but replaces as #769 was based on kube-router's older code that set MTU statically. Since kube-router 1.1.X, we've had the ability to automatically set the MTU for kube-bridge based upon the primary interfaces MTU setting.

So, I moved `GetMTUFromNodeIP()` up a few layers and utilized the logic for figuring out how to set the TCPMSS.

Fixes #630 