### PR TITLE
Swap temporary IPSets during ipset restore

### DIFF
--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -80,6 +80,9 @@ const (
 	OptionNoMatch = "nomatch"
 	// OptionForceAdd All hash set types support the optional forceadd parameter when creating a set. When sets created with this option become full the next addition to the set may succeed and evict a random entry from the set.
 	OptionForceAdd = "forceadd"
+
+	// tmpIPSetPrefix Is the prefix added to temporary ipset names used in the atomic swap operations during ipset restore. You should never see these on your system because they only exist during the restore.
+	tmpIPSetPrefix = "TMP-"
 )
 
 // IPSet represent ipset sets managed by.
@@ -397,8 +400,6 @@ func parseIPSetSave(ipset *IPSet, result string) map[string]*Set {
 
 	return sets
 }
-
-const tmpIPSetPrefix = "TMP-"
 
 // Build ipset restore input
 // ex:

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -426,6 +426,9 @@ func buildIPSetRestore(ipset *IPSet) string {
 			hash := sha1.Sum([]byte("tmp:" + setOptions))
 			tmpSetName = tmpIPSetPrefix + base32.StdEncoding.EncodeToString(hash[:10])
 			ipSetRestore.WriteString(fmt.Sprintf("create %s %s\n", tmpSetName, setOptions))
+			// just in case we are starting up after a crash, we should flush the TMP ipset to be safe if it
+			// already existed, so we do not pollute other ipsets:
+			ipSetRestore.WriteString(fmt.Sprintf("flush %s\n", tmpSetName))
 			tmpSets[setOptions] = tmpSetName
 		}
 

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"bytes"
-	"crypto/sha256"
+	"crypto/sha1"
 	"encoding/base32"
 	"errors"
 	"fmt"
@@ -406,37 +406,49 @@ func parseIPSetSave(ipset *IPSet, result string) map[string]*Set {
 // create KUBE-DST-3YNVZWWGX3UQQ4VQ hash:ip family inet hashsize 1024 maxelem 65536 timeout 0
 // add KUBE-DST-3YNVZWWGX3UQQ4VQ 100.96.1.6 timeout 0
 func buildIPSetRestore(ipset *IPSet) string {
-	ipSetRestore := &strings.Builder{}
-
-	keys := make([]string, 0, len(ipset.Sets))
-	for key := range ipset.Sets {
-		// we need keys in some consistent order so that we can unit-test this method has a predictable output:
-		keys = append(keys, key)
+	setNames := make([]string, 0, len(ipset.Sets))
+	for setName := range ipset.Sets {
+		// we need setNames in some consistent order so that we can unit-test this method has a predictable output:
+		setNames = append(setNames, setName)
 	}
 
-	sort.Strings(keys)
+	sort.Strings(setNames)
 
-	for _, key := range keys {
-		set := ipset.Sets[key]
-		// we will create a temporary IPSet of the right type and then swap it in.
-		// it will be named based on the sha of the name of the set it will be swapped
-		// with, since IPSets have a 32-byte name size limit:
-		hash := sha256.Sum256([]byte("tmp:" + set.Name))
-		tmpSetName := tmpIPSetPrefix + (base32.StdEncoding.EncodeToString(hash[:]))[:16]
+	tmpSets := map[string]string{}
+	ipSetRestore := &strings.Builder{}
+	for _, setName := range setNames {
+		set := ipset.Sets[setName]
+		setOptions := strings.Join(set.Options, " ")
 
-		// first, create and populate the temporary ipset.
-		setOptions := strings.Join(set.Options[:], " ")
-		ipSetRestore.WriteString(fmt.Sprintf("create %s %s\n", tmpSetName, setOptions))
-		for _, entry := range set.Entries {
-			ipSetRestore.WriteString(fmt.Sprintf("add %s %s\n", tmpSetName, strings.Join(entry.Options[:], " ")))
+		tmpSetName := tmpSets[setOptions]
+		if tmpSetName == "" {
+			// create a temporary set per unique set-options:
+			hash := sha1.Sum([]byte("tmp:" + setOptions))
+			tmpSetName = tmpIPSetPrefix + base32.StdEncoding.EncodeToString(hash[:10])
+			ipSetRestore.WriteString(fmt.Sprintf("create %s %s\n", tmpSetName, setOptions))
+			tmpSets[setOptions] = tmpSetName
 		}
+
+		for _, entry := range set.Entries {
+			// add entries to the tmp set:
+			ipSetRestore.WriteString(fmt.Sprintf("add %s %s\n", tmpSetName, strings.Join(entry.Options, " ")))
+		}
+
 		// now create the actual IPSet (this is a noop if it already exists, because we run with -exists):
 		ipSetRestore.WriteString(fmt.Sprintf("create %s %s\n", set.Name, setOptions))
+
 		// now that both exist, we can swap them:
 		ipSetRestore.WriteString(fmt.Sprintf("swap %s %s\n", tmpSetName, set.Name))
-		// clean up the tmp- one which is actually the old one now:
+
+		// empty the tmp set (which is actually the old one now):
+		ipSetRestore.WriteString(fmt.Sprintf("flush %s\n", tmpSetName))
+	}
+
+	for _, tmpSetName := range tmpSets {
+		// finally, destroy the tmp sets.
 		ipSetRestore.WriteString(fmt.Sprintf("destroy %s\n", tmpSetName))
 	}
+
 	return ipSetRestore.String()
 }
 

--- a/pkg/utils/ipset_test.go
+++ b/pkg/utils/ipset_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import "testing"
+
+func Test_buildIPSetRestore(t *testing.T) {
+	type args struct {
+		ipset *IPSet
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "swap-two-sets",
+			args: args{
+				ipset: &IPSet{Sets: map[string]*Set{
+					"foo": {
+						Name:    "foo",
+						Options: []string{"hash:ip", "yolo", "things", "12345"},
+						Entries: []*Entry{
+							{Options: []string{"1.2.3.4"}},
+						},
+					},
+					"google-dns-servers": {
+						Name:    "google-dns-servers",
+						Options: []string{"hash:ip", "lol"},
+						Entries: []*Entry{
+							{Options: []string{"4.4.4.4"}},
+							{Options: []string{"8.8.8.8"}},
+						},
+					},
+				}},
+			},
+			want: "create TMP-GOAQNXK75HLZIRC5 hash:ip yolo things 12345\n" +
+				"add TMP-GOAQNXK75HLZIRC5 1.2.3.4\n" +
+				"create foo hash:ip yolo things 12345\n" +
+				"swap TMP-GOAQNXK75HLZIRC5 foo\n" +
+				"destroy TMP-GOAQNXK75HLZIRC5\n" +
+				"create TMP-5IF7SUJ4ODWBSS75 hash:ip lol\n" +
+				"add TMP-5IF7SUJ4ODWBSS75 4.4.4.4\n" +
+				"add TMP-5IF7SUJ4ODWBSS75 8.8.8.8\n" +
+				"create google-dns-servers hash:ip lol\n" +
+				"swap TMP-5IF7SUJ4ODWBSS75 google-dns-servers\n" +
+				"destroy TMP-5IF7SUJ4ODWBSS75\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildIPSetRestore(tt.args.ipset); got != tt.want {
+				t.Errorf("buildIPSetRestore() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/ipset_test.go
+++ b/pkg/utils/ipset_test.go
@@ -12,7 +12,7 @@ func Test_buildIPSetRestore(t *testing.T) {
 		want string
 	}{
 		{
-			name: "swap-two-sets",
+			name: "simple-restore",
 			args: args{
 				ipset: &IPSet{Sets: map[string]*Set{
 					"foo": {
@@ -30,19 +30,36 @@ func Test_buildIPSetRestore(t *testing.T) {
 							{Options: []string{"8.8.8.8"}},
 						},
 					},
+					// this one and the one above share the same exact options -- and therefore will reuse the same
+					// tmp ipset:
+					"more-ip-addresses": {
+						Name:    "google-dns-servers",
+						Options: []string{"hash:ip", "lol"},
+						Entries: []*Entry{
+							{Options: []string{"5.5.5.5"}},
+							{Options: []string{"6.6.6.6"}},
+						},
+					},
 				}},
 			},
-			want: "create TMP-GOAQNXK75HLZIRC5 hash:ip yolo things 12345\n" +
-				"add TMP-GOAQNXK75HLZIRC5 1.2.3.4\n" +
+			want: "create TMP-7NOTZDOMLXBX6DAJ hash:ip yolo things 12345\n" +
+				"add TMP-7NOTZDOMLXBX6DAJ 1.2.3.4\n" +
 				"create foo hash:ip yolo things 12345\n" +
-				"swap TMP-GOAQNXK75HLZIRC5 foo\n" +
-				"destroy TMP-GOAQNXK75HLZIRC5\n" +
-				"create TMP-5IF7SUJ4ODWBSS75 hash:ip lol\n" +
-				"add TMP-5IF7SUJ4ODWBSS75 4.4.4.4\n" +
-				"add TMP-5IF7SUJ4ODWBSS75 8.8.8.8\n" +
+				"swap TMP-7NOTZDOMLXBX6DAJ foo\n" +
+				"flush TMP-7NOTZDOMLXBX6DAJ\n" +
+				"create TMP-XD7BSSQZELS7TP35 hash:ip lol\n" +
+				"add TMP-XD7BSSQZELS7TP35 4.4.4.4\n" +
+				"add TMP-XD7BSSQZELS7TP35 8.8.8.8\n" +
 				"create google-dns-servers hash:ip lol\n" +
-				"swap TMP-5IF7SUJ4ODWBSS75 google-dns-servers\n" +
-				"destroy TMP-5IF7SUJ4ODWBSS75\n",
+				"swap TMP-XD7BSSQZELS7TP35 google-dns-servers\n" +
+				"flush TMP-XD7BSSQZELS7TP35\n" +
+				"add TMP-XD7BSSQZELS7TP35 5.5.5.5\n" +
+				"add TMP-XD7BSSQZELS7TP35 6.6.6.6\n" +
+				"create google-dns-servers hash:ip lol\n" +
+				"swap TMP-XD7BSSQZELS7TP35 google-dns-servers\n" +
+				"flush TMP-XD7BSSQZELS7TP35\n" +
+				"destroy TMP-7NOTZDOMLXBX6DAJ\n" +
+				"destroy TMP-XD7BSSQZELS7TP35\n",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/utils/ipset_test.go
+++ b/pkg/utils/ipset_test.go
@@ -43,11 +43,13 @@ func Test_buildIPSetRestore(t *testing.T) {
 				}},
 			},
 			want: "create TMP-7NOTZDOMLXBX6DAJ hash:ip yolo things 12345\n" +
+				"flush TMP-7NOTZDOMLXBX6DAJ\n" +
 				"add TMP-7NOTZDOMLXBX6DAJ 1.2.3.4\n" +
 				"create foo hash:ip yolo things 12345\n" +
 				"swap TMP-7NOTZDOMLXBX6DAJ foo\n" +
 				"flush TMP-7NOTZDOMLXBX6DAJ\n" +
 				"create TMP-XD7BSSQZELS7TP35 hash:ip lol\n" +
+				"flush TMP-XD7BSSQZELS7TP35\n" +
 				"add TMP-XD7BSSQZELS7TP35 4.4.4.4\n" +
 				"add TMP-XD7BSSQZELS7TP35 8.8.8.8\n" +
 				"create google-dns-servers hash:ip lol\n" +


### PR DESCRIPTION
# The problem.

There is a bit of a bug in kube-router, which only seems to exist since 1.2.x — since the implementation was changed to use `iptables-restore` and friends. Essentially, the generated IPSets are observably empty/incomplete for a brief moment between the `flush` and the completion of all the `add`s provided to `ipset restore`. This causes inbound or outbound connection failures for ingress/egress networkpolicies, respectively.

After some [discussion in slack,](https://kubernetes.slack.com/archives/C8DCQGTSB/p1618429634057500) here's a PR.

# A Solution?

This PR uses an approach discussed [on the netfilter mailing list](https://netfilter.vger.kernel.narkive.com/tJsj5nGC/ipset-save-and-restore) to avoid this problem by creating new sets and swapping them into place. 

1) a temporary set is created of the same type as the target set. The name is generated deterministically (`base32(sha256(...))`) from the target's name.
2) the temporary set is populated to be in the desired state of the target set.
3) the two are atomically swapped.
4) the temporary set (whose name now refers to the old target set) is deleted.

An example:

```
create TMP-5FIQLNFPVGLJPQU5 hash:ip family inet hashsize 1024 maxelem 65536 timeout 0
add TMP-5FIQLNFPVGLJPQU5 110.120.130.1 timeout 0
add TMP-5FIQLNFPVGLJPQU5 110.120.130.2 timeout 0
add TMP-5FIQLNFPVGLJPQU5 110.120.130.3 timeout 0
add TMP-5FIQLNFPVGLJPQU5 110.120.130.4 timeout 0
add TMP-5FIQLNFPVGLJPQU5 110.120.130.5 timeout 0
create KUBE-XYZ-EXAMPLE hash:ip family inet hashsize 1024 maxelem 65536 timeout 0
swap TMP-5FIQLNFPVGLJPQU5 KUBE-XYZ-EXAMPLE
destroy TMP-5FIQLNFPVGLJPQU5
```

# Example

If you have pods with type=ingress NetworkPolicy, for example, then 
- when Kube-router is synchronizing, 
- there is a small window where clients will get an erroneous `connection refused` error. 
- At that moment, their traffic enters the `POD-FW` chain,
- jumps into the `NWPLCY` chain, 
- is unmarked because their client IP is not in the IPset due to this race, and as such: 
- logged to nflog:100 and 
- `-j REJECT`-ed.

# Reproduction

You can reproduce this fairly easily by launching a bunch of short-lived pods which have a netpol acting on them, while simultaneously making network requests in a loop to some long-lived pod that also has a netpol (same or different one) acting on it. The short-lived pods only exist to repeatedly trigger the synchronization loop in kube-router, which will momentarily remove all IPSet members from the long-lived pod's ipsets. Your loop will sometimes catch it in this state and get a `connection refused` error. If you are monitoring `nflog:100`, you will see it there too.



