### PR TITLE
skip hostnetwok pod's from enforcing network policies

### DIFF
--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -36,6 +36,10 @@ func (npc *NetworkPolicyController) newPodEventHandler() cache.ResourceEventHand
 // OnPodUpdate handles updates to pods from the Kubernetes api server
 func (npc *NetworkPolicyController) OnPodUpdate(obj interface{}) {
 	pod := obj.(*api.Pod)
+	if pod.Spec.HostNetwork {
+		klog.V(2).Info("Ignoring update to hostNetwork pod: %s/%s", pod.Namespace, pod.Name)
+		return
+	}
 	klog.V(2).Infof("Received update to pod: %s/%s", pod.Namespace, pod.Name)
 
 	npc.RequestFullSync()


### PR DESCRIPTION

Fixes #1067 

existing KUBE-POD-FW rules for any host network pods will be automatically cleaned up on first sync.