### PR TITLE
Make pod firewall nflog rate-limiting configurable

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -84,6 +84,8 @@ Usage of kube-router:
       --peer-router-passwords strings                 Password for authenticating against the BGP peer defined with "--peer-router-ips".
       --peer-router-passwords-file string             Path to file containing password for authenticating against the BGP peer defined with "--peer-router-ips". --peer-router-passwords will be preferred if both are set.
       --peer-router-ports uints                       The remote port of the external BGP to which all nodes will peer. If not set, default BGP port (179) will be used. (default [])
+      --pod-fw-rejects-log-burst int                  The number of rejected packets logged from pod firewalls to nflog before the limit defined with "--pod-fw-rejects-log-limit" is used to ratelimit. (default 10)
+      --pod-fw-rejects-log-limit string               The maximum rate of rejected packets logged from pod firewalls to nflog. (default "10/minute")
       --router-id string                              BGP router-id. Must be specified in a ipv6 only cluster.
       --routes-sync-period duration                   The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0. (default 5m0s)
       --run-firewall                                  Enables Network Policy -- sets up iptables to provide ingress firewall for pods. (default true)

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -70,6 +70,9 @@ type NetworkPolicyController struct {
 	NetworkPolicyEventHandler cache.ResourceEventHandler
 
 	filterTableRules bytes.Buffer
+
+	nflogRejectsBurst int
+	nflogRejectsLimit string
 }
 
 // internal structure to represent a network policy
@@ -588,7 +591,10 @@ func (npc *NetworkPolicyController) Cleanup() {
 func NewNetworkPolicyController(clientset kubernetes.Interface,
 	config *options.KubeRouterConfig, podInformer cache.SharedIndexInformer,
 	npInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer) (*NetworkPolicyController, error) {
-	npc := NetworkPolicyController{}
+	npc := NetworkPolicyController{
+		nflogRejectsLimit: config.PodFWRejectsLogLimit,
+		nflogRejectsBurst: config.PodFWRejectsLogBurst,
+	}
 
 	// Creating a single-item buffered channel to ensure that we only keep a single full sync request at a time,
 	// additional requests would be pointless to queue since after the first one was processed the system would already

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -60,6 +60,8 @@ type KubeRouterConfig struct {
 	PeerPasswordsFile              string
 	PeerPorts                      []uint
 	PeerRouters                    []net.IP
+	PodFWRejectsLogBurst           int
+	PodFWRejectsLogLimit           string
 	RouterID                       string
 	RoutesSyncPeriod               time.Duration
 	RunFirewall                    bool
@@ -84,6 +86,8 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		IpvsSyncPeriod:                 5 * time.Minute,
 		NodePortRange:                  "30000-32767",
 		OverlayType:                    "subnet",
+		PodFWRejectsLogBurst:           10,
+		PodFWRejectsLogLimit:           "10/minute",
 		RoutesSyncPeriod:               5 * time.Minute,
 	}
 }
@@ -176,6 +180,10 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Path to file containing password for authenticating against the BGP peer defined with \"--peer-router-ips\". --peer-router-passwords will be preferred if both are set.")
 	fs.UintSliceVar(&s.PeerPorts, "peer-router-ports", s.PeerPorts,
 		"The remote port of the external BGP to which all nodes will peer. If not set, default BGP port ("+strconv.Itoa(DefaultBgpPort)+") will be used.")
+	fs.IntVar(&s.PodFWRejectsLogBurst, "pod-fw-rejects-log-burst", s.PodFWRejectsLogBurst,
+		"The number of rejected packets logged from pod firewalls to nflog before the limit defined with \"--pod-fw-rejects-log-limit\" is used to ratelimit.")
+	fs.StringVar(&s.PodFWRejectsLogLimit, "pod-fw-rejects-log-limit", s.PodFWRejectsLogLimit,
+		"The maximum rate of rejected packets logged from pod firewalls to nflog.")
 	fs.StringVar(&s.RouterID, "router-id", "", "BGP router-id. Must be specified in a ipv6 only cluster.")
 	fs.DurationVar(&s.RoutesSyncPeriod, "routes-sync-period", s.RoutesSyncPeriod,
 		"The delay between route updates and advertisements (e.g. '5s', '1m', '2h22m'). Must be greater than 0.")


### PR DESCRIPTION
For compliance reasons, it might be desired to tune the nflog rate-limits for packets that are rejected from pod firewalls. This PR makes it possible to tune the limit/burst parameters, or remove limiting entirely if you know what you are doing.

The defaults remain at `burst=10`, `limit=10/minute` as before.
