### PR TITLE
Fix Multiple Reductions in MTU

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -2347,7 +2347,7 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 		return nil, err
 	}
 	nsc.nodeIP = NodeIP
-	automtu, err := utils.GetMTUFromNodeIP(nsc.nodeIP, config.EnableOverlay)
+	automtu, err := utils.GetMTUFromNodeIP(nsc.nodeIP)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -234,7 +234,7 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 	}
 
 	if nrc.autoMTU {
-		mtu, err := utils.GetMTUFromNodeIP(nrc.nodeIP, nrc.enableOverlays)
+		mtu, err := utils.GetMTUFromNodeIP(nrc.nodeIP)
 		if err != nil {
 			klog.Errorf("Failed to find MTU for node IP: %s for intelligently setting the kube-bridge MTU "+
 				"due to %s.", nrc.nodeIP, err.Error())
@@ -401,7 +401,7 @@ func (nrc *NetworkRoutingController) updateCNIConfig() {
 }
 
 func (nrc *NetworkRoutingController) autoConfigureMTU() error {
-	mtu, err := utils.GetMTUFromNodeIP(nrc.nodeIP, nrc.enableOverlays)
+	mtu, err := utils.GetMTUFromNodeIP(nrc.nodeIP)
 	if err != nil {
 		return fmt.Errorf("failed to generate MTU: %s", err.Error())
 	}
@@ -700,10 +700,6 @@ func (nrc *NetworkRoutingController) setupOverlayTunnel(tunnelName string, nextH
 		}
 		if err = netlink.LinkSetUp(link); err != nil {
 			return nil, errors.New("Failed to bring tunnel interface " + tunnelName + " up due to: " + err.Error())
-		}
-		// reduce the MTU by 20 bytes to accommodate ipip tunnel overhead
-		if err = netlink.LinkSetMTU(link, link.Attrs().MTU-utils.IPInIPHeaderLength); err != nil {
-			return nil, errors.New("Failed to set MTU of tunnel interface " + tunnelName + " up due to: " + err.Error())
 		}
 	} else {
 		klog.V(1).Infof(

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -63,7 +63,7 @@ func GetNodeIP(node *apiv1.Node) (net.IP, error) {
 }
 
 // GetMTUFromNodeIP returns the MTU by detecting it from the IP on the node and figuring in tunneling configurations
-func GetMTUFromNodeIP(nodeIP net.IP, overlayEnabled bool) (int, error) {
+func GetMTUFromNodeIP(nodeIP net.IP) (int, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
 		return 0, errors.New("failed to get list of links")
@@ -76,9 +76,6 @@ func GetMTUFromNodeIP(nodeIP net.IP, overlayEnabled bool) (int, error) {
 		for _, addr := range addresses {
 			if addr.IPNet.IP.Equal(nodeIP) {
 				linkMTU := link.Attrs().MTU
-				if overlayEnabled {
-					return linkMTU - IPInIPHeaderLength, nil // -20 to accommodate IPIP header
-				}
 				return linkMTU, nil
 			}
 		}


### PR DESCRIPTION
Fixes kube-router so that it mostly leaves MTU alone. I'm not 100% sure about this PR as these MTU reductions seem to have come out of #102, #108, & #109 all of which are a bit light on details about why reducing MTU saw performance improvements.

What I suspect may be the case is that it's possible that the `ip` command may not have originally reduced the MTU when building `ipip` tunnels. However, it is now doing so, so our reduction of MTU actually results in a very small MTU size when overlay networking is enabled and caused #1033.

Proof that creating an `ipip` device type reduces the MTU of the tunnel link automatically in recent tooling/kernels:
```
# ip addr
...
3: br0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
...
# ip tunnel add testtun1 mode ipip local <ip> remote <ip> dev br0
# ip addr
...
# 65: testtun1@br0: <POINTOPOINT,NOARP> mtu 1480 qdisc noop state DOWN group default qlen 1000
...
```

Given that, I don't see why we would reduce the kube-bridge interface ahead of the MTU reduction that will already be part of the tunnel. It is possible that it might benefit us to reduce the MTU on the CNI configuration in case traffic routes across the pod network or to a k8s service, but we don't do this currently (except if automtu is enabled), so I'm not sure its worth introducing that now.