### PR TITLE
Add Locking Around ipset Invocations

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -57,6 +57,7 @@ type NetworkPolicyController struct {
 	MetricsEnabled          bool
 	healthChan              chan<- *healthcheck.ControllerHeartbeat
 	fullSyncRequestChan     chan struct{}
+	ipsetMutex              *sync.Mutex
 
 	ipSetHandler *utils.IPSet
 
@@ -567,6 +568,13 @@ func (npc *NetworkPolicyController) Cleanup() {
 	}
 
 	// delete all ipsets
+	klog.V(1).Infof("Attempting to attain ipset mutex lock")
+	npc.ipsetMutex.Lock()
+	klog.V(1).Infof("Attained ipset mutex lock, continuing...")
+	defer func() {
+		npc.ipsetMutex.Unlock()
+		klog.V(1).Infof("Returned ipset mutex lock")
+	}()
 	ipset, err := utils.NewIPSet(false)
 	if err != nil {
 		klog.Errorf("Failed to clean up ipsets: " + err.Error())
@@ -586,8 +594,8 @@ func (npc *NetworkPolicyController) Cleanup() {
 // NewNetworkPolicyController returns new NetworkPolicyController object
 func NewNetworkPolicyController(clientset kubernetes.Interface,
 	config *options.KubeRouterConfig, podInformer cache.SharedIndexInformer,
-	npInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer) (*NetworkPolicyController, error) {
-	npc := NetworkPolicyController{}
+	npInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer, ipsetMutex *sync.Mutex) (*NetworkPolicyController, error) {
+	npc := NetworkPolicyController{ipsetMutex: ipsetMutex}
 
 	// Creating a single-item buffered channel to ensure that we only keep a single full sync request at a time,
 	// additional requests would be pointless to queue since after the first one was processed the system would already

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -522,7 +523,7 @@ func TestNetworkPolicyController(t *testing.T) {
 	_, podInformer, nsInformer, netpolInformer := newFakeInformersFromClient(client)
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer)
+			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer, &sync.Mutex{})
 			if err == nil && test.expectError {
 				t.Error("This config should have failed, but it was successful instead")
 			} else if err != nil {

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -76,6 +76,14 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 		klog.V(2).Infof("Syncing network policy chains took %v", endTime)
 	}()
 
+	klog.V(1).Infof("Attempting to attain ipset mutex lock")
+	npc.ipsetMutex.Lock()
+	klog.V(1).Infof("Attained ipset mutex lock, continuing...")
+	defer func() {
+		npc.ipsetMutex.Unlock()
+		klog.V(1).Infof("Returned ipset mutex lock")
+	}()
+
 	ipset, err := utils.NewIPSet(false)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -17,6 +17,8 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/cloudnativelabs/kube-router/pkg/cri"
 	"github.com/cloudnativelabs/kube-router/pkg/healthcheck"
 	"github.com/cloudnativelabs/kube-router/pkg/metrics"
@@ -28,7 +30,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
-	"golang.org/x/net/context"
 	api "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -220,6 +221,7 @@ type NetworkServicesController struct {
 	ln                  LinuxNetworking
 	readyForUpdates     bool
 	ProxyFirewallSetup  *sync.Cond
+	ipsetMutex          *sync.Mutex
 
 	// Map of ipsets that we use.
 	ipsetMap map[string]*utils.Set
@@ -648,6 +650,13 @@ func (nsc *NetworkServicesController) cleanupIpvsFirewall() {
 	}
 
 	// Clear ipsets.
+	klog.V(1).Infof("Attempting to attain ipset mutex lock")
+	nsc.ipsetMutex.Lock()
+	klog.V(1).Infof("Attained ipset mutex lock, continuing...")
+	defer func() {
+		nsc.ipsetMutex.Unlock()
+		klog.V(1).Infof("Returned ipset mutex lock")
+	}()
 	ipSetHandler, err := utils.NewIPSet(false)
 	if err != nil {
 		klog.Errorf("Failed to initialize ipset handler: %s", err.Error())
@@ -674,6 +683,13 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 	   - update ipsets based on currently active IPVS services
 	*/
 	var err error
+	klog.V(1).Infof("Attempting to attain ipset mutex lock")
+	nsc.ipsetMutex.Lock()
+	klog.V(1).Infof("Attained ipset mutex lock, continuing...")
+	defer func() {
+		nsc.ipsetMutex.Unlock()
+		klog.V(1).Infof("Returned ipset mutex lock")
+	}()
 
 	localIPsIPSet := nsc.ipsetMap[localIPsIPSetName]
 
@@ -2462,7 +2478,7 @@ func (nsc *NetworkServicesController) handleServiceDelete(obj interface{}) {
 // NewNetworkServicesController returns NetworkServicesController object
 func NewNetworkServicesController(clientset kubernetes.Interface,
 	config *options.KubeRouterConfig, svcInformer cache.SharedIndexInformer,
-	epInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer) (*NetworkServicesController, error) {
+	epInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer, ipsetMutex *sync.Mutex) (*NetworkServicesController, error) {
 
 	var err error
 	ln, err := newLinuxNetworking()
@@ -2470,7 +2486,7 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 		return nil, err
 	}
 
-	nsc := NetworkServicesController{ln: ln}
+	nsc := NetworkServicesController{ln: ln, ipsetMutex: ipsetMutex}
 
 	if config.MetricsEnabled {
 		//Register the metrics for this controller

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -118,6 +118,7 @@ type NetworkRoutingController struct {
 	overrideNextHop                bool
 	podCidr                        string
 	CNIFirewallSetup               *sync.Cond
+	ipsetMutex                     *sync.Mutex
 
 	nodeLister cache.Indexer
 	svcLister  cache.Indexer
@@ -645,6 +646,13 @@ func (nrc *NetworkRoutingController) Cleanup() {
 	}
 
 	// delete all ipsets created by kube-router
+	klog.V(1).Infof("Attempting to attain ipset mutex lock")
+	nrc.ipsetMutex.Lock()
+	klog.V(1).Infof("Attained ipset mutex lock, continuing...")
+	defer func() {
+		nrc.ipsetMutex.Unlock()
+		klog.V(1).Infof("Returned ipset mutex lock")
+	}()
 	ipset, err := utils.NewIPSet(nrc.isIpv6)
 	if err != nil {
 		klog.Errorf("Failed to clean up ipsets: " + err.Error())
@@ -667,6 +675,13 @@ func (nrc *NetworkRoutingController) syncNodeIPSets() error {
 		if nrc.MetricsEnabled {
 			metrics.ControllerRoutesSyncTime.Observe(time.Since(start).Seconds())
 		}
+	}()
+	klog.V(1).Infof("Attempting to attain ipset mutex lock")
+	nrc.ipsetMutex.Lock()
+	klog.V(1).Infof("Attained ipset mutex lock, continuing...")
+	defer func() {
+		nrc.ipsetMutex.Unlock()
+		klog.V(1).Infof("Returned ipset mutex lock")
 	}()
 
 	nodes := nrc.nodeLister.List()
@@ -1019,11 +1034,11 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 func NewNetworkRoutingController(clientset kubernetes.Interface,
 	kubeRouterConfig *options.KubeRouterConfig,
 	nodeInformer cache.SharedIndexInformer, svcInformer cache.SharedIndexInformer,
-	epInformer cache.SharedIndexInformer) (*NetworkRoutingController, error) {
+	epInformer cache.SharedIndexInformer, ipsetMutex *sync.Mutex) (*NetworkRoutingController, error) {
 
 	var err error
 
-	nrc := NetworkRoutingController{}
+	nrc := NetworkRoutingController{ipsetMutex: ipsetMutex}
 	if kubeRouterConfig.MetricsEnabled {
 		//Register the metrics for this controller
 		prometheus.MustRegister(metrics.ControllerBGPadvertisementsReceived)


### PR DESCRIPTION
@murali-reddy @mrueg 

Potential fix for #1081 

I'm marking this as a WIP as I'm not 100% sure that this is what's causing a problem, but at this point I highly suspect that there is contention between ipset invocations within the different controllers. Especially since most of the periodic syncs happen right on top of each other (by default the 5m period syncs are on a ticker that end up being scheduled within milliseconds of each other).

I suspect that what happens is that on some starts when the timing of the periodic syncs is incredibly unlucky, the controllers end up executing something like this:
1. NPC takes a snapshot of the system’s ipset state: https://github.com/cloudnativelabs/kube-router/blob/96675e620be3e0c152d5b873146cc2f7f54c9429/pkg/controllers/netpol/policy.go#L83
2. NPC continues to process but is no longer holding a lock on ipset since it doesn’t have any commands in process
3. NSC/NRC makes some changes to an ipset: https://github.com/cloudnativelabs/kube-router/blob/4306e5d47cba468f24b6e259a5514e883172d00f/pkg/controllers/proxy/network_services_controller.go#L672
4. NPC restores its now stale ipset rules back to the system which does not contain the changes from step 3: https://github.com/cloudnativelabs/kube-router/blob/96675e620be3e0c152d5b873146cc2f7f54c9429/pkg/controllers/netpol/policy.go#L136

Unfortunately, this collision is really difficult to track down, because even a restart of one kube-router process can cause the collision to no longer be in that magical window where it causes problems.

I inserted some debug into each of the control loops and I can see that during the periodic syncs they all execute right on top of each other, but in order to be within one of the NPC controller's ipset save/restore portion requires precise timing:
```
I0519 19:47:21.469114   33414 network_services_controller.go:412] ---- Performing periodic sync of ipvs services
I0519 19:47:21.469165   33414 network_services_controller.go:437] ---- START ipvs sync
I0519 19:47:21.473170   33414 network_routes_controller.go:289] ---- START periodic sync of routes
I0519 19:47:21.478918   33414 service_endpoints_sync.go:34] ---- START ipvs services sync
I0519 19:47:21.727247   33414 network_routes_controller.go:338] ---- END periodic sync routes took 254.079823ms
I0519 19:47:21.737685   33414 network_policy_controller.go:182] ---- PERIODIC policy sync
I0519 19:47:21.737728   33414 network_policy_controller.go:218] ---- START sync of iptables with version: 1621453641737721625
I0519 19:47:21.895080   33414 ipset.go:480] ---- START ipset restore
I0519 19:47:22.280165   33414 service_endpoints_sync.go:31] ---- END ipvs services sync took 801.24877ms
I0519 19:47:22.303753   33414 network_services_controller.go:465] ---- END ipvs sync
I0519 19:47:22.446412   33414 ipset.go:491] ---- END ipset restore
I0519 19:47:22.529935   33414 iptables.go:34] ---- START iptables restore
I0519 19:47:22.581375   33414 iptables.go:53] ---- END iptables restore
I0519 19:47:22.610633   33414 network_policy_controller.go:215] ---- END sync iptables took 872.905003ms
```

The main thing that doesn't make sense to me at this point, which is why this is still a WIP, is that I'm not sure why missing an update causes such a big impact. It seems to me that the end result of this would be some stale data for a while until another update came in and caused the controller to fix the issue, and not missing data, or bad data. However, the impact that we see is disruption to services and sometimes the node itself.

Also, this isn't a very elegant solution. There are probably better ways to handle this.