### PR TITLE
Make Pod NetworkPolicy Handling More Efficient / Correct

### DIFF
--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -36,10 +36,6 @@ func (npc *NetworkPolicyController) newPodEventHandler() cache.ResourceEventHand
 // OnPodUpdate handles updates to pods from the Kubernetes api server
 func (npc *NetworkPolicyController) OnPodUpdate(obj interface{}) {
 	pod := obj.(*api.Pod)
-	if pod.Spec.HostNetwork {
-		klog.V(2).Infof("Ignoring update to hostNetwork pod: %s/%s", pod.Namespace, pod.Name)
-		return
-	}
 	klog.V(2).Infof("Received update to pod: %s/%s", pod.Namespace, pod.Name)
 
 	npc.RequestFullSync()

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -14,8 +14,13 @@ import (
 func (npc *NetworkPolicyController) newPodEventHandler() cache.ResourceEventHandler {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			npc.OnPodUpdate(obj)
-
+			if podObj, ok := obj.(*api.Pod); ok {
+				// If the pod isn't yet actionable there is no action to take here anyway, so skip it. When it becomes
+				// actionable, we'll get an update below.
+				if isNetPolActionable(podObj) {
+					npc.OnPodUpdate(obj)
+				}
+			}
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			newPodObj := newObj.(*api.Pod)

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -226,8 +226,8 @@ func (npc *NetworkPolicyController) getIngressNetworkPolicyEnabledPods(networkPo
 	for _, obj := range npc.podLister.List() {
 		pod := obj.(*api.Pod)
 
-		// ignore the pods running on the different node or running in host network
-		if strings.Compare(pod.Status.HostIP, nodeIP) != 0 || pod.Spec.HostNetwork {
+		// ignore the pods running on the different node and pods that are not actionable
+		if strings.Compare(pod.Status.HostIP, nodeIP) != 0 || !isNetPolActionable(pod) {
 			continue
 		}
 
@@ -246,8 +246,8 @@ func (npc *NetworkPolicyController) getIngressNetworkPolicyEnabledPods(networkPo
 			}
 		}
 	}
-	return &nodePods, nil
 
+	return &nodePods, nil
 }
 
 func (npc *NetworkPolicyController) getEgressNetworkPolicyEnabledPods(networkPoliciesInfo []networkPolicyInfo, nodeIP string) (*map[string]podInfo, error) {
@@ -257,10 +257,11 @@ func (npc *NetworkPolicyController) getEgressNetworkPolicyEnabledPods(networkPol
 	for _, obj := range npc.podLister.List() {
 		pod := obj.(*api.Pod)
 
-		// ignore the pods running on the different node or running in host network
-		if strings.Compare(pod.Status.HostIP, nodeIP) != 0 || pod.Spec.HostNetwork {
+		// ignore the pods running on the different node and pods that are not actionable
+		if strings.Compare(pod.Status.HostIP, nodeIP) != 0 || !isNetPolActionable(pod) {
 			continue
 		}
+
 		for _, policy := range networkPoliciesInfo {
 			if policy.namespace != pod.ObjectMeta.Namespace {
 				continue
@@ -276,6 +277,7 @@ func (npc *NetworkPolicyController) getEgressNetworkPolicyEnabledPods(networkPol
 			}
 		}
 	}
+
 	return &nodePods, nil
 }
 

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -475,7 +475,7 @@ func (npc *NetworkPolicyController) buildNetworkPoliciesInfo() ([]networkPolicyI
 		namedPort2IngressEps := make(namedPort2eps)
 		if err == nil {
 			for _, matchingPod := range matchingPods {
-				if matchingPod.Status.PodIP == "" {
+				if !isNetPolActionable(matchingPod) {
 					continue
 				}
 				newPolicy.targetPods[matchingPod.Status.PodIP] = podInfo{ip: matchingPod.Status.PodIP,
@@ -511,7 +511,7 @@ func (npc *NetworkPolicyController) buildNetworkPoliciesInfo() ([]networkPolicyI
 				for _, peer := range specIngressRule.From {
 					if peerPods, err := npc.evalPodPeer(policy, peer); err == nil {
 						for _, peerPod := range peerPods {
-							if peerPod.Status.PodIP == "" {
+							if !isNetPolActionable(peerPod) {
 								continue
 							}
 							ingressRule.srcPods = append(ingressRule.srcPods,
@@ -552,7 +552,7 @@ func (npc *NetworkPolicyController) buildNetworkPoliciesInfo() ([]networkPolicyI
 				if policyRulePortsHasNamedPort(specEgressRule.Ports) {
 					matchingPeerPods, _ := npc.ListPodsByNamespaceAndLabels(policy.Namespace, labels.Everything())
 					for _, peerPod := range matchingPeerPods {
-						if peerPod.Status.PodIP == "" {
+						if !isNetPolActionable(peerPod) {
 							continue
 						}
 						npc.grabNamedPortFromPod(peerPod, &namedPort2EgressEps)
@@ -563,7 +563,7 @@ func (npc *NetworkPolicyController) buildNetworkPoliciesInfo() ([]networkPolicyI
 				for _, peer := range specEgressRule.To {
 					if peerPods, err := npc.evalPodPeer(policy, peer); err == nil {
 						for _, peerPod := range peerPods {
-							if peerPod.Status.PodIP == "" {
+							if !isNetPolActionable(peerPod) {
 								continue
 							}
 							egressRule.dstPods = append(egressRule.dstPods,

--- a/pkg/controllers/netpol/utils.go
+++ b/pkg/controllers/netpol/utils.go
@@ -2,6 +2,7 @@ package netpol
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 
@@ -11,6 +12,20 @@ import (
 const (
 	PodCompleted api.PodPhase = "Completed"
 )
+
+// isPodUpdateNetPolRelevant checks the attributes that we care about for building NetworkPolicies on the host and if it
+// finds a relevant change, it returns true otherwise it returns false. The things we care about for NetworkPolicies:
+// 1) Is the phase of the pod changing? (matters for catching completed, succeeded, or failed jobs)
+// 2) Is the pod IP changing? (changes how the network policy is applied to the host)
+// 3) Is the pod's host IP changing? (should be caught in the above, with the CNI kube-router runs with but we check this as well for sanity)
+// 4) Is a pod's label changing? (potentially changes which NetworkPolicies select this pod)
+func isPodUpdateNetPolRelevant(oldPod, newPod *api.Pod) bool {
+	return newPod.Status.Phase != oldPod.Status.Phase ||
+		newPod.Status.PodIP != oldPod.Status.PodIP ||
+		!reflect.DeepEqual(newPod.Status.PodIPs, oldPod.Status.PodIPs) ||
+		newPod.Status.HostIP != oldPod.Status.HostIP ||
+		!reflect.DeepEqual(newPod.Labels, oldPod.Labels)
+}
 
 func isNetPolActionable(pod *api.Pod) bool {
 	return !isFinished(pod) && pod.Status.PodIP != "" && !pod.Spec.HostNetwork

--- a/pkg/controllers/netpol/utils.go
+++ b/pkg/controllers/netpol/utils.go
@@ -4,7 +4,25 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+
+	api "k8s.io/api/core/v1"
 )
+
+const (
+	PodCompleted api.PodPhase = "Completed"
+)
+
+func isNetPolActionable(pod *api.Pod) bool {
+	return !isFinished(pod) && pod.Status.PodIP != "" && !pod.Spec.HostNetwork
+}
+
+func isFinished(pod *api.Pod) bool {
+	switch pod.Status.Phase {
+	case api.PodFailed, api.PodSucceeded, PodCompleted:
+		return true
+	}
+	return false
+}
 
 func validateNodePortRange(nodePortOption string) (string, error) {
 	nodePortValidator := regexp.MustCompile(`^([0-9]+)[:-]([0-9]+)$`)

--- a/pkg/controllers/netpol/utils_test.go
+++ b/pkg/controllers/netpol/utils_test.go
@@ -38,6 +38,44 @@ var (
 	}
 )
 
+func Test_isPodUpdateNetPolRelevant(t *testing.T) {
+	t.Run("Pod phase change should be detected as NetworkPolicy relevant", func(t *testing.T) {
+		newPod := fakePod.DeepCopy()
+		newPod.Status.Phase = api.PodFailed
+		assert.True(t, isPodUpdateNetPolRelevant(&fakePod, newPod))
+	})
+	t.Run("Pod IP change should be detected as NetworkPolicy relevant", func(t *testing.T) {
+		newPod := fakePod.DeepCopy()
+		newPod.Status.PodIP = "172.16.0.2"
+		assert.True(t, isPodUpdateNetPolRelevant(&fakePod, newPod))
+	})
+	t.Run("Pod IPs change should be detected as NetworkPolicy relevant", func(t *testing.T) {
+		newPod := fakePod.DeepCopy()
+		newPod.Status.PodIPs = []api.PodIP{{IP: "172.16.0.2"}}
+		assert.True(t, isPodUpdateNetPolRelevant(&fakePod, newPod))
+	})
+	t.Run("Pod Label change should be detected as NetworkPolicy relevant", func(t *testing.T) {
+		newPod := fakePod.DeepCopy()
+		newPod.ObjectMeta.Labels = map[string]string{"bar": "foo"}
+		assert.True(t, isPodUpdateNetPolRelevant(&fakePod, newPod))
+	})
+	t.Run("Pod Host IP change should be detected as NetworkPolicy relevant", func(t *testing.T) {
+		newPod := fakePod.DeepCopy()
+		newPod.Status.HostIP = "10.0.0.2"
+		assert.True(t, isPodUpdateNetPolRelevant(&fakePod, newPod))
+	})
+	t.Run("Pod Image change should NOT be detected as NetworkPolicy relevant", func(t *testing.T) {
+		newPod := fakePod.DeepCopy()
+		newPod.Spec.Containers[0].Image = "k8s.gcr.io/otherimage"
+		assert.False(t, isPodUpdateNetPolRelevant(&fakePod, newPod))
+	})
+	t.Run("Pod Name change should NOT be detected as NetworkPolicy relevant", func(t *testing.T) {
+		newPod := fakePod.DeepCopy()
+		newPod.ObjectMeta.Name = "otherpod"
+		assert.False(t, isPodUpdateNetPolRelevant(&fakePod, newPod))
+	})
+}
+
 func Test_isPodFinished(t *testing.T) {
 	t.Run("Failed pod should be detected as finished", func(t *testing.T) {
 		fakePod.Status.Phase = api.PodFailed


### PR DESCRIPTION
@murali-reddy @mrueg 

This has a couple of changes in it that make kube-router's NetworkPolicy handling better:
1. Don't process policy for pod statuses that are `Completed`, `Succeeded`, or `Failed`. This changes kube-router to match what other network plugins do (e.g. https://github.com/projectcalico/libcalico-go/blob/9bbd69b5de2b6df62f4508d7557ddb67b1be1dc2/lib/backend/k8s/conversion/conversion.go#L157-L171 thanks @chendotjs). Additionally, this fixes the issue reported in #1056 where errors were caused because the CNI will re-use the Pod IP address of pods in these phases which can improperly apply NetworkPolicy to pods that should be without it.
2. Don't process new pods (i.e. ones going through `AddFunc()`) if they are missing their PodIP, are in an invalid phase ^^^, or are HostNetwork, as NetworkPolicy can't be properly applied to these pods anyway. This optimizes kube-router's NPC controller to be more efficient and avoid early full syncs that wouldn't have worked correctly.
3. Still request a full sync on pod update if the updated pod has `HostNetwork=true`. It is important to still process this event as the pod may have changed from `HostNetwork=false -> HostNetwork=true` in which case we need to remove NetworkPolicy that was previously applied to the Pod's previous Pod IP.
4. Refactor/Consolidate a lot of items into the utils package so that it can be more easily re-used and tested (also added unit testing for all of the above ^^^)
5. Now includes testing for changed `PodIPs` array and `HostIP` to cover all of the bases when testing if kube-router should request a full sync off of a pod update.