### PR TITLE
.github: Enable dependabot to manage dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
See also: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates


@aauren @murali-reddy this enables dependabot to manage and updates golang dependencies once per week. It will send PRs with suggested updates.