### PR TITLE
fix(goreleaser): add version and date to published binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,8 +16,8 @@ builds:
   env:
   - CGO_ENABLED=0
   ldflags:
-  - "-X github.com/cloudnativelabs/kube-router/pkg/cmd.version={{.Version}}"
-  - "-X github.com/cloudnativelabs/kube-router/pkg/cmd.buildDate={{.Date}}"
+  - "-X github.com/cloudnativelabs/kube-router/pkg/version.Version={{.Version}}"
+  - "-X github.com/cloudnativelabs/kube-router/pkg/version.BuildDate={{.Date}}"
 
 archives:
   -


### PR DESCRIPTION
@mrueg 

This should have been included in #1031 as without this, published binaries made by goreleaser don't print build version/date correctly.