### PR TITLE
add logic to explicitly ACCEPT traffic from/to the pod

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -387,7 +387,7 @@ func (npc *NetworkPolicyController) ensureTopLevelChains() {
 	// for the traffic to/from the local pod's let network policy controller be
 	// authoritative entity to ACCEPT the traffic if it complies to network policies
 	for _, chain := range chains {
-		comment := "rule to explictly ACCEPT traffic that comply to network policies"
+		comment := "rule to explicitly ACCEPT traffic that comply to network policies"
 		args := []string{"-m", "comment", "--comment", comment, "-m", "mark", "--mark", "0x20000/0x20000", "-j", "ACCEPT"}
 		err = iptablesCmdHandler.AppendUnique("filter", chain, args...)
 		if err != nil {

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -224,6 +224,9 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 	// ensure kube-router specific top level chains and corresponding rules exist
 	npc.ensureTopLevelChains()
 
+	// ensure default network policy chain that is applied to traffic from/to the pods that does not match any network policy
+	npc.ensureDefaultNetworkPolicyChain()
+
 	networkPoliciesInfo, err = npc.buildNetworkPoliciesInfo()
 	if err != nil {
 		klog.Errorf("Aborting sync. Failed to build network policies: %v", err.Error())

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -255,7 +255,7 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 	}
 
 	if err := utils.Restore("filter", npc.filterTableRules.Bytes()); err != nil {
-		klog.Errorf("Aborting sync. Failed to run iptables-restore: %v" + err.Error())
+		klog.Errorf("Aborting sync. Failed to run iptables-restore: %v\n%s", err.Error(), npc.filterTableRules.String())
 		return
 	}
 
@@ -433,6 +433,9 @@ func (npc *NetworkPolicyController) cleanupStaleRules(activePolicyChains, active
 	}
 	for _, chain := range chains {
 		if strings.HasPrefix(chain, kubeNetworkPolicyChainPrefix) {
+			if chain == kubeDefaultNetpolChain {
+				continue
+			}
 			if _, ok := activePolicyChains[chain]; !ok {
 				cleanupPolicyChains = append(cleanupPolicyChains, chain)
 			}

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -142,8 +142,8 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 
 		// set mark to indicate traffic from/to the pod passed network policies.
 		// Mark will be checked to explictly ACCEPT the traffic
-		comment := "set mark to ACCEPT traffic that comply to network policies"
-		args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment, "-j", "MARK", "--set-mark", "0x20000/0x20000"}
+		comment := "\"set mark to ACCEPT traffic that comply to network policies\""
+		args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment, "-j", "MARK", "--set-mark", "0x20000/0x20000", "\n"}
 		npc.filterTableRules.WriteString(strings.Join(args, " "))
 	}
 
@@ -171,8 +171,8 @@ func (npc *NetworkPolicyController) setupPodIngressRules(pod *podInfo, podFwChai
 	// if pod does not have any network policy which applies rules for pod's ingress traffic
 	// then apply default network policy
 	if !npc.isIngressNetworkPolicyEnabledPod(networkPoliciesInfo, pod) {
-		comment := "run through default ingress policy  chain"
-		args := []string{"-I", podFwChainName, "1", "-d", pod.ip, "-m", "comment", "--comment", comment, "-j", kubeDefaultNetpolChain}
+		comment := "\"run through default ingress policy  chain\""
+		args := []string{"-I", podFwChainName, "1", "-d", pod.ip, "-m", "comment", "--comment", comment, "-j", kubeDefaultNetpolChain, "\n"}
 		npc.filterTableRules.WriteString(strings.Join(args, " "))
 	}
 
@@ -229,8 +229,8 @@ func (npc *NetworkPolicyController) setupPodEgressRules(pod *podInfo, podFwChain
 	// if pod does not have any network policy which applies rules for pod's egress traffic
 	// then apply default network policy
 	if !npc.isEgressNetworkPolicyEnabledPod(networkPoliciesInfo, pod) {
-		comment := "run through default network policy  chain"
-		args := []string{"-I", podFwChainName, "1", "-s", pod.ip, "-m", "comment", "--comment", comment, "-j", kubeDefaultNetpolChain}
+		comment := "\"run through default network policy  chain\""
+		args := []string{"-I", podFwChainName, "1", "-s", pod.ip, "-m", "comment", "--comment", comment, "-j", kubeDefaultNetpolChain, "\n"}
 		npc.filterTableRules.WriteString(strings.Join(args, " "))
 	}
 

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -247,7 +247,7 @@ func (npc *NetworkPolicyController) interceptPodOutboundTraffic(pod *podInfo, po
 		// to pod on a different node)
 		comment := "\"rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
 			" to chain " + podFwChainName + "\""
-		args := []string{"-A", chain, "-m", "comment", "--comment", comment, "-s", pod.ip, "-j", podFwChainName, "\n"}
+		args := []string{"-I", chain, "1", "-m", "comment", "--comment", comment, "-s", pod.ip, "-j", podFwChainName, "\n"}
 		npc.filterTableRules.WriteString(strings.Join(args, " "))
 	}
 

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -126,7 +126,7 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 		}
 
 		// set mark to indicate traffic from/to the pod passed network policies.
-		// Mark will be checked to explictly ACCEPT the traffic
+		// Mark will be checked to explicitly ACCEPT the traffic
 		comment := "\"set mark to ACCEPT traffic that comply to network policies\""
 		args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment, "-j", "MARK", "--set-mark", "0x20000/0x20000", "\n"}
 		npc.filterTableRules.WriteString(strings.Join(args, " "))


### PR DESCRIPTION
add logic in network policy controller to explicitly ACCEPT traffic from/to the pod in both cases

- ACCEPT traffic from the pod is permitted by applicable network policies. 
- ACCEPT traffic if there are no network policies appicable to the traffic

`0x20000` will be used to mark the traffic from/to the pod that matches above cases.

Rule is appened in kube-router's top level chain to  `ACCEPT` traffic if packet is marked `0x20000` 

Fixes https://github.com/cloudnativelabs/kube-router/issues/984