### PR TITLE
use wait option of iptables-restore when available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=
-FROM ${ARCH}alpine:3.12
+FROM ${ARCH}alpine:3.14
 
 RUN apk add --no-cache \
       iptables \


### PR DESCRIPTION
update alpine image to 3.14 which has latest version of `iptables-restore` command with `--wait` option.

Also check if the `iptables-restore` has the wait option (to cover previous vesion of command with no --wait option) and use it
