### PR TITLE
Adds basic support for advertising both v4 and v6 VIPs in a dual-stack cluster

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"io"
+	"net"
 	"sync"
 )
 
@@ -42,4 +43,9 @@ func (b *Broadcaster) Notify(instance interface{}) {
 // statements, this allows an action like that to pass a linter as well as describe its intention well
 func CloseCloserDisregardError(handler io.Closer) {
 	_ = handler.Close()
+}
+
+// MatchAddressFamily compares 2 addresses families and returns true if they're the same, else false
+func MatchAddressFamily(x net.IP, y net.IP) bool {
+	return x.To4() != nil && y.To4() != nil || x.To16() != nil && x.To4() == nil && y.To16() != nil && y.To4() == nil
 }


### PR DESCRIPTION
A service can have multiple address from both v4 and v6 in a dual-stack cluster.  Prior to this PR, only single-stack was really considered, and further, all VIP prefixes were masked with /32 which is not the intention for single-stack v6 clusters.

This PR lets you to advertise dual-stack service VIPs to upstream neighbours, and correctly masks the v6 VIPs in a single-stack v6 cluster.

In this implementation, for a node to be considered dual-stack it should have addresses in both address families in either NodeInternalIP or NodeExternalIP.  The first of each of these addresses are chosen as the NH in the update to the upstream peer.  You can do this by starting kubelet with `--node-ip=<node_v4_address>,<node_v6_address>`

Upstream neighbours dual-stack sessions can be initiated by annotating the node like this:
```
'kube-router.io/peer.ips=<neigh_v4_address>,<neigh_v6_address>'
'kube-router.io/bgp-local-addresses=<node_v4_address>,<node_v6_address>'
'kube-router.io/peer.asns=<upstream_asn>,<upstream_asn>'
```