### PR TITLE
fix: add nil checking to ipsetMutex cleanup actions

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -611,13 +611,18 @@ func (npc *NetworkPolicyController) Cleanup() {
 	}
 
 	// delete all ipsets
-	klog.V(1).Infof("Attempting to attain ipset mutex lock")
-	npc.ipsetMutex.Lock()
-	klog.V(1).Infof("Attained ipset mutex lock, continuing...")
-	defer func() {
-		npc.ipsetMutex.Unlock()
-		klog.V(1).Infof("Returned ipset mutex lock")
-	}()
+	// There are certain actions like Cleanup() actions that aren't working with full instantiations of the controller
+	// and in these instances the mutex may not be present and may not need to be present as they are operating out of a
+	// single goroutine where there is no need for locking
+	if nil != npc.ipsetMutex {
+		klog.V(1).Infof("Attempting to attain ipset mutex lock")
+		npc.ipsetMutex.Lock()
+		klog.V(1).Infof("Attained ipset mutex lock, continuing...")
+		defer func() {
+			npc.ipsetMutex.Unlock()
+			klog.V(1).Infof("Returned ipset mutex lock")
+		}()
+	}
 	ipset, err := utils.NewIPSet(false)
 	if err != nil {
 		klog.Errorf("Failed to clean up ipsets: " + err.Error())


### PR DESCRIPTION
@murali-reddy this is similarly rough to the mutex locking that I did around ipset operations. My goal would be that once we rework the controllers to have unified ipset and iptables calls from all controllers that this code would go away or at least be rafactored into something else.

However, for the time being, this will fix #1126 by checking for nil's before attempting to call the mutex. I went with this approach because while nothing else uses these `Cleanup()` methods other than `--cleanup-config`, I figured it was better to not count on that in case someone ever changed to code to call them from a running controller and without the mutex present it caused a data layer issue.