### PR TITLE
Fix and Refactor Inject Route

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -611,7 +611,7 @@ func (nrc *NetworkRoutingController) isPeerEstablished(peerIP string) (bool, err
 	return peerDisconnected, nil
 }
 
-// cleanupTunnels removes any traces of tunnels / routes that were setup by nrc.setupOverlayTunnel() and are no longer
+// cleanupTunnel removes any traces of tunnels / routes that were setup by nrc.setupOverlayTunnel() and are no longer
 // needed. All errors are logged only, as we want to attempt to perform all cleanup actions regardless of their success
 func (nrc *NetworkRoutingController) cleanupTunnel(destinationSubnet *net.IPNet, tunnelName string) {
 	klog.V(1).Infof("Cleaning up old routes for %s if there are any", destinationSubnet.String())

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -576,7 +576,7 @@ func (nrc *NetworkRoutingController) injectRoute(path *gobgpapi.Path) error {
 // cleanupTunnels removes any traces of tunnels / routes that were setup by nrc.setupOverlayTunnel() and are no longer
 // needed. All errors are logged only, as we want to attempt to perform all cleanup actions regardless of their success
 func (nrc *NetworkRoutingController) cleanupTunnel(destinationSubnet *net.IPNet, tunnelName string) {
-	klog.Infof("Cleaning up old routes if there are any")
+	klog.V(1).Infof("Cleaning up old routes for %s if there are any", destinationSubnet.String())
 	routes, err := netlink.RouteListFiltered(nl.FAMILY_ALL, &netlink.Route{
 		Dst: destinationSubnet, Protocol: 0x11,
 	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_PROTOCOL)
@@ -590,7 +590,7 @@ func (nrc *NetworkRoutingController) cleanupTunnel(destinationSubnet *net.IPNet,
 		}
 	}
 
-	klog.Infof("Cleaning up if there is any existing tunnel interface for the node")
+	klog.V(1).Infof("Cleaning up any lingering tunnel interfaces named: %s", tunnelName)
 	if link, err := netlink.LinkByName(tunnelName); err == nil {
 		if err = netlink.LinkDel(link); err != nil {
 			klog.Errorf("Failed to delete tunnel link for the node due to " + err.Error())
@@ -628,7 +628,8 @@ func (nrc *NetworkRoutingController) setupOverlayTunnel(tunnelName string, nextH
 			return nil, errors.New("Failed to set MTU of tunnel interface " + tunnelName + " up due to: " + err.Error())
 		}
 	} else {
-		klog.Infof("Tunnel interface: " + tunnelName + " for the node " + nextHop.String() + " already exists.")
+		klog.V(1).Infof(
+			"Tunnel interface: " + tunnelName + " for the node " + nextHop.String() + " already exists.")
 	}
 
 	// Now that the tunnel link exists, we need to add a route to it, so the node knows where to send traffic bound for


### PR DESCRIPTION
@murali-reddy / @mrueg - I was originally setting out to fix #973 but as I got into the code I realized that it desperately needed to be refactored. So I did the refactoring first, mostly extracting methods to make the logic flow a little easier to read. However, I also made it a bit more performant as well by processing withdrawals first.

This also contains a fix for #973 by checking at path withdrawal time whether the reason for the withdrawal is because the peer is unestablished. If the peer is no longer established, then it attempts to clean up the tunnels as well as the routes. I found in my testing that when the tunnel was deleted the system also seemed to automatically clean up the routes that were in table `77`.

@murali-reddy I only did a small amount of local testing as we don't frequently remove nodes from our clusters. I'd appreciate any additional testing that you might be able to do on this.