### PR TITLE
Fix Controller Cleanup() Functions

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -441,11 +441,13 @@ func (npc *NetworkPolicyController) cleanupStaleRules(activePolicyChains, active
 			}
 			if _, ok := activePolicyChains[chain]; !ok {
 				cleanupPolicyChains = append(cleanupPolicyChains, chain)
+				continue
 			}
 		}
 		if strings.HasPrefix(chain, kubePodFirewallChainPrefix) {
 			if _, ok := activePodFwChains[chain]; !ok {
 				cleanupPodFwChains = append(cleanupPodFwChains, chain)
+				continue
 			}
 		}
 	}

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -621,35 +621,40 @@ func (nsc *NetworkServicesController) setupIpvsFirewall() error {
 }
 
 func (nsc *NetworkServicesController) cleanupIpvsFirewall() {
-	/*
-		- delete firewall rules
-		- delete ipsets
-	*/
-	var err error
-
-	// Clear iptables rules.
+	// Clear iptables rules
 	iptablesCmdHandler, err := iptables.New()
 	if err != nil {
-		klog.Errorf("Failed to initialize iptables executor: %s", err.Error())
+		klog.Errorf("failed to initialize iptables executor: %v", err)
 	} else {
 		ipvsFirewallInputChainRule := getIpvsFirewallInputChainRule()
-		err = iptablesCmdHandler.Delete("filter", "INPUT", ipvsFirewallInputChainRule...)
+		exists, err := iptablesCmdHandler.Exists("filter", "INPUT", ipvsFirewallInputChainRule...)
 		if err != nil {
-			klog.Errorf("Failed to run iptables command: %s", err.Error())
+			// Changing to level 1 logging as errors occur when ipsets have already been cleaned and needlessly worries users
+			klog.V(1).Infof("failed to check if iptables rules exists: %v", err)
+		} else if exists {
+			err = iptablesCmdHandler.Delete("filter", "INPUT", ipvsFirewallInputChainRule...)
+			if err != nil {
+				klog.Errorf("failed to run iptables command: %v", err)
+			}
 		}
 
-		err = iptablesCmdHandler.ClearChain("filter", ipvsFirewallChainName)
+		exists, err = iptablesCmdHandler.ChainExists("filter", ipvsFirewallChainName)
 		if err != nil {
-			klog.Errorf("Failed to run iptables command: %s", err.Error())
-		}
+			klog.Errorf("failed to check if chain exists for deletion: %v", err)
+		} else if exists {
+			err = iptablesCmdHandler.ClearChain("filter", ipvsFirewallChainName)
+			if err != nil {
+				klog.Errorf("Failed to run iptables command: %s", err.Error())
+			}
 
-		err = iptablesCmdHandler.DeleteChain("filter", ipvsFirewallChainName)
-		if err != nil {
-			klog.Errorf("Failed to run iptables command: %s", err.Error())
+			err = iptablesCmdHandler.DeleteChain("filter", ipvsFirewallChainName)
+			if err != nil {
+				klog.Errorf("Failed to run iptables command: %s", err.Error())
+			}
 		}
 	}
 
-	// Clear ipsets.
+	// Clear ipsets
 	// There are certain actions like Cleanup() actions that aren't working with full instantiations of the controller
 	// and in these instances the mutex may not be present and may not need to be present as they are operating out of a
 	// single goroutine where there is no need for locking
@@ -665,17 +670,29 @@ func (nsc *NetworkServicesController) cleanupIpvsFirewall() {
 	ipSetHandler, err := utils.NewIPSet(false)
 	if err != nil {
 		klog.Errorf("Failed to initialize ipset handler: %s", err.Error())
-	} else {
+		return
+	}
+	err = ipSetHandler.Save()
+	if err != nil {
+		klog.Fatalf("failed to initialize ipsets command executor due to %v", err)
+		return
+	}
+
+	if _, ok := ipSetHandler.Sets[localIPsIPSetName]; ok {
 		err = ipSetHandler.Destroy(localIPsIPSetName)
 		if err != nil {
 			klog.Errorf("failed to destroy ipset: %s", err.Error())
 		}
+	}
 
+	if _, ok := ipSetHandler.Sets[serviceIPsIPSetName]; ok {
 		err = ipSetHandler.Destroy(serviceIPsIPSetName)
 		if err != nil {
 			klog.Errorf("failed to destroy ipset: %s", err.Error())
 		}
+	}
 
+	if _, ok := ipSetHandler.Sets[ipvsServicesIPSetName]; ok {
 		err = ipSetHandler.Destroy(ipvsServicesIPSetName)
 		if err != nil {
 			klog.Errorf("failed to destroy ipset: %s", err.Error())

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -654,6 +654,10 @@ func (nsc *NetworkServicesController) cleanupIpvsFirewall() {
 		}
 	}
 
+	// For some reason, if we go too fast into the ipset logic below it causes the system to think that the above
+	// iptables rules are still referencing the ipsets below, and we get errors
+	time.Sleep(1 * time.Second)
+
 	// Clear ipsets
 	// There are certain actions like Cleanup() actions that aren't working with full instantiations of the controller
 	// and in these instances the mutex may not be present and may not need to be present as they are operating out of a

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -2347,16 +2347,21 @@ func (ln *linuxNetworking) getKubeDummyInterface() (netlink.Link, error) {
 
 // Cleanup cleans all the configurations (IPVS, iptables, links) done
 func (nsc *NetworkServicesController) Cleanup() {
-	// cleanup ipvs rules by flush
-	klog.Infof("Cleaning up IPVS configuration permanently")
+	klog.Infof("Cleaning up NetworkServiceController configurations...")
 
+	// cleanup ipvs rules by flush
 	handle, err := ipvs.New("")
 	if err != nil {
-		klog.Errorf("Failed to cleanup ipvs rules: %s", err.Error())
-		return
+		klog.Errorf("failed to get ipvs handle for cleaning ipvs definitions: %v", err)
+	} else {
+		klog.Infof("ipvs definitions don't have names associated with them for checking, during cleanup " +
+			"we assume that we own all of them and delete all ipvs definitions")
+		err = handle.Flush()
+		if err != nil {
+			klog.Errorf("unable to flush ipvs tables: %v", err)
+		}
+		handle.Close()
 	}
-
-	handle.Close()
 
 	// cleanup iptables masquerade rule
 	err = deleteMasqueradeIptablesRule()
@@ -2387,7 +2392,8 @@ func (nsc *NetworkServicesController) Cleanup() {
 			return
 		}
 	}
-	klog.Infof("Successfully cleaned the ipvs configuration done by kube-router")
+
+	klog.Infof("Successfully cleaned the NetworkServiceController configuration done by kube-router")
 }
 
 func (nsc *NetworkServicesController) newEndpointsEventHandler() cache.ResourceEventHandler {

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -634,15 +634,19 @@ out:
 
 // Cleanup performs the cleanup of configurations done
 func (nrc *NetworkRoutingController) Cleanup() {
+	klog.Infof("Cleaning up NetworkRoutesController configurations")
+
 	// Pod egress cleanup
 	err := nrc.deletePodEgressRule()
 	if err != nil {
-		klog.Warningf("Error deleting Pod egress iptables rule: %s", err.Error())
+		// Changing to level 1 logging as errors occur when ipsets have already been cleaned and needlessly worries users
+		klog.V(1).Infof("Error deleting Pod egress iptables rule: %v", err)
 	}
 
 	err = nrc.deleteBadPodEgressRules()
 	if err != nil {
-		klog.Warningf("Error deleting Pod egress iptables rule: %s", err.Error())
+		// Changing to level 1 logging as errors occur when ipsets have already been cleaned and needlessly worries users
+		klog.V(1).Infof("Error deleting Pod egress iptables rule: %s", err.Error())
 	}
 
 	// delete all ipsets created by kube-router
@@ -671,6 +675,8 @@ func (nrc *NetworkRoutingController) Cleanup() {
 	if err != nil {
 		klog.Warningf("Error deleting ipset: %s", err.Error())
 	}
+
+	klog.Infof("Successfully cleaned the NetworkRoutesController configuration done by kube-router")
 }
 
 func (nrc *NetworkRoutingController) syncNodeIPSets() error {

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -649,6 +649,10 @@ func (nrc *NetworkRoutingController) Cleanup() {
 		klog.V(1).Infof("Error deleting Pod egress iptables rule: %s", err.Error())
 	}
 
+	// For some reason, if we go too fast into the ipset logic below it causes the system to think that the above
+	// iptables rules are still referencing the ipsets below, and we get errors
+	time.Sleep(1 * time.Second)
+
 	// delete all ipsets created by kube-router
 	// There are certain actions like Cleanup() actions that aren't working with full instantiations of the controller
 	// and in these instances the mutex may not be present and may not need to be present as they are operating out of a


### PR DESCRIPTION
@murali-reddy I had some free time this weekend, so I put together some fixes to the `Cleanup()` functions. Fixes #1021 and #968

I pushed to the `cloudnativelabs` repo, in case you want to rework anything that I put in here, or in case you had a better approach to something. With these fixes, in my cluster, I found that everything was cleaned correctly and there were no more disconcerting errors. I also tried to break down the commits into a pretty granular form.

I changed the one in the NPC controller to utilize the same cleanupStale*() functions that the run control loop uses. This turned out to be pretty easy and pretty clean, so I'm happy with it. It only required a small modification to the cleanupStaleRules() function, other than that, I just pass in empty maps and it does the right things.

The changes to the NSC and NRC I'm not quite as happy with. Mainly I just turned down errors and started checking for existence before deleting. I did this because users can encounter errors while running cleanup for things that are normal conditions. Like maybe they weren't running the NSC controller, but when it cleans up, it tries to check for / delete things that then don't exist. Or maybe they ran the function already and now there's nothing to delete.

One thing that I hit a lot of in my testing was the ipset mechanism complaining that it couldn't delete the ipset because there were still references from iptables, even though those reference chains had been deleted in the step prior. I found that putting a 1 second pause in, fixed that, but obviously that's not a great solution. That being said, it's a cleanup function and not part of the main runtime, so take it for what it is. Definitely open to a better approach on that if you have one.