### PR TITLE
remove IPVS metrics

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -2508,7 +2508,7 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 	nsc := NetworkServicesController{ln: ln, ipsetMutex: ipsetMutex, metricsMap: make(map[string][]string)}
 
 	if config.MetricsEnabled {
-		// Register the metrics for this controller.
+		// Register the metrics for this controller
 		prometheus.MustRegister(metrics.ControllerIpvsServices)
 		prometheus.MustRegister(metrics.ControllerIpvsServicesSyncTime)
 		prometheus.MustRegister(metrics.ServiceBpsIn)

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -548,6 +548,23 @@ func (nsc *NetworkServicesController) cleanupStaleIPVSConfig(activeServiceEndpoi
 					ipvsServiceString(ipvsSvc), err.Error())
 				continue
 			}
+
+			labelValues, ok := nsc.metricsMap[key]
+			if !ok {
+				continue
+			}
+
+			metrics.ServiceBpsIn.DeleteLabelValues(labelValues...)
+			metrics.ServiceBpsOut.DeleteLabelValues(labelValues...)
+			metrics.ServiceBytesIn.DeleteLabelValues(labelValues...)
+			metrics.ServiceBytesOut.DeleteLabelValues(labelValues...)
+			metrics.ServiceCPS.DeleteLabelValues(labelValues...)
+			metrics.ServicePacketsIn.DeleteLabelValues(labelValues...)
+			metrics.ServicePacketsOut.DeleteLabelValues(labelValues...)
+			metrics.ServicePpsIn.DeleteLabelValues(labelValues...)
+			metrics.ServicePpsOut.DeleteLabelValues(labelValues...)
+			metrics.ServiceTotalConn.DeleteLabelValues(labelValues...)
+			metrics.ControllerIpvsServices.Dec()
 		} else {
 			dsts, err := nsc.ln.ipvsGetDestinations(ipvsSvc)
 			if err != nil {

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -63,11 +63,9 @@ func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInf
 		syncErrors = true
 		klog.Errorf("Error cleaning up stale IPVS services and servers: %s", err.Error())
 	}
-	err = nsc.cleanupStaleMetrics(activeServiceEndpointMap)
-	if err != nil {
-		syncErrors = true
-		klog.Errorf("Error cleaning up stale metrics: %s", err.Error())
-	}
+
+	nsc.cleanupStaleMetrics(activeServiceEndpointMap)
+
 	err = nsc.syncIpvsFirewall()
 	if err != nil {
 		syncErrors = true
@@ -581,7 +579,7 @@ func (nsc *NetworkServicesController) cleanupStaleIPVSConfig(activeServiceEndpoi
 	return nil
 }
 
-func (nsc *NetworkServicesController) cleanupStaleMetrics(activeServiceEndpointMap map[string][]string) error {
+func (nsc *NetworkServicesController) cleanupStaleMetrics(activeServiceEndpointMap map[string][]string) {
 	for k, v := range nsc.metricsMap {
 		if _, ok := activeServiceEndpointMap[k]; ok {
 			continue
@@ -600,5 +598,4 @@ func (nsc *NetworkServicesController) cleanupStaleMetrics(activeServiceEndpointM
 		metrics.ControllerIpvsServices.Dec()
 		delete(nsc.metricsMap, k)
 	}
-	return nil
 }

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -565,6 +565,7 @@ func (nsc *NetworkServicesController) cleanupStaleIPVSConfig(activeServiceEndpoi
 			metrics.ServicePpsOut.DeleteLabelValues(labelValues...)
 			metrics.ServiceTotalConn.DeleteLabelValues(labelValues...)
 			metrics.ControllerIpvsServices.Dec()
+			delete(nsc.metricsMap, key)
 		} else {
 			dsts, err := nsc.ln.ipvsGetDestinations(ipvsSvc)
 			if err != nil {


### PR DESCRIPTION
Remove metrics for IPVS services when the IPVS service is deleted so
that the number of metrics does not grow without bound.

Fixes #734