### PR TITLE
Add a default route 0.0.0.0/8 import policy deny rule

### DIFF
--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -150,6 +150,23 @@ func Test_AddPolicies(t *testing.T) {
 						RouteAction: gobgpapi.RouteAction_REJECT,
 					},
 				},
+				{
+					Name: "kube_router_import_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							MatchType: gobgpapi.MatchType_ANY,
+							Name:      "defaultroutedefinedset",
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							MatchType: gobgpapi.MatchType_ANY,
+							Name:      "allpeerset",
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_REJECT,
+					},
+				},
 			},
 			nil,
 			nil,


### PR DESCRIPTION
This pull request protects Kube-router from receiving the default route from a misconfigured switch, affecting the node's reachability.

fixes #584 and #586