### PR TITLE
fix(npc): ordering of firewall / service rules

### DIFF
--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -70,3 +70,34 @@ func Restore(table string, data []byte) error {
 
 	return nil
 }
+
+// AppendUnique ensures that rule is in chain only once in the buffer and that the occurrence is at the end of the buffer
+func AppendUnique(buffer bytes.Buffer, chain string, rule []string) bytes.Buffer {
+	var desiredBuffer bytes.Buffer
+
+	// First we need to remove any previous instances of the rule that exist, so that we can be sure that our version
+	// is unique and appended to the very end of the buffer
+	rules := strings.Split(buffer.String(), "\n")
+	if len(rules) > 0 && rules[len(rules)-1] == "" {
+		rules = rules[:len(rules)-1]
+	}
+	for _, foundRule := range rules {
+		if strings.Contains(foundRule, chain) {
+			if strings.Contains(foundRule, strings.Join(rule, " ")) {
+				continue
+			}
+		}
+		desiredBuffer.WriteString(foundRule + "\n")
+	}
+
+	// Now append the rule that we wanted to be unique
+	desiredBuffer = Append(desiredBuffer, chain, rule)
+	return desiredBuffer
+}
+
+// Append appends rule to chain at the end of buffer
+func Append(buffer bytes.Buffer, chain string, rule []string) bytes.Buffer {
+	ruleStr := strings.Join(append(append([]string{"-A", chain}, rule...), "\n"), " ")
+	buffer.WriteString(ruleStr)
+	return buffer
+}


### PR DESCRIPTION
@murali-reddy / @mrueg - This fixes #1136 by ensuring that service rules always come before the firewall rules and that the explicit accept is always at the end of the firewall rules.

@murali-reddy I pushed this to cloudnativelabs so that you could change it as you want. I feel like it makes more sense for the `0x20000` accept rule to be handled in the same way that the firewall rules are (with the npc buffer and `save`/`restore`), but there were some complications that made this more difficult. Mostly because `cleanupStaleRules()` won't work on `KUBE-ROUTER-INPUT`, `KUBE-ROUTER-FORWARD`, and `KUBE-ROUTER-OUTPUT` to get rid of previous occurrences of the rule.

So I had to create some additional functions to handle appending in a way that wouldn't make multiple rules. I feel like using this way to fix this ends up taking us partially towards the work that you were going to do to standardize the way that iptables is handled (consolidation around `iptables-save`/`iptables-restore` and the utility methods that go along with that). So, if you have a different vision for the way that should work, feel free to either change this work, or discard it with your own vision.