### PR TITLE
ensure withdrawn external IP's on service update, are not used by any other service

### DIFF
--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -227,7 +227,26 @@ func (nrc *NetworkRoutingController) OnServiceUpdate(objNew interface{}, objOld 
 	//
 	// As such, it needs to be handled differently as nrc.handleServiceUpdate only withdraws VIPs if the service
 	// endpoint is no longer scheduled on this node and its a local type service.
-	nrc.withdrawVIPs(nrc.getExternalIPsToWithdraw(getServiceObject(objOld), getServiceObject(objNew)))
+	withdrawnServiceVips := nrc.getExternalIPsToWithdraw(getServiceObject(objOld), getServiceObject(objNew))
+
+	// ensure external IP to be withdrawn is not used by any other service
+	allActiveVIPs, _, err := nrc.getActiveVIPs()
+	if err != nil {
+		klog.Errorf("Failed to get all active VIP's due to: %s", err.Error())
+		return
+	}
+	activeVIPsMap := make(map[string]bool)
+	for _, activeVIP := range allActiveVIPs {
+		activeVIPsMap[activeVIP] = true
+	}
+	withdrawVIPs := make([]string, 0)
+	for _, serviceVIP := range withdrawnServiceVips {
+		// withdraw VIP only if updated service is the last service using the VIP
+		if !activeVIPsMap[serviceVIP] {
+			withdrawVIPs = append(withdrawVIPs, serviceVIP)
+		}
+	}
+	nrc.withdrawVIPs(withdrawVIPs)
 }
 
 func (nrc *NetworkRoutingController) getExternalIPsToWithdraw(svcOld, svcNew *v1core.Service) (out []string) {


### PR DESCRIPTION
ensure withdrawn external IP's on service update, are not used by any 
other service. i.e) check if external IP really not used by any service

Fixes #1154