### PR TITLE
only enable nf_call_ip{,6}tables for kube-bridge

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -232,11 +232,11 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 	if _, err := exec.Command("modprobe", "br_netfilter").CombinedOutput(); err != nil {
 		klog.Errorf("Failed to enable netfilter for bridge. Network policies and service proxy may not work: %s", err.Error())
 	}
-	if err = ioutil.WriteFile("/proc/sys/net/bridge/bridge-nf-call-iptables", []byte(strconv.Itoa(1)), 0640); err != nil {
+	if err = ioutil.WriteFile("/sys/class/net/kube-bridge/bridge/nf_call_iptables", []byte(strconv.Itoa(1)), 0644); err != nil {
 		klog.Errorf("Failed to enable iptables for bridge. Network policies and service proxy may not work: %s", err.Error())
 	}
 	if nrc.isIpv6 {
-		if err = ioutil.WriteFile("/proc/sys/net/bridge/bridge-nf-call-ip6tables", []byte(strconv.Itoa(1)), 0640); err != nil {
+		if err = ioutil.WriteFile("/sys/class/net/kube-bridge/bridge/nf_call_ip6tables", []byte(strconv.Itoa(1)), 0644); err != nil {
 			klog.Errorf("Failed to enable ip6tables for bridge. Network policies and service proxy may not work: %s", err.Error())
 		}
 


### PR DESCRIPTION
The bridge CNI plugin requires traffic traversing its bridge interface to be passed to ip{,6}tables. kube-router currently ensures this by setting the sysctl `net.bridge.bridge-nf-call-ip{,6}tables=1` (the kernel's default), which forces traffic traversing **any** bridge on the node to be filtered through ip{,6}tables.

That sysctl is disabled by default on some distros because it leads to issues with VMs and other applications which expect bridges (other than `kube-bridge` of cause) to be just plain L2 bridges. The per-bridge setting in `/sys/class/net/other-bridge/bridge/nf_call_ip{,6}tables` will also be ignored when the sysctl is enabled.
However, when the sysctl is disabled, the filtering can still be enabled per bridge. I propose that kube-router enables `nf-call-ip{,6}tables` only for the `kube-bridge` interface and does not touch the sysctl anymore. The per-bridge setting will be applied if it's disabled; and if it's enabled, we don't need to do anything anyway.

A limitation of the proposed solution is that the `kube-bridge` interface has to exist for kube-router to be able to configure it. If kube-router fails to create `kube-bridge`, it leaves the creation to the bridge CNI plugin, which does not handle this setting and relies on the sysctl already being enabled. So in the case where the sysctl is disabled and kube-router somehow fails to create the `kube-bridge` interface, one would end up with an incorrectly configured `kube-bridge`.