### PR TITLE
fix(sysctl): revert is fatal check for some conditions

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1437,22 +1437,17 @@ func (nsc *NetworkServicesController) syncHairpinIptablesRules() error {
 		return errors.New("Failed to initialize iptables executor" + err.Error())
 	}
 
-	// TODO: Factor these variables out
-	hasHairpinChain := false
-
 	// TODO: Factor out this code
+	hasHairpinChain := false
 	chains, err := iptablesCmdHandler.ListChains("nat")
 	if err != nil {
 		return errors.New("Failed to list iptables chains: " + err.Error())
 	}
-
-	// TODO: Factor out this code
 	for _, chain := range chains {
 		if chain == ipvsHairpinChainName {
 			hasHairpinChain = true
 		}
 	}
-
 	// Create a chain for hairpin rules, if needed
 	if !hasHairpinChain {
 		err = iptablesCmdHandler.NewChain("nat", ipvsHairpinChainName)
@@ -1522,15 +1517,12 @@ func (nsc *NetworkServicesController) syncHairpinIptablesRules() error {
 }
 
 func hairpinRuleFrom(serviceIP string, endpointIP string, servicePort int) (string, []string) {
-	// TODO: Factor hairpinChain out
-	hairpinChain := "KUBE-ROUTER-HAIRPIN"
-
 	ruleArgs := []string{"-s", endpointIP + "/32", "-d", endpointIP + "/32",
 		"-m", "ipvs", "--vaddr", serviceIP, "--vport", strconv.Itoa(servicePort),
 		"-j", "SNAT", "--to-source", serviceIP}
 
 	// Trying to ensure this matches iptables.List()
-	ruleString := "-A " + hairpinChain + " -s " + endpointIP + "/32" + " -d " +
+	ruleString := "-A " + ipvsHairpinChainName + " -s " + endpointIP + "/32" + " -d " +
 		endpointIP + "/32" + " -m ipvs" + " --vaddr " + serviceIP + " --vport " +
 		strconv.Itoa(servicePort) + " -j SNAT" + " --to-source " + serviceIP
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -352,7 +352,7 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 	// https://www.kernel.org/doc/Documentation/networking/ipvs-sysctl.txt
 	// enable ipvs connection tracking
 	sysctlErr := utils.SetSysctl(utils.IPv4IPVSConntrack, ipvsConntrackEnable)
-	if sysctlErr != nil && sysctlErr.IsFatal() {
+	if sysctlErr != nil {
 		klog.Error(sysctlErr.Error())
 	}
 

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -123,7 +123,7 @@ func (ln *linuxNetworking) configureContainerForDSR(
 
 	// disable rp_filter on all interface
 	sysctlErr := utils.SetSysctlSingleTemplate(utils.IPv4ConfRPFilterTemplate, "kube-tunnel-if", 0)
-	if sysctlErr != nil && sysctlErr.IsFatal() {
+	if sysctlErr != nil {
 		attemptNamespaceResetAfterError(hostNetworkNamespaceHandle)
 		return fmt.Errorf("failed to disable rp_filter on kube-tunnel-if in the endpoint container: %s",
 			sysctlErr.Error())
@@ -134,13 +134,13 @@ func (ln *linuxNetworking) configureContainerForDSR(
 	// this may shift sometime in the future with a different runtime. It would be better to find a reliable way to
 	// determine the interface name from inside the container.
 	sysctlErr = utils.SetSysctlSingleTemplate(utils.IPv4ConfRPFilterTemplate, "eth0", 0)
-	if sysctlErr != nil && sysctlErr.IsFatal() {
+	if sysctlErr != nil {
 		attemptNamespaceResetAfterError(hostNetworkNamespaceHandle)
 		return fmt.Errorf("failed to disable rp_filter on eth0 in the endpoint container: %s", sysctlErr.Error())
 	}
 
 	sysctlErr = utils.SetSysctlSingleTemplate(utils.IPv4ConfRPFilterTemplate, "all", 0)
-	if sysctlErr != nil && sysctlErr.IsFatal() {
+	if sysctlErr != nil {
 		attemptNamespaceResetAfterError(hostNetworkNamespaceHandle)
 		return fmt.Errorf("failed to disable rp_filter on `all` in the endpoint container: %s", sysctlErr.Error())
 	}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -252,13 +252,13 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 			"not work: %s", err.Error())
 	}
 	sysctlErr := utils.SetSysctl(utils.BridgeNFCallIPTables, 1)
-	if sysctlErr != nil && sysctlErr.IsFatal() {
+	if sysctlErr != nil {
 		klog.Errorf("Failed to enable iptables for bridge. Network policies and service proxy may "+
 			"not work: %s", sysctlErr.Error())
 	}
 	if nrc.isIpv6 {
 		sysctlErr = utils.SetSysctl(utils.BridgeNFCallIP6Tables, 1)
-		if sysctlErr != nil && sysctlErr.IsFatal() {
+		if sysctlErr != nil {
 			klog.Errorf("Failed to enable ip6tables for bridge. Network policies and service proxy may "+
 				"not work: %s", sysctlErr.Error())
 		}


### PR DESCRIPTION
@mrueg @murali-reddy 

I was a little quick on this one. I added a check for `IsFatal()` (which returns false when the path doesn't exist) to some of the error checks for `utils.SetSysctl()`. However, for some of the conditions, this just stops us from logging messages (as the error handling doesn't results in only a logging statement), which isn't helpful.

For the cases of DSR, we probably want the condition to be fatal even if `utils.SetSysctl()` isn't able to find the path (which was the previous behavior).