### PR TITLE
Fix Misc DSR Issues

### DIFF
--- a/docs/dsr.md
+++ b/docs/dsr.md
@@ -1,0 +1,125 @@
+# Direct Server Return
+
+## More Information
+
+For a more detailed explanation on how to use Direct Server Return (DSR) to build a highly scalable and available ingress for Kubernetes see the following blog post:
+https://cloudnativelabs.github.io/post/2017-11-01-kube-high-available-ingress/
+
+## What is DSR?
+
+When enabled, DSR allows the service endpoint to respond directly to the client request, bypassing the service proxy. When DSR is enabled kube-router will use LVS's tunneling mode to achieve this (more on how later).
+
+## Quick Start
+
+You can enable DSR functionality on a per service basis.
+
+Requirements:
+* ClusterIP type service has an externalIP set on it or is a LoadBalancer type service
+* kube-router has been started with `--service-external-ip-range` configured at least once. This option can be specified multiple times for multiple ranges. The external IPs or LoadBalancer IPs must be included in these ranges.
+* kube-router must be run in service proxy mode with `--run-service-proxy` (this option is defaulted to `true` if left unspecified)
+* If you are advertising the service outside the cluster `--advertise-external-ip` must be set
+* If kube-router is deployed as a Kubernetes pod:
+    * `hostIPC: true` must be set for the pod
+    * `hostPID: true` must be set for the pod
+    * The container runtime socket must be mounted into the kube-router pod via a `hostPath` volume mount.
+
+To enable DSR you need to annotate service with the `kube-router.io/service.dsr=tunnel` annotation:
+```
+kubectl annotate service my-service "kube-router.io/service.dsr=tunnel"
+```
+
+## Things To Lookout For
+* In the current implementation, **DSR will only be available to the external IPs or LoadBalancer IPs**
+* **The current implementation does not support port remapping.** So you need to use same port and target port for the service.
+* In order for DSR to work correctly, an `ipip` tunnel to the pod is used. This reduces the [MTU](https://en.wikipedia.org/wiki/Maximum_transmission_unit) for the packet by 20 bytes. Because of the way DSR works it is not possible for clients to use [PMTU](https://en.wikipedia.org/wiki/Path_MTU_Discovery) to discover this MTU reduction. In TCP based services, we mitigate this by using iptables to set the [TCP MSS](https://en.wikipedia.org/wiki/Maximum_segment_size) value to 20 bytes less than kube-router's primary interface MTU size. However, it is not possible to do this for UDP streams. Therefore, UDP streams that continuously use large packets may see a performance impact due to packet fragmentation. Additionally, if clients set the `DF` (Do Not Fragment) bit, services may see packet loss on UDP services.
+
+## Kubernetes Pod Examples
+As mentioned previously, if kube-router is run as a Kubernetes deployment, there are a couple of things needed on the deployment. Below is an example of what is necessary to get going (this is NOT a full deployment, it is just meant to highlight the elements needed for DSR):
+```
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    k8s-app: kube-router
+    tier: node
+  name: kube-router
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-router
+      tier: node
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-router
+        tier: node
+    spec:
+      hostNetwork: true
+      hostIPC: true
+      hostPID: true
+      volumes:
+      - name: run
+        hostPath:
+          path: /var/run/docker.sock
+      ...
+      containers:
+      - name: kube-router
+        image: docker.io/cloudnativelabs/kube-router:latest
+        ...
+        volumeMounts:
+        - name: run
+          mountPath: /var/run/docker.sock
+          readOnly: true
+...
+```
+
+For an example manifest please look at the [kube-router all features manifest](../daemonset/kubeadm-kuberouter-all-features-dsr.yaml) with DSR requirements for Docker enabled.
+
+### DSR with containerd or cri-o
+
+As of kube-router-1.2.X and later, kube-router's DSR mode now works with non-docker container runtimes. Officially only containerd has been tested, but this solution should work with cri-o as well.
+
+Most of what was said above also applies for non-docker container runtimes, however, there are some adjustments that you'll need to make:
+* You'll need to let kube-router know what container runtime socket to use via the `--runtime-endpoint` CLI parameter
+* If running kube-router as a Kubernetes deployment you'll need to make sure that you expose the correct socket via `hostPath` volume mount
+
+Here is an example kube-router daemonset manifest with just the changes needed to enable DSR with containerd (this is not a full manifest, it is just meant to highlight differences):
+```
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-router
+spec:
+  template:
+    spec:
+    ...
+      volumes:
+      - name: containerd-sock
+        hostPath:
+          path: /run/containerd/containerd.sock
+      ...
+      containers:
+      - name: kube-router
+        args:
+        - --runtime-endpoint=unix:///run/containerd/containerd.sock
+        ...
+        volumeMounts:
+        - name: containerd-sock
+          mountPath: /run/containerd/containerd.sock
+          readOnly: true
+...
+```
+
+## More Details About DSR
+
+In order to facilitate troubleshooting it is worth while to explain how kube-router accomplishes DSR functionality.
+
+1. kube-router adds iptables rules to the `mangle` table which marks incoming packets destined for DSR based services with a unique FW mark. This mark is then used in later stages to identify the packet and route it correctly. Additionally, for TCP streams, there are rules that enable [TCP MSS](https://en.wikipedia.org/wiki/Maximum_segment_size) since the packets will change MTU when traversing an ipip tunnel later on.
+2. kube-router adds the marks to an `ip rule` (see: [ip-rule(8)](https://man7.org/linux/man-pages/man8/ip-rule.8.html)). This ip rule then forces the incoming DSR service packets to use a specific routing table.
+3. kube-router adds a new `ip route` table (at the time of this writing the table number is `78`) which forces the packet to route to the host even though there are no interfaces on the host that carry the DSR IP address
+4. kube-router adds an IPVS server configured for the custom FW mark. When packets arrive on the localhost interface because of the above `ip rule` and `ip route`, IPVS will intercept them based on their unique FW mark.
+5. When pods selected by the DSR service become ready, kube-router adds endpoints configured for tunnel mode to the above IPVS server. Each endpoint is configured in tunnel mode (as opposed to masquerade mode), which then encapsulates the incoming packet in an ipip packet. It is at this point that the pod's destination IP is placed on the ipip packet header so that a packet can be routed to the pod via the kube-bridge on either this host or the destination host.
+6. kube-router then finds the targeted pod and enters it's local network namespace. Once inside the pod's linux network namespace, it sets up two new interfaces called `kube-dummy-if` and `ipip`. `kube-dummy-if` is configured with the externalIP address of the service.
+7. When the ipip packet arrives inside the pod, the original source packet with the externalIP is then extracted from the ipip packet via the `ipip` interface and is accepted to the listening application via the `kube-dummy-if` interface.
+8. When the application sends its response back to the client, it responds to the client's public IP address (since that is what it saw on the request's IP header) and the packet is returned directly to the client (as opposed to traversing the Kubernetes internal network and potentially making multiple intermediate hops)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -225,33 +225,6 @@ If you want to also hairpin externalIPs declared for Service `my-service` (note,
 kubectl annotate service my-service "kube-router.io/service.hairpin.externalips="
 ```
 
-## Direct server return
-
-Please read below blog on how to user DSR in combination with `--advertise-external-ip` to build highly scalable and available ingress.
-https://cloudnativelabs.github.io/post/2017-11-01-kube-high-available-ingress/
-
-You can enable DSR(Direct Server Return) functionality per service. When enabled service endpoint
-will directly respond to the client by passing the service proxy. When DSR is enabled Kube-router 
-will uses LVS's tunneling mode to achieve this.
-
-To enable DSR you need to annotate service with `kube-router.io/service.dsr=tunnel` annotation. For e.g.
-
-```
-kubectl annotate service my-service "kube-router.io/service.dsr=tunnel"
-```
-
-**In the current implementation when annotation is applied on the service, DSR will be applicable only to the external IP's.**
-
-**Also when DSR is used, current implementation does not support port remapping. So you need to use same port and target port for the service**
-
-You will need to enable `hostIPC: true` and `hostPID: true` in kube-router daemonset manifest.
-Also host path `/var/run/docker.sock` must be made a volumemount to kube-router.
-
-Above changes are required for kube-router to enter pod namespeace and create ipip tunnel in the pod and to 
-assign the external IP to the VIP. 
-
-For an e.g manifest please look at [manifest](../daemonset/kubeadm-kuberouter-all-features-dsr.yaml) with DSR requirements enabled.
-
 ## SNATing Service Traffic
 By default, as traffic ingresses into the cluster, kube-router will source nat the traffic to ensure symmetric routing if it needs to proxy that traffic to ensure it gets to a node that has a service pod that is capable of servicing the traffic. This has a potential to cause issues when network policies are applied to that service since now the traffic will appear to be coming from a node in your cluster instead of the traffic originator.
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1649,7 +1649,13 @@ func ipvsServiceString(s *ipvs.Service) string {
 		flags += "[flag-3]"
 	}
 
-	return fmt.Sprintf("%s:%s:%v (Flags: %s)", protocol, s.Address, s.Port, flags)
+	// FWMark entries don't contain a protocol, address, or port which means that we need to log them differently so as
+	// not to confuse users
+	if s.FWMark != 0 {
+		return fmt.Sprintf("FWMark:%d (Flags: %s)", s.FWMark, flags)
+	} else {
+		return fmt.Sprintf("%s:%s:%v (Flags: %s)", protocol, s.Address, s.Port, flags)
+	}
 }
 
 func ipvsDestinationString(d *ipvs.Destination) string {

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1749,10 +1749,8 @@ func (ln *linuxNetworking) ipvsAddService(svcs []*ipvs.Service, vip net.IP, prot
 				}
 				klog.V(2).Infof("Updated schedule for the service: %s", ipvsServiceString(svc))
 			}
-			// TODO: Make this debug output when we get log levels
-			// klog.Fatal("ipvs service %s:%s:%s already exists so returning", vip.String(),
-			// 	protocol, strconv.Itoa(int(port)))
 
+			klog.V(2).Infof("ipvs service %s already exists so returning", ipvsServiceString(svc))
 			return svc, nil
 		}
 	}
@@ -1850,10 +1848,8 @@ func (ln *linuxNetworking) ipvsAddFWMarkService(vip net.IP, protocol, port uint1
 				}
 				klog.V(2).Infof("Updated schedule for the service: %s", ipvsServiceString(svc))
 			}
-			// TODO: Make this debug output when we get log levels
-			// klog.Fatal("ipvs service %s:%s:%s already exists so returning", vip.String(),
-			// 	protocol, strconv.Itoa(int(port)))
 
+			klog.V(2).Infof("ipvs service %s already exists so returning", ipvsServiceString(svc))
 			return svc, nil
 		}
 	}
@@ -1891,9 +1887,8 @@ func (ln *linuxNetworking) ipvsAddServer(service *ipvs.Service, dest *ipvs.Desti
 			return fmt.Errorf("failed to update ipvs destination %s to the ipvs service %s due to : %s",
 				ipvsDestinationString(dest), ipvsServiceString(service), err.Error())
 		}
-		// TODO: Make this debug output when we get log levels
-		// klog.Infof("ipvs destination %s already exists in the ipvs service %s so not adding destination",
-		// 	ipvsDestinationString(dest), ipvsServiceString(service))
+		klog.V(2).Infof("ipvs destination %s already exists in the ipvs service %s so not adding destination",
+			ipvsDestinationString(dest), ipvsServiceString(service))
 	} else {
 		return fmt.Errorf("failed to add ipvs destination %s to the ipvs service %s due to : %s",
 			ipvsDestinationString(dest), ipvsServiceString(service), err.Error())

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -48,6 +48,11 @@ const (
 	IpvsSvcFSched2    = "flag-2"
 	IpvsSvcFSched3    = "flag-3"
 
+	customDSRRouteTableID    = "78"
+	customDSRRouteTableName  = "kube-router-dsr"
+	externalIPRouteTableID   = "79"
+	externalIPRouteTableName = "external_ip"
+
 	// Taken from https://github.com/torvalds/linux/blob/master/include/uapi/linux/ip_vs.h#L21
 	ipvsPersistentFlagHex = 0x0001
 	ipvsHashedFlagHex     = 0x0002
@@ -1895,13 +1900,6 @@ func (ln *linuxNetworking) ipvsAddServer(service *ipvs.Service, dest *ipvs.Desti
 	}
 	return nil
 }
-
-const (
-	customDSRRouteTableID    = "78"
-	customDSRRouteTableName  = "kube-router-dsr"
-	externalIPRouteTableID   = "79"
-	externalIPRouteTableName = "external_ip"
-)
 
 // setupMangleTableRule: sets up iptables rule to FWMARK the traffic to external IP vip
 func setupMangleTableRule(ip string, protocol string, port string, fwmark string, tcpMSS int) error {

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -898,48 +898,6 @@ func (nsc *NetworkServicesController) publishMetrics(serviceInfoMap serviceInfoM
 	return nil
 }
 
-// TODO Move to utils
-func unsortedListsEquivalent(a, b []endpointsInfo) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	values := make(map[interface{}]int)
-	for _, val := range a {
-		values[val] = 1
-	}
-	for _, val := range b {
-		values[val]++
-	}
-
-	for _, val := range values {
-		if val == 1 {
-			return false
-		}
-	}
-
-	return true
-}
-
-func endpointsMapsEquivalent(a, b endpointsInfoMap) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for key, valA := range a {
-		valB, ok := b[key]
-		if !ok {
-			return false
-		}
-
-		if !unsortedListsEquivalent(valA, valB) {
-			return false
-		}
-	}
-
-	return true
-}
-
 // OnEndpointsUpdate handle change in endpoints update from the API server
 func (nsc *NetworkServicesController) OnEndpointsUpdate(ep *api.Endpoints) {
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1851,6 +1851,7 @@ func (ln *linuxNetworking) cleanupMangleTableRule(ip string, protocol string, po
 		return errors.New("Failed to cleanup iptables command to set up FWMARK due to " + err.Error())
 	}
 	if exists {
+		klog.V(2).Infof("removing mangle rule with: iptables -D PREROUTING -t mangle %s", args)
 		err = iptablesCmdHandler.Delete("mangle", "PREROUTING", args...)
 		if err != nil {
 			return errors.New("Failed to cleanup iptables command to set up FWMARK due to " + err.Error())
@@ -1861,6 +1862,7 @@ func (ln *linuxNetworking) cleanupMangleTableRule(ip string, protocol string, po
 		return errors.New("Failed to cleanup iptables command to set up FWMARK due to " + err.Error())
 	}
 	if exists {
+		klog.V(2).Infof("removing mangle rule with: iptables -D OUTPUT -t mangle %s", args)
 		err = iptablesCmdHandler.Delete("mangle", "OUTPUT", args...)
 		if err != nil {
 			return errors.New("Failed to cleanup iptables command to set up FWMARK due to " + err.Error())
@@ -1875,6 +1877,7 @@ func (ln *linuxNetworking) cleanupMangleTableRule(ip string, protocol string, po
 		return errors.New("Failed to cleanup iptables command to set up TCPMSS due to " + err.Error())
 	}
 	if exists {
+		klog.V(2).Infof("removing mangle rule with: iptables -D PREROUTING -t mangle %s", args)
 		err = iptablesCmdHandler.Delete("mangle", "PREROUTING", mtuArgs...)
 		if err != nil {
 			return errors.New("Failed to cleanup iptables command to set up TCPMSS due to " + err.Error())
@@ -1886,6 +1889,7 @@ func (ln *linuxNetworking) cleanupMangleTableRule(ip string, protocol string, po
 		return errors.New("Failed to cleanup iptables command to set up TCPMSS due to " + err.Error())
 	}
 	if exists {
+		klog.V(2).Infof("removing mangle rule with: iptables -D POSTROUTING -t mangle %s", args)
 		err = iptablesCmdHandler.Delete("mangle", "POSTROUTING", mtuArgs...)
 		if err != nil {
 			return errors.New("Failed to cleanup iptables command to set up TCPMSS due to " + err.Error())

--- a/pkg/controllers/proxy/network_services_controller_moq.go
+++ b/pkg/controllers/proxy/network_services_controller_moq.go
@@ -36,7 +36,7 @@ var _ LinuxNetworking = &LinuxNetworkingMock{}
 // 			ipAddrDelFunc: func(iface netlink.Link, ip string) error {
 // 				panic("mock out the ipAddrDel method")
 // 			},
-// 			ipvsAddFWMarkServiceFunc: func(fwMark uint32, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
+// 			ipvsAddFWMarkServiceFunc: func(svcs []*ipvs.Service, fwMark uint32, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
 // 				panic("mock out the ipvsAddFWMarkService method")
 // 			},
 // 			ipvsAddServerFunc: func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error {
@@ -104,7 +104,7 @@ type LinuxNetworkingMock struct {
 	ipAddrDelFunc func(iface netlink.Link, ip string) error
 
 	// ipvsAddFWMarkServiceFunc mocks the ipvsAddFWMarkService method.
-	ipvsAddFWMarkServiceFunc func(fwMark uint32, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error)
+	ipvsAddFWMarkServiceFunc func(svcs []*ipvs.Service, fwMark uint32, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error)
 
 	// ipvsAddServerFunc mocks the ipvsAddServer method.
 	ipvsAddServerFunc func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error
@@ -197,6 +197,8 @@ type LinuxNetworkingMock struct {
 		}
 		// ipvsAddFWMarkService holds details about calls to the ipvsAddFWMarkService method.
 		ipvsAddFWMarkService []struct {
+			// Svcs is the svcs argument value.
+			Svcs []*ipvs.Service
 			// FwMark is the fwMark argument value.
 			FwMark uint32
 			// Protocol is the protocol argument value.
@@ -528,11 +530,12 @@ func (mock *LinuxNetworkingMock) ipAddrDelCalls() []struct {
 }
 
 // ipvsAddFWMarkService calls ipvsAddFWMarkServiceFunc.
-func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(fwMark uint32, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
+func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(svcs []*ipvs.Service, fwMark uint32, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
 	if mock.ipvsAddFWMarkServiceFunc == nil {
 		panic("LinuxNetworkingMock.ipvsAddFWMarkServiceFunc: method is nil but LinuxNetworking.ipvsAddFWMarkService was just called")
 	}
 	callInfo := struct {
+		Svcs              []*ipvs.Service
 		FwMark            uint32
 		Protocol          uint16
 		Port              uint16
@@ -541,6 +544,7 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(fwMark uint32, protocol ui
 		Scheduler         string
 		Flags             schedFlags
 	}{
+		Svcs:              svcs,
 		FwMark:            fwMark,
 		Protocol:          protocol,
 		Port:              port,
@@ -552,13 +556,14 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(fwMark uint32, protocol ui
 	mock.lockipvsAddFWMarkService.Lock()
 	mock.calls.ipvsAddFWMarkService = append(mock.calls.ipvsAddFWMarkService, callInfo)
 	mock.lockipvsAddFWMarkService.Unlock()
-	return mock.ipvsAddFWMarkServiceFunc(fwMark, protocol, port, persistent, persistentTimeout, scheduler, flags)
+	return mock.ipvsAddFWMarkServiceFunc(svcs, fwMark, protocol, port, persistent, persistentTimeout, scheduler, flags)
 }
 
 // ipvsAddFWMarkServiceCalls gets all the calls that were made to ipvsAddFWMarkService.
 // Check the length with:
 //     len(mockedLinuxNetworking.ipvsAddFWMarkServiceCalls())
 func (mock *LinuxNetworkingMock) ipvsAddFWMarkServiceCalls() []struct {
+	Svcs              []*ipvs.Service
 	FwMark            uint32
 	Protocol          uint16
 	Port              uint16
@@ -568,6 +573,7 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkServiceCalls() []struct {
 	Flags             schedFlags
 } {
 	var calls []struct {
+		Svcs              []*ipvs.Service
 		FwMark            uint32
 		Protocol          uint16
 		Port              uint16

--- a/pkg/controllers/proxy/network_services_controller_moq.go
+++ b/pkg/controllers/proxy/network_services_controller_moq.go
@@ -36,7 +36,7 @@ var _ LinuxNetworking = &LinuxNetworkingMock{}
 // 			ipAddrDelFunc: func(iface netlink.Link, ip string) error {
 // 				panic("mock out the ipAddrDel method")
 // 			},
-// 			ipvsAddFWMarkServiceFunc: func(vip net.IP, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
+// 			ipvsAddFWMarkServiceFunc: func(fwMark uint32, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
 // 				panic("mock out the ipvsAddFWMarkService method")
 // 			},
 // 			ipvsAddServerFunc: func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error {
@@ -104,7 +104,7 @@ type LinuxNetworkingMock struct {
 	ipAddrDelFunc func(iface netlink.Link, ip string) error
 
 	// ipvsAddFWMarkServiceFunc mocks the ipvsAddFWMarkService method.
-	ipvsAddFWMarkServiceFunc func(vip net.IP, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error)
+	ipvsAddFWMarkServiceFunc func(fwMark uint32, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error)
 
 	// ipvsAddServerFunc mocks the ipvsAddServer method.
 	ipvsAddServerFunc func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error
@@ -197,8 +197,8 @@ type LinuxNetworkingMock struct {
 		}
 		// ipvsAddFWMarkService holds details about calls to the ipvsAddFWMarkService method.
 		ipvsAddFWMarkService []struct {
-			// Vip is the vip argument value.
-			Vip net.IP
+			// FwMark is the fwMark argument value.
+			FwMark uint32
 			// Protocol is the protocol argument value.
 			Protocol uint16
 			// Port is the port argument value.
@@ -528,12 +528,12 @@ func (mock *LinuxNetworkingMock) ipAddrDelCalls() []struct {
 }
 
 // ipvsAddFWMarkService calls ipvsAddFWMarkServiceFunc.
-func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(vip net.IP, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
+func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(fwMark uint32, protocol uint16, port uint16, persistent bool, persistentTimeout int32, scheduler string, flags schedFlags) (*ipvs.Service, error) {
 	if mock.ipvsAddFWMarkServiceFunc == nil {
 		panic("LinuxNetworkingMock.ipvsAddFWMarkServiceFunc: method is nil but LinuxNetworking.ipvsAddFWMarkService was just called")
 	}
 	callInfo := struct {
-		Vip               net.IP
+		FwMark            uint32
 		Protocol          uint16
 		Port              uint16
 		Persistent        bool
@@ -541,7 +541,7 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(vip net.IP, protocol uint1
 		Scheduler         string
 		Flags             schedFlags
 	}{
-		Vip:               vip,
+		FwMark:            fwMark,
 		Protocol:          protocol,
 		Port:              port,
 		Persistent:        persistent,
@@ -552,14 +552,14 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkService(vip net.IP, protocol uint1
 	mock.lockipvsAddFWMarkService.Lock()
 	mock.calls.ipvsAddFWMarkService = append(mock.calls.ipvsAddFWMarkService, callInfo)
 	mock.lockipvsAddFWMarkService.Unlock()
-	return mock.ipvsAddFWMarkServiceFunc(vip, protocol, port, persistent, persistentTimeout, scheduler, flags)
+	return mock.ipvsAddFWMarkServiceFunc(fwMark, protocol, port, persistent, persistentTimeout, scheduler, flags)
 }
 
 // ipvsAddFWMarkServiceCalls gets all the calls that were made to ipvsAddFWMarkService.
 // Check the length with:
 //     len(mockedLinuxNetworking.ipvsAddFWMarkServiceCalls())
 func (mock *LinuxNetworkingMock) ipvsAddFWMarkServiceCalls() []struct {
-	Vip               net.IP
+	FwMark            uint32
 	Protocol          uint16
 	Port              uint16
 	Persistent        bool
@@ -568,7 +568,7 @@ func (mock *LinuxNetworkingMock) ipvsAddFWMarkServiceCalls() []struct {
 	Flags             schedFlags
 } {
 	var calls []struct {
-		Vip               net.IP
+		FwMark            uint32
 		Protocol          uint16
 		Port              uint16
 		Persistent        bool

--- a/pkg/controllers/proxy/network_services_controller_test.go
+++ b/pkg/controllers/proxy/network_services_controller_test.go
@@ -185,8 +185,8 @@ var _ = Describe("NetworkServicesController", func() {
 			Expect(syncErr).To(Succeed())
 		})
 		It("Should have called cleanupMangleTableRule for ExternalIPs", func() {
-			fwmark1, _ := generateFwmark("1.1.1.1", tcpProtocol, "8080")
-			fwmark2, _ := generateFwmark("2.2.2.2", tcpProtocol, "8080")
+			fwmark1, _ := nsc.generateUniqueFWMark("1.1.1.1", tcpProtocol, "8080")
+			fwmark2, _ := nsc.generateUniqueFWMark("2.2.2.2", tcpProtocol, "8080")
 			Expect(
 				fmt.Sprintf("%v", mockedLinuxNetworking.cleanupMangleTableRuleCalls())).To(
 				Equal(

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -497,7 +497,7 @@ func (nsc *NetworkServicesController) setupForDSR(serviceInfoMap serviceInfoMap)
 		return fmt.Errorf("failed setup custom routing table required to add routes for external IP's due to: %v",
 			err)
 	}
-	klog.V(1).Infof("Custom routing table required for Direct Server Return is setup as expected.",
+	klog.V(1).Infof("Custom routing table required for Direct Server Return (%s) is setup as expected.",
 		externalIPRouteTableName)
 	return nil
 }

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -320,8 +320,8 @@ func (nsc *NetworkServicesController) setupExternalIPServices(serviceInfoMap ser
 					klog.Errorf("failed to generate FW mark")
 					continue
 				}
-				ipvsExternalIPSvc, err := nsc.ln.ipvsAddFWMarkService(fwMark, protocol,
-					uint16(svc.port), svc.sessionAffinity, svc.sessionAffinityTimeoutSeconds, svc.scheduler, svc.flags)
+				ipvsExternalIPSvc, err := nsc.ln.ipvsAddFWMarkService(ipvsSvcs, fwMark, protocol, uint16(svc.port),
+					svc.sessionAffinity, svc.sessionAffinityTimeoutSeconds, svc.scheduler, svc.flags)
 				if err != nil {
 					klog.Errorf("failed to create IPVS service for External IP: %s due to: %s",
 						externalIP, err.Error())

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -315,77 +315,83 @@ func (nsc *NetworkServicesController) setupExternalIPServices(serviceInfoMap ser
 		for _, externalIP := range extIPSet.List() {
 			var externalIPServiceID string
 			if svc.directServerReturn && svc.directServerReturnMethod == tunnelInterfaceType {
-				ipvsExternalIPSvc, err := nsc.ln.ipvsAddFWMarkService(net.ParseIP(externalIP), protocol,
+				fwMark, err := nsc.generateUniqueFWMark(externalIP, svc.protocol, strconv.Itoa(svc.port))
+				if err != nil {
+					klog.Errorf("failed to generate FW mark")
+					continue
+				}
+				ipvsExternalIPSvc, err := nsc.ln.ipvsAddFWMarkService(fwMark, protocol,
 					uint16(svc.port), svc.sessionAffinity, svc.sessionAffinityTimeoutSeconds, svc.scheduler, svc.flags)
 				if err != nil {
-					klog.Errorf("Failed to create ipvs service for External IP: %s due to: %s",
+					klog.Errorf("failed to create IPVS service for External IP: %s due to: %s",
 						externalIP, err.Error())
 					continue
 				}
 				externalIPServices = append(externalIPServices, externalIPService{ipvsSvc: ipvsExternalIPSvc,
 					externalIP: externalIP})
-				fwMark, err := generateFwmark(externalIP, svc.protocol, strconv.Itoa(svc.port))
-				if err != nil {
-					klog.Errorf("Failed to generate Fwmark")
-					continue
-				}
+
 				externalIPServiceID = fmt.Sprint(fwMark)
 
 				// ensure there is iptables mangle table rule to FWMARK the packet
 				err = setupMangleTableRule(externalIP, svc.protocol, strconv.Itoa(svc.port), externalIPServiceID,
 					nsc.dsrTCPMSS)
 				if err != nil {
-					klog.Errorf("Failed to setup mangle table rule to FMWARD the traffic to external IP")
+					klog.Errorf("failed to setup mangle table rule to forward the traffic to external IP")
 					continue
 				}
 
 				// ensure VIP less director. we dont assign VIP to any interface
 				err = nsc.ln.ipAddrDel(dummyVipInterface, externalIP)
 				if err != nil && err.Error() != IfaceHasNoAddr {
-					klog.Errorf("Failed to delete external ip address from dummyVipInterface due to %s", err)
+					klog.Errorf("failed to delete external ip address from dummyVipInterface due to %v", err)
 					continue
 				}
 				// do policy routing to deliver the packet locally so that IPVS can pick the packet
 				err = routeVIPTrafficToDirector("0x" + fmt.Sprintf("%x", fwMark))
 				if err != nil {
-					klog.Errorf("Failed to setup ip rule to lookup traffic to external IP: %s through custom "+
-						"route table due to %s", externalIP, err.Error())
+					klog.Errorf("failed to setup ip rule to lookup traffic to external IP: %s through custom "+
+						"route table due to %v", externalIP, err)
 					continue
 				}
 			} else {
 				// ensure director with vip assigned
 				err := nsc.ln.ipAddrAdd(dummyVipInterface, externalIP, true)
 				if err != nil && err.Error() != IfaceHasAddr {
-					klog.Errorf("Failed to assign external ip %s to dummy interface %s due to %s",
-						externalIP, KubeDummyIf, err.Error())
+					klog.Errorf("failed to assign external ip %s to dummy interface %s due to %v",
+						externalIP, KubeDummyIf, err)
 				}
 
 				// create IPVS service for the service to be exposed through the external ip
 				ipvsExternalIPSvc, err := nsc.ln.ipvsAddService(ipvsSvcs, net.ParseIP(externalIP), protocol,
 					uint16(svc.port), svc.sessionAffinity, svc.sessionAffinityTimeoutSeconds, svc.scheduler, svc.flags)
 				if err != nil {
-					klog.Errorf("Failed to create ipvs service for external ip: %s due to %s",
-						externalIP, err.Error())
+					klog.Errorf("failed to create ipvs service for external ip: %s due to %v",
+						externalIP, err)
 					continue
 				}
 				externalIPServices = append(externalIPServices, externalIPService{
 					ipvsSvc: ipvsExternalIPSvc, externalIP: externalIP})
 				externalIPServiceID = generateIPPortID(externalIP, svc.protocol, strconv.Itoa(svc.port))
 
-				// ensure there is NO iptables mangle table rule to FWMARK the packet
-				fwmark, err := generateFwmark(externalIP, svc.protocol, strconv.Itoa(svc.port))
+				// ensure there is NO iptables mangle table rule to FW mark the packet
+				fwMark, err := nsc.lookupFWMarkByService(externalIP, svc.protocol, strconv.Itoa(svc.port))
 				if err != nil {
-					klog.Errorf("Failed to generate a fwmark due to " + err.Error())
+					klog.V(1).Infof("no FW mark found for service, nothing to cleanup: %v", err)
 					continue
 				}
-				fwMark := fmt.Sprint(fwmark)
+				klog.V(1).Infof("the following service '%s:%s:%d' had fwMark associated with it: %d doing "+
+					"additional cleanup", externalIP, svc.protocol, svc.port, fwMark)
+				if err = nsc.cleanupDSRService(fwMark); err != nil {
+					klog.Errorf("failed to cleanup DSR service: %v", err)
+				}
+				fwMarkStr := fmt.Sprint(fwMark)
 				for _, mangleTableRule := range mangleTableRules {
-					if strings.Contains(mangleTableRule, externalIP) && strings.Contains(mangleTableRule, fwMark) {
-						err = nsc.ln.cleanupMangleTableRule(externalIP, svc.protocol, strconv.Itoa(svc.port), fwMark,
+					if strings.Contains(mangleTableRule, externalIP) && strings.Contains(mangleTableRule, fwMarkStr) {
+						err = nsc.ln.cleanupMangleTableRule(externalIP, svc.protocol, strconv.Itoa(svc.port), fwMarkStr,
 							nsc.dsrTCPMSS)
 						if err != nil {
-							klog.Errorf("Failed to verify and cleanup any mangle table rule to FMWARD the traffic " +
-								"to external IP due to " + err.Error())
+							klog.Errorf("failed to verify and cleanup any mangle table rule to FORWARD the traffic "+
+								"to external IP due to: %v", err)
 							continue
 						}
 					}
@@ -552,6 +558,8 @@ func (nsc *NetworkServicesController) cleanupStaleIPVSConfig(activeServiceEndpoi
 
 	var protocol string
 	for _, ipvsSvc := range ipvsSvcs {
+		// Note that this isn't all that safe of an assumption because FWMark services have a completely different
+		// protocol. So do SCTP services. However, we don't deal with SCTP in kube-router and FWMark is handled below.
 		if ipvsSvc.Protocol == syscall.IPPROTO_TCP {
 			protocol = tcpProtocol
 		} else {
@@ -587,7 +595,15 @@ func (nsc *NetworkServicesController) cleanupStaleIPVSConfig(activeServiceEndpoi
 
 			klog.V(1).Infof("Found a IPVS service %s which is no longer needed so cleaning up",
 				ipvsServiceString(ipvsSvc))
-			err := nsc.ln.ipvsDelService(ipvsSvc)
+			if ipvsSvc.FWMark != 0 {
+				_, _, _, err = nsc.lookupServiceByFWMark(ipvsSvc.FWMark)
+				if err != nil {
+					klog.V(1).Infof("no FW mark found for service, nothing to cleanup: %v", err)
+				} else if err = nsc.cleanupDSRService(ipvsSvc.FWMark); err != nil {
+					klog.Errorf("failed to cleanup DSR service: %v", err)
+				}
+			}
+			err = nsc.ln.ipvsDelService(ipvsSvc)
 			if err != nil {
 				klog.Errorf("Failed to delete stale IPVS service %s due to: %s",
 					ipvsServiceString(ipvsSvc), err.Error())
@@ -618,6 +634,20 @@ func (nsc *NetworkServicesController) cleanupStaleIPVSConfig(activeServiceEndpoi
 			}
 		}
 	}
+	return nil
+}
+
+// cleanupDSRService takes an FW mark was its only input and uses that to lookup the service and then remove DSR
+// specific pieces of that service that may be left-over from the service provisioning.
+func (nsc *NetworkServicesController) cleanupDSRService(fwMark uint32) error {
+	// nolint:dogsled // ignore this for now, we'll fix this in the next commit
+	_, _, _, err := nsc.lookupServiceByFWMark(fwMark)
+	if err != nil {
+		return fmt.Errorf("no service was found for FW mark: %d, service may not be all the way cleaned up: %v",
+			fwMark, err)
+	}
+	// cleanup the fwMarkMap to ensure that we don't accidentally build state
+	delete(nsc.fwMarkMap, fwMark)
 	return nil
 }
 

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -237,3 +237,48 @@ func (nsc *NetworkServicesController) lookupServiceByFWMark(fwMark uint32) (stri
 	}
 	return serviceKeySplit[0], serviceKeySplit[1], int(port), nil
 }
+
+// unsortedListsEquivalent compares two lists of endpointsInfo and considers them the same if they contains the same
+// contents regardless of order. Returns true if both lists contain the same contents.
+func unsortedListsEquivalent(a, b []endpointsInfo) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	values := make(map[interface{}]int)
+	for _, val := range a {
+		values[val] = 1
+	}
+	for _, val := range b {
+		values[val]++
+	}
+
+	for _, val := range values {
+		if val == 1 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// endpointsMapsEquivalent compares two maps of endpointsInfoMap to see if they have the same keys and values. Returns
+// true if both maps contain the same keys and values.
+func endpointsMapsEquivalent(a, b endpointsInfoMap) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for key, valA := range a {
+		valB, ok := b[key]
+		if !ok {
+			return false
+		}
+
+		if !unsortedListsEquivalent(valA, valB) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/controllers/proxy/utils_test.go
+++ b/pkg/controllers/proxy/utils_test.go
@@ -1,0 +1,138 @@
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getMoqNSC() *NetworkServicesController {
+	lnm := NewLinuxNetworkMock()
+	mockedLinuxNetworking := &LinuxNetworkingMock{
+		cleanupMangleTableRuleFunc:         lnm.cleanupMangleTableRule,
+		getKubeDummyInterfaceFunc:          lnm.getKubeDummyInterface,
+		ipAddrAddFunc:                      lnm.ipAddrAdd,
+		ipvsAddServerFunc:                  lnm.ipvsAddServer,
+		ipvsAddServiceFunc:                 lnm.ipvsAddService,
+		ipvsDelServiceFunc:                 lnm.ipvsDelService,
+		ipvsGetDestinationsFunc:            lnm.ipvsGetDestinations,
+		ipvsGetServicesFunc:                lnm.ipvsGetServices,
+		setupPolicyRoutingForDSRFunc:       lnm.setupPolicyRoutingForDSR,
+		setupRoutesForExternalIPForDSRFunc: lnm.setupRoutesForExternalIPForDSR,
+	}
+	return &NetworkServicesController{
+		nodeIP:       net.ParseIP("10.0.0.0"),
+		nodeHostName: "node-1",
+		ln:           mockedLinuxNetworking,
+		fwMarkMap:    map[uint32]string{},
+	}
+}
+
+func TestNetworkServicesController_generateUniqueFWMark(t *testing.T) {
+	t.Run("ensure same service protocol and port get same FW mark", func(t *testing.T) {
+		nsc := getMoqNSC()
+		fwMark1, err1 := nsc.generateUniqueFWMark("10.255.0.1", "TCP", "80")
+		fwMark2, err2 := nsc.generateUniqueFWMark("10.255.0.1", "TCP", "80")
+
+		assert.NoError(t, err1, "there shouldn't have been an error calling generateUniqueFWMark the first time")
+		assert.NoError(t, err2, "there shouldn't have been an error calling generateUniqueFWMark the second time")
+
+		assert.Equal(t, fwMark1, fwMark2,
+			"expected the FW marks for generateUniqueFWMark to be the same when called with the same parameters")
+	})
+
+	t.Run("ensure FW marks cannot be duplicated", func(t *testing.T) {
+		nsc := getMoqNSC()
+		fwMark1, err1 := nsc.generateUniqueFWMark("10.255.0.1", "TCP", "80")
+		// Now we change the port number of the backing map so that when generateUniqueFWMark evaluates the same service
+		// it will find that it doesn't match and give attempt to give us a new FW mark
+		nsc.fwMarkMap[fwMark1] = fmt.Sprintf("%s-%s-%s", "10.255.0.1", "TCP", "81")
+
+		fwMark2, err2 := nsc.generateUniqueFWMark("10.255.0.1", "TCP", "80")
+
+		assert.NoError(t, err1, "there shouldn't have been an error calling generateUniqueFWMark the first time")
+		assert.NoError(t, err2, "there shouldn't have been an error calling generateUniqueFWMark the second time")
+
+		assert.NotEqual(t, fwMark1, fwMark2,
+			"expected the FW marks for generateUniqueFWMark to be different when we changed the "+
+				"stored service key of the fwMarkMap")
+	})
+
+	t.Run("ensure error is passed when generateUniqueFWMark is filled", func(t *testing.T) {
+		nsc := getMoqNSC()
+		fwMark1, err1 := nsc.generateUniqueFWMark("10.255.0.1", "TCP", "80")
+		assert.NoError(t, err1, "there shouldn't have been an error calling generateUniqueFWMark the first time")
+		// Artificially fill up the fwMarkMap using the same way that the function internally would increment the
+		// service if it conflicted which is <ip>-<protocol>-<port>-<increment> up to maxUniqueFWMarkInc size
+		for i := 1; i < 16380+1; i++ {
+			_, err1 = nsc.generateUniqueFWMark("10.255.0.1", "TCP", fmt.Sprintf("80-%d", i))
+			assert.NoError(t, err1, "there shouldn't have been an error calling generateUniqueFWMark the %d time", i)
+		}
+		// Then we need to change the original FW mark so that it doesn't just return that one as a match
+		nsc.fwMarkMap[fwMark1] = fmt.Sprintf("%s-%s-%s", "10.255.0.1", "TCP", "81")
+
+		fwMark2, err2 := nsc.generateUniqueFWMark("10.255.0.1", "TCP", "80")
+
+		assert.EqualError(t, err2,
+			fmt.Sprintf("could not obtain a unique FWMark for %s:%s:%s after %d tries", "TCP", "10.255.0.1", "80", 16380),
+			"expected an error after filling up the internal fwMarkMap with possibilities")
+		assert.Equal(t, uint32(0), fwMark2, "excepted FW mark to be 0 after an error")
+	})
+}
+
+func TestNetworkServicesController_lookupFWMarkByService(t *testing.T) {
+	t.Run("ensure existing FW mark is found in lookup", func(t *testing.T) {
+		nsc := getMoqNSC()
+		fwMark1, err1 := nsc.generateUniqueFWMark("10.255.0.1", "TCP", "80")
+		fwMark2, err2 := nsc.lookupFWMarkByService("10.255.0.1", "TCP", "80")
+
+		assert.NoError(t, err1, "there shouldn't have been an error calling generateUniqueFWMark")
+		assert.NoError(t, err2, "there shouldn't have been an error calling lookupFWMarkByService")
+
+		assert.Equal(t, fwMark1, fwMark2,
+			"given the same inputs, lookupFWMarkByService should be able to find the previously generated FW mark")
+	})
+	t.Run("ensure error is returned when a service doesn't exist in FW mark map", func(t *testing.T) {
+		nsc := getMoqNSC()
+		fwMark, err := nsc.lookupFWMarkByService("10.255.0.1", "TCP", "80")
+
+		assert.EqualErrorf(t, err,
+			fmt.Sprintf("no key matching %s:%s:%s was found in fwMarkMap", "TCP", "10.255.0.1", "80"),
+			"expected to get an error when service had not yet been added to fwMarkMap")
+		assert.Equal(t, uint32(0), fwMark, "expected FW mark to be 0 on error condition")
+	})
+}
+
+func TestNetworkServicesController_lookupServiceByFWMark(t *testing.T) {
+	t.Run("ensure that the found service matches the same inputs that were passed in to create the FW mark", func(t *testing.T) {
+		ip := "10.255.0.1"
+		protocol := "TCP"
+		port := 80
+		nsc := getMoqNSC()
+
+		fwMark, err := nsc.generateUniqueFWMark(ip, protocol, strconv.Itoa(port))
+
+		assert.NoError(t, err, "there shouldn't have been an error calling generateUniqueFWMark")
+
+		foundIP, foundProtocol, foundPort, err1 := nsc.lookupServiceByFWMark(fwMark)
+
+		assert.NoError(t, err1, "there shouldn't have been an error calling lookupServiceByFWMark")
+		assert.Equal(t, ip, foundIP, "IP addresses should match given matching inputs")
+		assert.Equal(t, protocol, foundProtocol, "protocol should match given matching inputs")
+		assert.Equal(t, port, foundPort, "port should match given matching inputs")
+	})
+
+	t.Run("ensure error is returned if no service is found for FW mark", func(t *testing.T) {
+		nsc := getMoqNSC()
+		foundIP, foundProtocol, foundPort, err1 := nsc.lookupServiceByFWMark(uint32(1002))
+
+		assert.Errorf(t, err1, "could not find service matching the given FW mark",
+			"an error should be returned for a made-up FW mark")
+		assert.Empty(t, foundIP, "IP should be empty on error")
+		assert.Empty(t, foundProtocol, "protocol should be empty on error")
+		assert.Zero(t, foundPort, "port should be zero on error")
+	})
+}


### PR DESCRIPTION
@murali-reddy / @mrueg 

This fixes multiple issues with DSR services: #1167, #1045, & #1055

* It ensures that FW marks are unique for each service IP / port / protocol
* It ensures that DSR iptables rules are cleaned up (something that has been broken since iptables-save was introduced in the NSC)
* It improves documentation for DSR and for containerd / cri-o DSR use-cases
* It reduces large code blocks

I've tested this pretty extensively on a small testing cluster, but I haven't put it through real-world development/production scenarios.