### PR TITLE
Fix Hairpinning

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -440,14 +440,17 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 			switch perform {
 			case synctypeAll:
 				klog.V(1).Info("Performing requested full sync of services")
-				err := nsc.doSync()
+				err = nsc.doSync()
 				if err != nil {
 					klog.Errorf("Error during full sync in network service controller. Error: " + err.Error())
 				}
 			case synctypeIpvs:
+				// We call the component pieces of doSync() here because for methods that send this on the channel they
+				// have already done expensive pieces of the doSync() method like building service and endpoint info
+				// and we don't want to duplicate the effort, so this is a slimmer version of doSync()
 				klog.V(1).Info("Performing requested sync of ipvs services")
 				nsc.mu.Lock()
-				err := nsc.syncIpvsServices(nsc.serviceMap, nsc.endpointsMap)
+				err = nsc.syncIpvsServices(nsc.serviceMap, nsc.endpointsMap)
 				nsc.mu.Unlock()
 				if err != nil {
 					klog.Errorf("Error during ipvs sync in network service controller. Error: " + err.Error())

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1423,11 +1423,11 @@ func (nsc *NetworkServicesController) syncHairpinIptablesRules() error {
 	}
 
 	// Apply the rules we need
-	for _, ruleArgs := range rulesNeeded {
+	for rule, ruleArgs := range rulesNeeded {
 		ruleExists := false
 		for _, ruleFromNode := range rulesFromNode {
-			_, ruleExists = rulesNeeded[ruleFromNode]
-			if ruleExists {
+			if rule == ruleFromNode {
+				ruleExists = true
 				break
 			}
 		}

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -451,10 +451,14 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 				klog.V(1).Info("Performing requested sync of ipvs services")
 				nsc.mu.Lock()
 				err = nsc.syncIpvsServices(nsc.serviceMap, nsc.endpointsMap)
-				nsc.mu.Unlock()
 				if err != nil {
 					klog.Errorf("Error during ipvs sync in network service controller. Error: " + err.Error())
 				}
+				err = nsc.syncHairpinIptablesRules()
+				if err != nil {
+					klog.Errorf("Error syncing hairpin iptables rules: %s", err.Error())
+				}
+				nsc.mu.Unlock()
 			}
 			if err == nil {
 				healthcheck.SendHeartBeat(healthChan, "NSC")


### PR DESCRIPTION
@murali-reddy @mrueg 

Fixes #1196 

Found a couple of bugs in the way that the Network Services Controller handles hairpinning updates.

Specifically:
* Hairpinning wasn't being updated on service / endpoint updates and only on startup / full sync
* The check for existing hairpinning rules was returning true as soon as any of the existing host rules matched any of the perspective add rules. This caused NSC to exit the check early and find matches incorrectly.