### PR TITLE
Remove Duplicate Iptables Sync Metrics

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -229,8 +229,6 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		endTime := time.Since(start)
 		if npc.MetricsEnabled {
 			metrics.ControllerIptablesSyncTime.Observe(endTime.Seconds())
-			metrics.ControllerIptablesSyncTotalTime.Add(endTime.Seconds())
-			metrics.ControllerIptablesSyncTotalCount.Add(1)
 		}
 		klog.V(1).Infof("sync iptables took %v", endTime)
 	}()
@@ -658,8 +656,6 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 		// Register the metrics for this controller
 		prometheus.MustRegister(metrics.ControllerIptablesSyncTime)
 		prometheus.MustRegister(metrics.ControllerPolicyChainsSyncTime)
-		prometheus.MustRegister(metrics.ControllerIptablesSyncTotalTime)
-		prometheus.MustRegister(metrics.ControllerIptablesSyncTotalCount)
 		npc.MetricsEnabled = true
 	}
 

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -100,18 +100,6 @@ var (
 		Name:      "controller_iptables_sync_time",
 		Help:      "Time it took for controller to sync iptables",
 	})
-	// ControllerIptablesSyncTotalTime Time it took for controller to sync iptables
-	ControllerIptablesSyncTotalTime = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      "controller_iptables_sync_total_time",
-		Help:      "Time it took for controller to sync iptables as a counter",
-	})
-	// ControllerIptablesSyncTotalCount Number of times the controller synced iptables for individual pods
-	ControllerIptablesSyncTotalCount = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      "controller_iptables_sync_total_count",
-		Help:      "Total number of times kube-router synced iptables",
-	})
 	// ControllerIpvsServicesSyncTime Time it took for controller to sync ipvs services
 	ControllerIpvsServicesSyncTime = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: namespace,


### PR DESCRIPTION
@mrueg @murali-reddy 

@MikeSpreitzer pointed out that these metrics are already present in the histogram type as *_count and *_sum and these two added metrics just add duplicates. I've also proved out in my own environments that these metric values are identical to the ones already carried in the histogram.