### PR TITLE
prometheus metrics: add option to specify listen address

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -72,6 +72,7 @@ Usage of kube-router:
       --kubeconfig string                             Path to kubeconfig file with authorization information (the master location is set by the master flag).
       --masquerade-all                                SNAT all traffic to cluster IP/node port.
       --master string                                 The address of the Kubernetes API server (overrides any value in kubeconfig).
+      --metrics-addr string                           Prometheus metrics address to listen on, (Default: all interfaces)
       --metrics-path string                           Prometheus metrics path (default "/metrics")
       --metrics-port uint16                           Prometheus metrics port, (Default 0, Disabled)
       --nodeport-bindon-all-ip                        For service of NodePort type create IPVS service that listens on all IP's of the node.

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -169,7 +169,7 @@ func (mc *Controller) Run(healthChan chan<- *healthcheck.ControllerHeartbeat, st
 	prometheus.MustRegister(BuildInfo)
 	prometheus.MustRegister(ControllerIpvsMetricsExportTime)
 
-	srv := &http.Server{Addr: mc.MetricsAddr + strconv.Itoa(int(mc.MetricsPort)), Handler: http.DefaultServeMux}
+	srv := &http.Server{Addr: mc.MetricsAddr + ":" + strconv.Itoa(int(mc.MetricsPort)), Handler: http.DefaultServeMux}
 
 	// add prometheus handler on metrics path
 	http.Handle(mc.MetricsPath, promhttp.Handler())
@@ -198,7 +198,7 @@ func (mc *Controller) Run(healthChan chan<- *healthcheck.ControllerHeartbeat, st
 // NewMetricsController returns new MetricController object
 func NewMetricsController(config *options.KubeRouterConfig) (*Controller, error) {
 	mc := Controller{}
-	mc.MetricsAddr = config.MetricsAddr + ":"
+	mc.MetricsAddr = config.MetricsAddr
 	mc.MetricsPath = config.MetricsPath
 	mc.MetricsPort = config.MetricsPort
 	return &mc, nil

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -153,6 +153,7 @@ var (
 // Controller Holds settings for the metrics controller
 type Controller struct {
 	MetricsPath string
+	MetricsAddr string
 	MetricsPort uint16
 }
 
@@ -168,7 +169,7 @@ func (mc *Controller) Run(healthChan chan<- *healthcheck.ControllerHeartbeat, st
 	prometheus.MustRegister(BuildInfo)
 	prometheus.MustRegister(ControllerIpvsMetricsExportTime)
 
-	srv := &http.Server{Addr: ":" + strconv.Itoa(int(mc.MetricsPort)), Handler: http.DefaultServeMux}
+	srv := &http.Server{Addr: mc.MetricsAddr + strconv.Itoa(int(mc.MetricsPort)), Handler: http.DefaultServeMux}
 
 	// add prometheus handler on metrics path
 	http.Handle(mc.MetricsPath, promhttp.Handler())
@@ -197,6 +198,11 @@ func (mc *Controller) Run(healthChan chan<- *healthcheck.ControllerHeartbeat, st
 // NewMetricsController returns new MetricController object
 func NewMetricsController(config *options.KubeRouterConfig) (*Controller, error) {
 	mc := Controller{}
+	if config.MetricsAddr == "" {
+		mc.MetricsAddr = ":"
+	} else {
+		mc.MetricsAddr = config.MetricsAddr
+	}
 	mc.MetricsPath = config.MetricsPath
 	mc.MetricsPort = config.MetricsPort
 	return &mc, nil

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -198,11 +198,7 @@ func (mc *Controller) Run(healthChan chan<- *healthcheck.ControllerHeartbeat, st
 // NewMetricsController returns new MetricController object
 func NewMetricsController(config *options.KubeRouterConfig) (*Controller, error) {
 	mc := Controller{}
-	if config.MetricsAddr == "" {
-		mc.MetricsAddr = ":"
-	} else {
-		mc.MetricsAddr = config.MetricsAddr
-	}
+	mc.MetricsAddr = config.MetricsAddr + ":"
 	mc.MetricsPath = config.MetricsPath
 	mc.MetricsPort = config.MetricsPort
 	return &mc, nil

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -53,6 +53,7 @@ type KubeRouterConfig struct {
 	MetricsEnabled                 bool
 	MetricsPath                    string
 	MetricsPort                    uint16
+	MetricsAddr                    string
 	NodePortBindOnAllIP            bool
 	NodePortRange                  string
 	OverlayType                    string
@@ -167,6 +168,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"The address of the Kubernetes API server (overrides any value in kubeconfig).")
 	fs.StringVar(&s.MetricsPath, "metrics-path", "/metrics", "Prometheus metrics path")
 	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, (Default 0, Disabled)")
+	fs.StringVar(&s.MetricsAddr, "metrics-addr", ":", "Prometheus metrics address to listen on, (Default :, all interfaces)")
 	fs.BoolVar(&s.NodePortBindOnAllIP, "nodeport-bindon-all-ip", false,
 		"For service of NodePort type create IPVS service that listens on all IP's of the node.")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", true,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -168,7 +168,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"The address of the Kubernetes API server (overrides any value in kubeconfig).")
 	fs.StringVar(&s.MetricsPath, "metrics-path", "/metrics", "Prometheus metrics path")
 	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, (Default 0, Disabled)")
-	fs.StringVar(&s.MetricsAddr, "metrics-addr", ":", "Prometheus metrics address to listen on, (Default :, all interfaces)")
+	fs.StringVar(&s.MetricsAddr, "metrics-addr", "", "Prometheus metrics address to listen on, (Default: all interfaces)")
 	fs.BoolVar(&s.NodePortBindOnAllIP, "nodeport-bindon-all-ip", false,
 		"For service of NodePort type create IPVS service that listens on all IP's of the node.")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", true,


### PR DESCRIPTION
In the situation that you have multiple interfaces/IP addresses, we want to be able to specify which one we want to expose the prometheus metrics on.