### PR TITLE
Refactor ExternalIP Service Handling

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -44,7 +44,7 @@ Usage of kube-router:
       --advertise-external-ip                         Add External IP of service to the RIB so that it gets advertised to the BGP peers.
       --advertise-loadbalancer-ip                     Add LoadbBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
       --advertise-pod-cidr                            Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
-      --auto-mtu                                      Auto detect and set the largest possible MTU for pod interfaces. (default true)
+      --auto-mtu                                      Auto detect and set the largest possible MTU for kube-bridge and pod interfaces (also accounts for IPIP overlay network when enabled). (default true)
       --bgp-graceful-restart                          Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
       --bgp-graceful-restart-deferral-time duration   BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h. (default 6m0s)
       --bgp-graceful-restart-time duration            BGP Graceful restart time according to RFC4724 3, maximum 4095s. (default 1m30s)

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -994,11 +994,6 @@ func (nsc *NetworkServicesController) OnServiceUpdate(svc *api.Service) {
 	}
 }
 
-type externalIPService struct {
-	ipvsSvc    *ipvs.Service
-	externalIP string
-}
-
 func hasActiveEndpoints(endpoints []endpointsInfo) bool {
 	for _, endpoint := range endpoints {
 		if endpoint.isLocal {

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -299,6 +299,19 @@ func convertSvcProtoToSysCallProto(svcProtocol string) uint16 {
 	}
 }
 
+// convertSysCallProtoToSvcProto converts a syscall based protocol version to a string representation that Kubernetes
+// and other parts of kube-router understand
+func convertSysCallProtoToSvcProto(sysProtocol uint16) string {
+	switch sysProtocol {
+	case syscall.IPPROTO_TCP:
+		return tcpProtocol
+	case syscall.IPPROTO_UDP:
+		return udpProtocol
+	default:
+		return noneProtocol
+	}
+}
+
 // addDSRIPInsidePodNetNamespace takes a given external IP and endpoint IP for a DSR service and then uses the container
 // runtime to add the external IP to a virtual interface inside the pod so that it can receive DSR traffic inside its
 // network namespace.

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -103,7 +103,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.AdvertiseNodePodCidr, "advertise-pod-cidr", true,
 		"Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers.")
 	fs.BoolVar(&s.AutoMTU, "auto-mtu", true,
-		"Auto detect and set the largest possible MTU for pod interfaces.")
+		"Auto detect and set the largest possible MTU for kube-bridge and pod interfaces (also accounts for "+
+			"IPIP overlay network when enabled).")
 	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time",


### PR DESCRIPTION
FYI @murali-reddy / @mrueg 

I was sitting down to fix the dangling mangle iptables declarations and consolidate them into KUBE-ROUTER chains, but I found that I kept running afoul of the way external IP services are handled in the NSC. The logic is very complicated and keeps bouncing around with multiple permanent objects being tracked.

This attempts to simplify the external IP service handling into something that is more contained, has specific purposes, is better laid out by functionality, and can hopefully be modified more easily in an upcoming PR.