### PR TITLE
fix(NPC): add missing quotes

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -420,7 +420,7 @@ func (npc *NetworkPolicyController) ensureExplicitAccept() {
 	// for the traffic to/from the local pod's let network policy controller be
 	// authoritative entity to ACCEPT the traffic if it complies to network policies
 	for _, chain := range defaultChains {
-		args := []string{"-m", "comment", "--comment", "rule to explicitly ACCEPT traffic that comply to network policies",
+		args := []string{"-m", "comment", "--comment", "\"explicitly ACCEPT traffic that complies with network policies\"",
 			"-m", "mark", "--mark", "0x20000/0x20000", "-j", "ACCEPT"}
 		npc.filterTableRules = utils.AppendUnique(npc.filterTableRules, chain, args)
 	}


### PR DESCRIPTION
Missed this in my review of #1261. Without this, it is missing quotes and iptables-restore fails to function.