### PR TITLE
fix(NSC): don't check protocol on DSR svcs

### DIFF
--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -525,7 +525,9 @@ func (nsc *NetworkServicesController) cleanupStaleIPVSConfig(activeServiceEndpoi
 		// Note that this isn't all that safe of an assumption because FWMark services have a completely different
 		// protocol. So do SCTP services. However, we don't deal with SCTP in kube-router and FWMark is handled below.
 		protocol = convertSysCallProtoToSvcProto(ipvsSvc.Protocol)
-		if protocol == noneProtocol {
+		// FWMark services by definition don't have a protocol, so we exclude those from the conditional so that they
+		// can be cleaned up correctly.
+		if protocol == noneProtocol && ipvsSvc.FWMark == 0 {
 			klog.Warningf("failed to convert protocol %d to a valid IPVS protocol for service: %s skipping",
 				ipvsSvc.Protocol, ipvsSvc.Address.String())
 			continue


### PR DESCRIPTION
DSR IPVS entries inherently don't have a protocol, so don't check for protocol with these services and ensure that they are cleaned up correctly.

Fixes #1328 

