### PR TITLE
netpol: Add dual-stack support (updated)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -57,7 +57,7 @@ Usage of kube-router:
       --enable-cni                                    Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin. (default true)
       --enable-ibgp                                   Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)
       --enable-ipv4                                   Enables IPv4 support (default true)
-      --enable-ipv6                                   Enables IPv6 support (default true)
+      --enable-ipv6                                   Enables IPv6 support
       --enable-overlay                                When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastructure is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
       --enable-pod-egress                             SNAT traffic from Pods to destinations outside the cluster. (default true)
       --enable-pprof                                  Enables pprof for debugging performance and memory leak issues.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -56,6 +56,8 @@ Usage of kube-router:
       --disable-source-dest-check                     Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way. (default true)
       --enable-cni                                    Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin. (default true)
       --enable-ibgp                                   Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)
+      --enable-ipv4                                   Enables IPv4 support (default true)
+      --enable-ipv6                                   Enables IPv6 support (default true)
       --enable-overlay                                When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across nodes in different subnets. When set to false no tunneling is used and routing infrastructure is expected to route traffic for pod-to-pod networking across nodes in different subnets (default true)
       --enable-pod-egress                             SNAT traffic from Pods to destinations outside the cluster. (default true)
       --enable-pprof                                  Enables pprof for debugging performance and memory leak issues.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -93,7 +93,7 @@ Usage of kube-router:
       --run-router                                    Enables Pod Networking -- Advertises and learns the routes to Pods via iBGP. (default true)
       --run-service-proxy                             Enables Service Proxy -- sets up IPVS for Kubernetes Services. (default true)
       --runtime-endpoint string                       Path to CRI compatible container runtime socket (used for DSR mode). Currently known working with containerd.
-      --service-cluster-ip-range string               CIDR value from which service cluster IPs are assigned. Default: 10.96.0.0/12 (default "10.96.0.0/12")
+      --service-cluster-ip-range string               CIDR value from which service cluster IPs are assigned. If dual-stack is used, this can be a comma-separated list of CIDR value. Default: 10.96.0.0/12 (default "10.96.0.0/12")
       --service-external-ip-range strings             Specify external IP CIDRs that are used for inter-cluster communication (can be specified multiple times)
       --service-node-port-range string                NodePort range specified with either a hyphen or colon (default "30000-32767")
   -v, --v string                                      log level for V logs (default "0")

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/client-go v0.24.4
 	k8s.io/cri-api v0.24.4
 	k8s.io/klog/v2 v2.70.1
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 )
 
 require (
@@ -96,7 +97,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.0.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -184,7 +184,7 @@ func (kr *KubeRouter) Run() error {
 	}
 
 	if kr.Config.RunFirewall {
-		iptablesCmdHandlers, ipSetHandlers, err := netpol.NewIpTablesHandler(kr.Config)
+		iptablesCmdHandlers, ipSetHandlers, err := netpol.NewIPTablesHandler(kr.Config)
 		if err != nil {
 			return errors.New("Failed to create iptables handlers: " + err.Error())
 		}

--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -15,12 +14,9 @@ import (
 	"github.com/cloudnativelabs/kube-router/pkg/healthcheck"
 	"github.com/cloudnativelabs/kube-router/pkg/metrics"
 	"github.com/cloudnativelabs/kube-router/pkg/options"
-	"github.com/cloudnativelabs/kube-router/pkg/utils"
 	"github.com/cloudnativelabs/kube-router/pkg/version"
-	"github.com/coreos/go-iptables/iptables"
 	"k8s.io/klog/v2"
 
-	v1core "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -188,39 +184,12 @@ func (kr *KubeRouter) Run() error {
 	}
 
 	if kr.Config.RunFirewall {
-		iptablesCmdHandlers := make(map[v1core.IPFamily]utils.IPTablesHandler, 2)
-		ipSetHandlers := make(map[v1core.IPFamily]utils.IPSetHandler, 2)
-
-		if kr.Config.EnableIPv4 {
-			iptHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
-			if err != nil {
-				return fmt.Errorf("failed to create iptables handler: %w", err)
-			}
-			iptablesCmdHandlers[v1core.IPv4Protocol] = iptHandler
-
-			ipset, err := utils.NewIPSet(false)
-			if err != nil {
-				return fmt.Errorf("failed to create ipset handler: %w", err)
-			}
-			ipSetHandlers[v1core.IPv4Protocol] = ipset
+		iptablesCmdHandlers, ipSetHandlers, err := netpol.NewIpTablesHandler(kr.Config)
+		if err != nil {
+			return errors.New("Failed to create iptables handlers: " + err.Error())
 		}
-		if kr.Config.EnableIPv6 {
-			iptHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
-			if err != nil {
-				return fmt.Errorf("failed to create iptables handler: %w", err)
-			}
-			iptablesCmdHandlers[v1core.IPv6Protocol] = iptHandler
-
-			ipset, err := utils.NewIPSet(true)
-			if err != nil {
-				return fmt.Errorf("failed to create ipset handler: %w", err)
-			}
-			ipSetHandlers[v1core.IPv6Protocol] = ipset
-		}
-
 		npc, err := netpol.NewNetworkPolicyController(kr.Client,
-			kr.Config, podInformer, npInformer, nsInformer, &ipsetMutex,
-			iptablesCmdHandlers, ipSetHandlers)
+			kr.Config, podInformer, npInformer, nsInformer, &ipsetMutex, iptablesCmdHandlers, ipSetHandlers)
 		if err != nil {
 			return errors.New("Failed to create network policy controller: " + err.Error())
 		}

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -15,13 +15,14 @@ import (
 	"github.com/cloudnativelabs/kube-router/pkg/metrics"
 	"github.com/cloudnativelabs/kube-router/pkg/options"
 	"github.com/cloudnativelabs/kube-router/pkg/utils"
-	"github.com/coreos/go-iptables/iptables"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog/v2"
 
+	v1core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -62,19 +63,23 @@ var (
 
 // NetworkPolicyController struct to hold information required by NetworkPolicyController
 type NetworkPolicyController struct {
-	nodeIP                  net.IP
-	nodeHostName            string
-	serviceClusterIPRange   net.IPNet
-	serviceExternalIPRanges []net.IPNet
-	serviceNodePortRange    string
-	mu                      sync.Mutex
-	syncPeriod              time.Duration
-	MetricsEnabled          bool
-	healthChan              chan<- *healthcheck.ControllerHeartbeat
-	fullSyncRequestChan     chan struct{}
-	ipsetMutex              *sync.Mutex
+	nodeHostName                   string
+	primaryServiceClusterIPRange   *net.IPNet
+	secondaryServiceClusterIPRange *net.IPNet
+	serviceExternalIPRanges        []net.IPNet
+	serviceNodePortRange           string
+	mu                             sync.Mutex
+	syncPeriod                     time.Duration
+	MetricsEnabled                 bool
+	healthChan                     chan<- *healthcheck.ControllerHeartbeat
+	fullSyncRequestChan            chan struct{}
+	ipsetMutex                     *sync.Mutex
 
-	ipSetHandler *utils.IPSet
+	iptablesCmdHandlers map[v1core.IPFamily]utils.IPTablesHandler
+	iptablesSaveRestore map[v1core.IPFamily]*utils.IPTablesSaveRestore
+	filterTableRules    map[v1core.IPFamily]*bytes.Buffer
+	ipSetHandlers       map[v1core.IPFamily]utils.IPSetHandler
+	nodeIPs             map[v1core.IPFamily]net.IP
 
 	podLister cache.Indexer
 	npLister  cache.Indexer
@@ -83,8 +88,6 @@ type NetworkPolicyController struct {
 	PodEventHandler           cache.ResourceEventHandler
 	NamespaceEventHandler     cache.ResourceEventHandler
 	NetworkPolicyEventHandler cache.ResourceEventHandler
-
-	filterTableRules bytes.Buffer
 }
 
 // internal structure to represent a network policy
@@ -108,7 +111,7 @@ type networkPolicyInfo struct {
 
 // internal structure to represent Pod
 type podInfo struct {
-	ip        string
+	ips       []v1core.PodIP
 	name      string
 	namespace string
 	labels    map[string]string
@@ -121,7 +124,7 @@ type ingressRule struct {
 	namedPorts     []endPoints
 	matchAllSource bool
 	srcPods        []podInfo
-	srcIPBlocks    [][]string
+	srcIPBlocks    map[v1core.IPFamily][][]string
 }
 
 // internal structure to represent NetworkPolicyEgressRule in the spec
@@ -131,7 +134,7 @@ type egressRule struct {
 	namedPorts           []endPoints
 	matchAllDestinations bool
 	dstPods              []podInfo
-	dstIPBlocks          [][]string
+	dstIPBlocks          map[v1core.IPFamily][][]string
 }
 
 type protocolAndPort struct {
@@ -141,7 +144,7 @@ type protocolAndPort struct {
 }
 
 type endPoints struct {
-	ips []string
+	ips map[v1core.IPFamily][]string
 	protocolAndPort
 }
 
@@ -248,15 +251,17 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		return
 	}
 
-	npc.filterTableRules.Reset()
-	if err := utils.SaveInto("filter", &npc.filterTableRules); err != nil {
-		klog.Errorf("Aborting sync. Failed to run iptables-save: %v" + err.Error())
-		return
+	for ipFamily, iptablesSaveRestore := range npc.iptablesSaveRestore {
+		npc.filterTableRules[ipFamily].Reset()
+		if err := iptablesSaveRestore.SaveInto("filter", npc.filterTableRules[ipFamily]); err != nil {
+			klog.Errorf("Aborting sync. Failed to run iptables-save: %v", err.Error())
+			return
+		}
 	}
 
 	activePolicyChains, activePolicyIPSets, err := npc.syncNetworkPolicyChains(networkPoliciesInfo, syncVersion)
 	if err != nil {
-		klog.Errorf("Aborting sync. Failed to sync network policy chains: %v" + err.Error())
+		klog.Errorf("Aborting sync. Failed to sync network policy chains: %v", err.Error())
 		return
 	}
 
@@ -272,10 +277,13 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		return
 	}
 
-	if err := utils.Restore("filter", npc.filterTableRules.Bytes()); err != nil {
-		klog.Errorf("Aborting sync. Failed to run iptables-restore: %v\n%s",
-			err.Error(), npc.filterTableRules.String())
-		return
+	for ipFamily, iptablesSaveRestore := range npc.iptablesSaveRestore {
+		if err := iptablesSaveRestore.Restore("filter",
+			npc.filterTableRules[ipFamily].Bytes()); err != nil {
+			klog.Errorf("Aborting sync. Failed to run iptables-restore: %v\n%s",
+				err.Error(), npc.filterTableRules[ipFamily].String())
+			return
+		}
 	}
 
 	err = npc.cleanupStaleIPSets(activePolicyIPSets)
@@ -283,6 +291,17 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		klog.Errorf("Failed to cleanup stale ipsets: %v", err.Error())
 		return
 	}
+}
+
+func (npc *NetworkPolicyController) iptablesCmdHandlerForCIDR(cidr *net.IPNet) (utils.IPTablesHandler, error) {
+	if netutils.IsIPv4CIDR(cidr) {
+		return npc.iptablesCmdHandlers[v1core.IPv4Protocol], nil
+	}
+	if netutils.IsIPv6CIDR(cidr) {
+		return npc.iptablesCmdHandlers[v1core.IPv6Protocol], nil
+	}
+
+	return nil, fmt.Errorf("invalid CIDR")
 }
 
 // Creates custom chains KUBE-ROUTER-INPUT, KUBE-ROUTER-FORWARD, KUBE-ROUTER-OUTPUT
@@ -295,11 +314,6 @@ func (npc *NetworkPolicyController) ensureTopLevelChains() {
 	const whitelistTCPNodePortsPosition = 2
 	const whitelistUDPNodePortsPosition = 3
 	const externalIPPositionAdditive = 4
-
-	iptablesCmdHandler, err := iptables.New()
-	if err != nil {
-		klog.Fatalf("Failed to initialize iptables executor due to %s", err.Error())
-	}
 
 	addUUIDForRuleSpec := func(chain string, ruleSpec *[]string) (string, error) {
 		hash := sha256.Sum256([]byte(chain + strings.Join(*ruleSpec, "")))
@@ -314,7 +328,8 @@ func (npc *NetworkPolicyController) ensureTopLevelChains() {
 			strings.Join(*ruleSpec, " "))
 	}
 
-	ensureRuleAtPosition := func(chain string, ruleSpec []string, uuid string, position int) {
+	ensureRuleAtPosition := func(
+		iptablesCmdHandler utils.IPTablesHandler, chain string, ruleSpec []string, uuid string, position int) {
 		exists, err := iptablesCmdHandler.Exists("filter", chain, ruleSpec...)
 		if err != nil {
 			klog.Fatalf("Failed to verify rule exists in %s chain due to %s", chain, err.Error())
@@ -358,101 +373,138 @@ func (npc *NetworkPolicyController) ensureTopLevelChains() {
 		}
 	}
 
-	for builtinChain, customChain := range defaultChains {
-		exists, err := iptablesCmdHandler.ChainExists("filter", customChain)
-		if err != nil {
-			klog.Fatalf("failed to check for the existence of chain %s, error: %v", customChain, err)
-		}
-		if !exists {
-			err = iptablesCmdHandler.NewChain("filter", customChain)
+	for _, iptablesCmdHandler := range npc.iptablesCmdHandlers {
+		for builtinChain, customChain := range defaultChains {
+			exists, err := iptablesCmdHandler.ChainExists("filter", customChain)
 			if err != nil {
 				klog.Fatalf("failed to run iptables command to create %s chain due to %s", customChain,
 					err.Error())
 			}
+			if !exists {
+				err = iptablesCmdHandler.NewChain("filter", customChain)
+				if err != nil {
+					klog.Fatalf("failed to run iptables command to create %s chain due to %s", customChain,
+						err.Error())
+				}
+			}
+			args := []string{"-m", "comment", "--comment", "kube-router netpol", "-j", customChain}
+			uuid, err := addUUIDForRuleSpec(builtinChain, &args)
+			if err != nil {
+				klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+			}
+			ensureRuleAtPosition(iptablesCmdHandler,
+				builtinChain, args, uuid, serviceVIPPosition)
 		}
-		args := []string{"-m", "comment", "--comment", "kube-router netpol", "-j", customChain}
-		uuid, err := addUUIDForRuleSpec(builtinChain, &args)
+	}
+
+	if npc.primaryServiceClusterIPRange != nil {
+		whitelistPrimaryServiceVips := []string{"-m", "comment", "--comment", "allow traffic to primary cluster IP range",
+			"-d", npc.primaryServiceClusterIPRange.String(), "-j", "RETURN"}
+		uuid, err := addUUIDForRuleSpec(kubeInputChainName, &whitelistPrimaryServiceVips)
 		if err != nil {
 			klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
 		}
-		ensureRuleAtPosition(builtinChain, args, uuid, 1)
+		iptablesCmdHandler, err := npc.iptablesCmdHandlerForCIDR(npc.primaryServiceClusterIPRange)
+		if err != nil {
+			klog.Fatalf("Failed to get iptables handler: %s", err.Error())
+		}
+		ensureRuleAtPosition(iptablesCmdHandler,
+			kubeInputChainName, whitelistPrimaryServiceVips, uuid, serviceVIPPosition)
+	} else {
+		klog.Fatalf("Primary service cluster IP range is not configured")
 	}
 
-	whitelistServiceVips := []string{"-m", "comment", "--comment", "allow traffic to cluster IP", "-d",
-		npc.serviceClusterIPRange.String(), "-j", "RETURN"}
-	uuid, err := addUUIDForRuleSpec(kubeInputChainName, &whitelistServiceVips)
-	if err != nil {
-		klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+	if npc.secondaryServiceClusterIPRange != nil {
+		whitelistSecondaryServiceVips := []string{"-m", "comment", "--comment", "allow traffic to primary cluster IP range",
+			"-d", npc.secondaryServiceClusterIPRange.String(), "-j", "RETURN"}
+		uuid, err := addUUIDForRuleSpec(kubeInputChainName, &whitelistSecondaryServiceVips)
+		if err != nil {
+			klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+		}
+		iptablesCmdHandler, err := npc.iptablesCmdHandlerForCIDR(npc.secondaryServiceClusterIPRange)
+		if err != nil {
+			klog.Fatalf("Failed to get iptables handler: %s", err.Error())
+		}
+		ensureRuleAtPosition(iptablesCmdHandler,
+			kubeInputChainName, whitelistSecondaryServiceVips, uuid, serviceVIPPosition)
 	}
-	ensureRuleAtPosition(kubeInputChainName, whitelistServiceVips, uuid, serviceVIPPosition)
 
-	whitelistTCPNodeports := []string{"-p", "tcp", "-m", "comment", "--comment",
-		"allow LOCAL TCP traffic to node ports", "-m", "addrtype", "--dst-type", "LOCAL",
-		"-m", "multiport", "--dports", npc.serviceNodePortRange, "-j", "RETURN"}
-	uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistTCPNodeports)
-	if err != nil {
-		klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
-	}
-	ensureRuleAtPosition(kubeInputChainName, whitelistTCPNodeports, uuid, whitelistTCPNodePortsPosition)
+	for _, iptablesCmdHandler := range npc.iptablesCmdHandlers {
+		whitelistTCPNodeports := []string{"-p", "tcp", "-m", "comment", "--comment",
+			"allow LOCAL TCP traffic to node ports", "-m", "addrtype", "--dst-type", "LOCAL",
+			"-m", "multiport", "--dports", npc.serviceNodePortRange, "-j", "RETURN"}
+		uuid, err := addUUIDForRuleSpec(kubeInputChainName, &whitelistTCPNodeports)
+		if err != nil {
+			klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+		}
+		ensureRuleAtPosition(iptablesCmdHandler,
+			kubeInputChainName, whitelistTCPNodeports, uuid, whitelistTCPNodePortsPosition)
 
-	whitelistUDPNodeports := []string{"-p", "udp", "-m", "comment", "--comment",
-		"allow LOCAL UDP traffic to node ports", "-m", "addrtype", "--dst-type", "LOCAL",
-		"-m", "multiport", "--dports", npc.serviceNodePortRange, "-j", "RETURN"}
-	uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistUDPNodeports)
-	if err != nil {
-		klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+		whitelistUDPNodeports := []string{"-p", "udp", "-m", "comment", "--comment",
+			"allow LOCAL UDP traffic to node ports", "-m", "addrtype", "--dst-type", "LOCAL",
+			"-m", "multiport", "--dports", npc.serviceNodePortRange, "-j", "RETURN"}
+		uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistUDPNodeports)
+		if err != nil {
+			klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
+		}
+		ensureRuleAtPosition(iptablesCmdHandler,
+			kubeInputChainName, whitelistUDPNodeports, uuid, whitelistUDPNodePortsPosition)
 	}
-	ensureRuleAtPosition(kubeInputChainName, whitelistUDPNodeports, uuid, whitelistUDPNodePortsPosition)
 
 	for externalIPIndex, externalIPRange := range npc.serviceExternalIPRanges {
 		whitelistServiceVips := []string{"-m", "comment", "--comment",
 			"allow traffic to external IP range: " + externalIPRange.String(), "-d", externalIPRange.String(),
 			"-j", "RETURN"}
-		uuid, err = addUUIDForRuleSpec(kubeInputChainName, &whitelistServiceVips)
+		uuid, err := addUUIDForRuleSpec(kubeInputChainName, &whitelistServiceVips)
 		if err != nil {
 			klog.Fatalf("Failed to get uuid for rule: %s", err.Error())
 		}
-		ensureRuleAtPosition(kubeInputChainName, whitelistServiceVips, uuid, externalIPIndex+externalIPPositionAdditive)
+		// Access externalIPRange via index to avoid implicit memory aliasing
+		iptablesCmdHandler, err := npc.iptablesCmdHandlerForCIDR(&npc.serviceExternalIPRanges[externalIPIndex])
+		if err != nil {
+			klog.Fatalf("Failed to get iptables handler: %s", err.Error())
+		}
+		ensureRuleAtPosition(iptablesCmdHandler,
+			kubeInputChainName, whitelistServiceVips, uuid, externalIPIndex+externalIPPositionAdditive)
 	}
 }
 
 func (npc *NetworkPolicyController) ensureExplicitAccept() {
 	// for the traffic to/from the local pod's let network policy controller be
 	// authoritative entity to ACCEPT the traffic if it complies to network policies
-	for _, chain := range defaultChains {
-		args := []string{"-m", "comment", "--comment", "\"explicitly ACCEPT traffic that complies with network policies\"",
-			"-m", "mark", "--mark", "0x20000/0x20000", "-j", "ACCEPT"}
-		npc.filterTableRules = utils.AppendUnique(npc.filterTableRules, chain, args)
+	for _, filterTableRules := range npc.filterTableRules {
+		for _, chain := range defaultChains {
+			comment := "\"rule to explicitly ACCEPT traffic that comply to network policies\""
+			args := []string{"-m", "comment", "--comment", comment, "-m", "mark", "--mark", "0x20000/0x20000",
+				"-j", "ACCEPT"}
+			utils.AppendUnique(filterTableRules, chain, args)
+		}
 	}
 }
 
 // Creates custom chains KUBE-NWPLCY-DEFAULT
 func (npc *NetworkPolicyController) ensureDefaultNetworkPolicyChain() {
+	for _, iptablesCmdHandler := range npc.iptablesCmdHandlers {
+		markArgs := make([]string, 0)
+		markComment := "rule to mark traffic matching a network policy"
+		markArgs = append(markArgs, "-j", "MARK", "-m", "comment", "--comment", markComment,
+			"--set-xmark", "0x10000/0x10000")
 
-	iptablesCmdHandler, err := iptables.New()
-	if err != nil {
-		klog.Fatalf("Failed to initialize iptables executor due to %s", err.Error())
-	}
-
-	markArgs := make([]string, 0)
-	markComment := "rule to mark traffic matching a network policy"
-	markArgs = append(markArgs, "-j", "MARK", "-m", "comment", "--comment", markComment,
-		"--set-xmark", "0x10000/0x10000")
-
-	exists, err := iptablesCmdHandler.ChainExists("filter", kubeDefaultNetpolChain)
-	if err != nil {
-		klog.Fatalf("failed to check for the existence of chain %s, error: %v", kubeDefaultNetpolChain, err)
-	}
-	if !exists {
-		err = iptablesCmdHandler.NewChain("filter", kubeDefaultNetpolChain)
+		exists, err := iptablesCmdHandler.ChainExists("filter", kubeDefaultNetpolChain)
 		if err != nil {
-			klog.Fatalf("failed to run iptables command to create %s chain due to %s",
-				kubeDefaultNetpolChain, err.Error())
+			klog.Fatalf("failed to check for the existence of chain %s, error: %v", kubeDefaultNetpolChain, err)
 		}
-	}
-	err = iptablesCmdHandler.AppendUnique("filter", kubeDefaultNetpolChain, markArgs...)
-	if err != nil {
-		klog.Fatalf("Failed to run iptables command: %s", err.Error())
+		if !exists {
+			err = iptablesCmdHandler.NewChain("filter", kubeDefaultNetpolChain)
+			if err != nil {
+				klog.Fatalf("failed to run iptables command to create %s chain due to %s",
+					kubeDefaultNetpolChain, err.Error())
+			}
+		}
+		err = iptablesCmdHandler.AppendUnique("filter", kubeDefaultNetpolChain, markArgs...)
+		if err != nil {
+			klog.Fatalf("Failed to run iptables command: %s", err.Error())
+		}
 	}
 }
 
@@ -462,88 +514,82 @@ func (npc *NetworkPolicyController) cleanupStaleRules(activePolicyChains, active
 	cleanupPodFwChains := make([]string, 0)
 	cleanupPolicyChains := make([]string, 0)
 
-	// initialize tool sets for working with iptables and ipset
-	iptablesCmdHandler, err := iptables.New()
-	if err != nil {
-		return fmt.Errorf("failed to initialize iptables command executor due to %s", err.Error())
-	}
+	for ipFamily, iptablesCmdHandler := range npc.iptablesCmdHandlers {
+		// find iptables chains and ipsets that are no longer used by comparing current to the active maps we were passed
+		chains, err := iptablesCmdHandler.ListChains("filter")
+		if err != nil {
+			return fmt.Errorf("unable to list chains: %w", err)
+		}
+		for _, chain := range chains {
+			if strings.HasPrefix(chain, kubeNetworkPolicyChainPrefix) {
+				if chain == kubeDefaultNetpolChain {
+					continue
+				}
+				if _, ok := activePolicyChains[chain]; !ok {
+					cleanupPolicyChains = append(cleanupPolicyChains, chain)
+					continue
+				}
+			}
+			if strings.HasPrefix(chain, kubePodFirewallChainPrefix) {
+				if _, ok := activePodFwChains[chain]; !ok {
+					cleanupPodFwChains = append(cleanupPodFwChains, chain)
+					continue
+				}
+			}
+		}
 
-	// find iptables chains and ipsets that are no longer used by comparing current to the active maps we were passed
-	chains, err := iptablesCmdHandler.ListChains("filter")
-	if err != nil {
-		return fmt.Errorf("unable to list chains: %s", err)
-	}
-	for _, chain := range chains {
-		if strings.HasPrefix(chain, kubeNetworkPolicyChainPrefix) {
-			if chain == kubeDefaultNetpolChain {
-				continue
-			}
-			if _, ok := activePolicyChains[chain]; !ok {
-				cleanupPolicyChains = append(cleanupPolicyChains, chain)
-				continue
-			}
+		var newChains, newRules, desiredFilterTable bytes.Buffer
+		rules := strings.Split(npc.filterTableRules[ipFamily].String(), "\n")
+		if len(rules) > 0 && rules[len(rules)-1] == "" {
+			rules = rules[:len(rules)-1]
 		}
-		if strings.HasPrefix(chain, kubePodFirewallChainPrefix) {
-			if _, ok := activePodFwChains[chain]; !ok {
-				cleanupPodFwChains = append(cleanupPodFwChains, chain)
-				continue
-			}
-		}
-	}
-
-	var newChains, newRules, desiredFilterTable bytes.Buffer
-	rules := strings.Split(npc.filterTableRules.String(), "\n")
-	if len(rules) > 0 && rules[len(rules)-1] == "" {
-		rules = rules[:len(rules)-1]
-	}
-	for _, rule := range rules {
-		skipRule := false
-		for _, podFWChainName := range cleanupPodFwChains {
-			if strings.Contains(rule, podFWChainName) {
-				skipRule = true
-				break
-			}
-		}
-		for _, policyChainName := range cleanupPolicyChains {
-			if strings.Contains(rule, policyChainName) {
-				skipRule = true
-				break
-			}
-		}
-		if deleteDefaultChains {
-			for _, chain := range []string{kubeInputChainName, kubeForwardChainName, kubeOutputChainName,
-				kubeDefaultNetpolChain} {
-				if strings.Contains(rule, chain) {
+		for _, rule := range rules {
+			skipRule := false
+			for _, podFWChainName := range cleanupPodFwChains {
+				if strings.Contains(rule, podFWChainName) {
 					skipRule = true
 					break
 				}
 			}
+			for _, policyChainName := range cleanupPolicyChains {
+				if strings.Contains(rule, policyChainName) {
+					skipRule = true
+					break
+				}
+			}
+			if deleteDefaultChains {
+				for _, chain := range []string{kubeInputChainName, kubeForwardChainName, kubeOutputChainName,
+					kubeDefaultNetpolChain} {
+					if strings.Contains(rule, chain) {
+						skipRule = true
+						break
+					}
+				}
+			}
+			if strings.Contains(rule, "COMMIT") || strings.HasPrefix(rule, "# ") {
+				skipRule = true
+			}
+			if skipRule {
+				continue
+			}
+			if strings.HasPrefix(rule, ":") {
+				newChains.WriteString(rule + " - [0:0]\n")
+			}
+			if strings.HasPrefix(rule, "-") {
+				newRules.WriteString(rule + "\n")
+			}
 		}
-		if strings.Contains(rule, "COMMIT") || strings.HasPrefix(rule, "# ") {
-			skipRule = true
-		}
-		if skipRule {
-			continue
-		}
-		if strings.HasPrefix(rule, ":") {
-			newChains.WriteString(rule + " - [0:0]\n")
-		}
-		if strings.HasPrefix(rule, "-") {
-			newRules.WriteString(rule + "\n")
-		}
+		desiredFilterTable.WriteString("*filter" + "\n")
+		desiredFilterTable.Write(newChains.Bytes())
+		desiredFilterTable.Write(newRules.Bytes())
+		desiredFilterTable.WriteString("COMMIT" + "\n")
+		npc.filterTableRules[ipFamily] = &desiredFilterTable
 	}
-	desiredFilterTable.WriteString("*filter" + "\n")
-	desiredFilterTable.Write(newChains.Bytes())
-	desiredFilterTable.Write(newRules.Bytes())
-	desiredFilterTable.WriteString("COMMIT" + "\n")
-	npc.filterTableRules = desiredFilterTable
 
 	return nil
 }
 
 func (npc *NetworkPolicyController) cleanupStaleIPSets(activePolicyIPSets map[string]bool) error {
-	cleanupPolicyIPSets := make([]*utils.Set, 0)
-
 	// There are certain actions like Cleanup() actions that aren't working with full instantiations of the controller
 	// and in these instances the mutex may not be present and may not need to be present as they are operating out of a
 	// single goroutine where there is no need for locking
@@ -557,27 +603,25 @@ func (npc *NetworkPolicyController) cleanupStaleIPSets(activePolicyIPSets map[st
 		}()
 	}
 
-	ipsets, err := utils.NewIPSet(false)
-	if err != nil {
-		return fmt.Errorf("failed to create ipsets command executor due to %s", err.Error())
-	}
-	err = ipsets.Save()
-	if err != nil {
-		klog.Fatalf("failed to initialize ipsets command executor due to %s", err.Error())
-	}
-	for _, set := range ipsets.Sets {
-		if strings.HasPrefix(set.Name, kubeSourceIPSetPrefix) ||
-			strings.HasPrefix(set.Name, kubeDestinationIPSetPrefix) {
-			if _, ok := activePolicyIPSets[set.Name]; !ok {
-				cleanupPolicyIPSets = append(cleanupPolicyIPSets, set)
+	for _, ipsets := range npc.ipSetHandlers {
+		cleanupPolicyIPSets := make([]*utils.Set, 0)
+
+		if err := ipsets.Save(); err != nil {
+			klog.Fatalf("failed to initialize ipsets command executor due to %s", err.Error())
+		}
+		for _, set := range ipsets.Sets() {
+			if strings.HasPrefix(set.Name, kubeSourceIPSetPrefix) ||
+				strings.HasPrefix(set.Name, kubeDestinationIPSetPrefix) {
+				if _, ok := activePolicyIPSets[set.Name]; !ok {
+					cleanupPolicyIPSets = append(cleanupPolicyIPSets, set)
+				}
 			}
 		}
-	}
-	// cleanup network policy ipsets
-	for _, set := range cleanupPolicyIPSets {
-		err = set.Destroy()
-		if err != nil {
-			return fmt.Errorf("failed to delete ipset %s due to %s", set.Name, err)
+		// cleanup network policy ipsets
+		for _, set := range cleanupPolicyIPSets {
+			if err := set.Destroy(); err != nil {
+				return fmt.Errorf("failed to delete ipset %s due to %s", set.Name, err)
+			}
 		}
 	}
 	return nil
@@ -589,9 +633,11 @@ func (npc *NetworkPolicyController) Cleanup() {
 
 	var emptySet map[string]bool
 	// Take a dump (iptables-save) of the current filter table for cleanupStaleRules() to work on
-	if err := utils.SaveInto("filter", &npc.filterTableRules); err != nil {
-		klog.Errorf("error encountered attempting to list iptables rules for cleanup: %v", err)
-		return
+	for ipFamily, iptablesSaveRestore := range npc.iptablesSaveRestore {
+		if err := iptablesSaveRestore.SaveInto("filter", npc.filterTableRules[ipFamily]); err != nil {
+			klog.Errorf("error encountered attempting to list iptables rules for cleanup: %v", err)
+			return
+		}
 	}
 	// Run cleanupStaleRules() to get rid of most of the kube-router rules (this is the same logic that runs as
 	// part NPC's runtime loop). Setting the last parameter to true causes even the default chains are removed.
@@ -601,10 +647,12 @@ func (npc *NetworkPolicyController) Cleanup() {
 		return
 	}
 	// Restore (iptables-restore) npc's cleaned up version of the iptables filter chain
-	if err = utils.Restore("filter", npc.filterTableRules.Bytes()); err != nil {
-		klog.Errorf(
-			"error encountered while loading running iptables-restore: %v\n%s", err,
-			npc.filterTableRules.String())
+	for ipFamily, iptablesSaveRestore := range npc.iptablesSaveRestore {
+		if err = iptablesSaveRestore.Restore("filter", npc.filterTableRules[ipFamily].Bytes()); err != nil {
+			klog.Errorf(
+				"error encountered while loading running iptables-restore: %v\n%s", err,
+				npc.filterTableRules[ipFamily].String())
+		}
 	}
 
 	// Cleanup ipsets
@@ -621,7 +669,9 @@ func (npc *NetworkPolicyController) Cleanup() {
 func NewNetworkPolicyController(clientset kubernetes.Interface,
 	config *options.KubeRouterConfig, podInformer cache.SharedIndexInformer,
 	npInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer,
-	ipsetMutex *sync.Mutex) (*NetworkPolicyController, error) {
+	ipsetMutex *sync.Mutex,
+	iptablesCmdHandlers map[v1core.IPFamily]utils.IPTablesHandler,
+	ipSetHandlers map[v1core.IPFamily]utils.IPSetHandler) (*NetworkPolicyController, error) {
 	npc := NetworkPolicyController{ipsetMutex: ipsetMutex}
 
 	// Creating a single-item buffered channel to ensure that we only keep a single full sync request at a time,
@@ -630,11 +680,32 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	npc.fullSyncRequestChan = make(chan struct{}, 1)
 
 	// Validate and parse ClusterIP service range
-	_, ipnet, err := net.ParseCIDR(config.ClusterIPCIDR)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: %s", err.Error())
+	if config.ClusterIPCIDR == "" {
+		return nil, fmt.Errorf("parameter --service-cluster-ip is empty")
 	}
-	npc.serviceClusterIPRange = *ipnet
+	clusterIPCIDRList := strings.Split(config.ClusterIPCIDR, ",")
+
+	if len(clusterIPCIDRList) == 0 {
+		return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter, the list is empty")
+	}
+
+	_, primaryIpnet, err := net.ParseCIDR(clusterIPCIDRList[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: %w", err)
+	}
+	npc.primaryServiceClusterIPRange = primaryIpnet
+
+	if len(clusterIPCIDRList) > 1 {
+		_, secondaryIpnet, err := net.ParseCIDR(clusterIPCIDRList[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: %v", err)
+		}
+		npc.secondaryServiceClusterIPRange = secondaryIpnet
+	}
+	if len(clusterIPCIDRList) > 2 {
+		return nil, fmt.Errorf("too many CIDRs provided in --service-cluster-ip-range parameter, only two " +
+			"addresses are allowed at once for dual-stack")
+	}
 
 	// Validate and parse NodePort range
 	if npc.serviceNodePortRange, err = validateNodePortRange(config.NodePortRange); err != nil {
@@ -667,11 +738,29 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 
 	npc.nodeHostName = node.Name
 
-	nodeIP, err := utils.GetNodeIP(node)
+	nodeIPv4, nodeIPv6, err := utils.GetNodeIPDualStack(node, config.EnableIPv4, config.EnableIPv6)
 	if err != nil {
 		return nil, err
 	}
-	npc.nodeIP = nodeIP
+
+	npc.iptablesCmdHandlers = iptablesCmdHandlers
+	npc.iptablesSaveRestore = make(map[v1core.IPFamily]*utils.IPTablesSaveRestore, 2)
+	npc.filterTableRules = make(map[v1core.IPFamily]*bytes.Buffer, 2)
+	npc.ipSetHandlers = ipSetHandlers
+	npc.nodeIPs = make(map[v1core.IPFamily]net.IP, 2)
+
+	if config.EnableIPv4 {
+		npc.iptablesSaveRestore[v1core.IPv4Protocol] = utils.NewIPTablesSaveRestore(v1core.IPv4Protocol)
+		var buf bytes.Buffer
+		npc.filterTableRules[v1core.IPv4Protocol] = &buf
+		npc.nodeIPs[v1core.IPv4Protocol] = nodeIPv4
+	}
+	if config.EnableIPv6 {
+		npc.iptablesSaveRestore[v1core.IPv6Protocol] = utils.NewIPTablesSaveRestore(v1core.IPv6Protocol)
+		var buf bytes.Buffer
+		npc.filterTableRules[v1core.IPv6Protocol] = &buf
+		npc.nodeIPs[v1core.IPv6Protocol] = nodeIPv6
+	}
 
 	npc.podLister = podInformer.GetIndexer()
 	npc.PodEventHandler = npc.newPodEventHandler()

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -111,6 +111,7 @@ type networkPolicyInfo struct {
 
 // internal structure to represent Pod
 type podInfo struct {
+	ip        string
 	ips       []v1core.PodIP
 	name      string
 	namespace string

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -77,7 +77,7 @@ type NetworkPolicyController struct {
 	ipsetMutex                     *sync.Mutex
 
 	iptablesCmdHandlers map[v1core.IPFamily]utils.IPTablesHandler
-	iptablesSaveRestore map[v1core.IPFamily]*utils.IPTablesSaveRestore
+	iptablesSaveRestore map[v1core.IPFamily]utils.IPTablesSaveRestorer
 	filterTableRules    map[v1core.IPFamily]*bytes.Buffer
 	ipSetHandlers       map[v1core.IPFamily]utils.IPSetHandler
 	nodeIPs             map[v1core.IPFamily]net.IP
@@ -778,7 +778,7 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	}
 
 	npc.iptablesCmdHandlers = iptablesCmdHandlers
-	npc.iptablesSaveRestore = make(map[v1core.IPFamily]*utils.IPTablesSaveRestore, 2)
+	npc.iptablesSaveRestore = make(map[v1core.IPFamily]utils.IPTablesSaveRestorer, 2)
 	npc.filterTableRules = make(map[v1core.IPFamily]*bytes.Buffer, 2)
 	npc.ipSetHandlers = ipSetHandlers
 	npc.nodeIPs = make(map[v1core.IPFamily]net.IP, 2)

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -197,7 +197,7 @@ func newUneventfulNetworkPolicyController(podInformer cache.SharedIndexInformer,
 	npc.syncPeriod = time.Hour
 
 	npc.iptablesCmdHandlers = make(map[v1.IPFamily]utils.IPTablesHandler)
-	npc.iptablesSaveRestore = make(map[v1.IPFamily]*utils.IPTablesSaveRestore)
+	npc.iptablesSaveRestore = make(map[v1.IPFamily]utils.IPTablesSaveRestorer)
 	npc.filterTableRules = make(map[v1.IPFamily]*bytes.Buffer)
 	npc.ipSetHandlers = make(map[v1.IPFamily]utils.IPSetHandler)
 	npc.nodeIPs = make(map[v1.IPFamily]net.IP)
@@ -889,13 +889,7 @@ func TestNetworkPolicyController(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			// TODO: Handle IPv6
-			iptablesHandlers := make(map[v1.IPFamily]utils.IPTablesHandler, 1)
-			iptablesHandlers[v1.IPv4Protocol] = newFakeIPTables(iptables.ProtocolIPv4)
-			ipSetHandlers := make(map[v1.IPFamily]utils.IPSetHandler, 1)
-			ipSetHandlers[v1.IPv4Protocol] = &fakeIPSet{}
-
-			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer, &sync.Mutex{},
-				iptablesHandlers, ipSetHandlers)
+			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer, &sync.Mutex{})
 			if err == nil && test.expectError {
 				t.Error("This config should have failed, but it was successful instead")
 			} else if err != nil {

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -896,7 +896,11 @@ func TestNetworkPolicyController(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			// TODO: Handle IPv6
-			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer, &sync.Mutex{})
+			iptablesHandlers := make(map[v1.IPFamily]utils.IPTablesHandler, 1)
+			iptablesHandlers[v1.IPv4Protocol] = newFakeIPTables(iptables.ProtocolIPv4)
+			ipSetHandlers := make(map[v1.IPFamily]utils.IPSetHandler, 1)
+			ipSetHandlers[v1.IPv4Protocol] = &fakeIPSet{}
+			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer, &sync.Mutex{}, iptablesHandlers, ipSetHandlers)
 			if err == nil && test.expectError {
 				t.Error("This config should have failed, but it was successful instead")
 			} else if err != nil {

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-iptables/iptables"
+
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -23,6 +25,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/cloudnativelabs/kube-router/pkg/options"
+	"github.com/cloudnativelabs/kube-router/pkg/utils"
 )
 
 // newFakeInformersFromClient creates the different informers used in the uneventful network policy controller
@@ -138,14 +141,14 @@ func tNewPodNamespaceMapFromTC(target map[string]string) tPodNamespaceMap {
 func tCreateFakePods(t *testing.T, podInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer) {
 	podNamespaceMap := make(tPodNamespaceMap)
 	pods := []podInfo{
-		{name: "Aa", labels: labels.Set{"app": "a"}, namespace: "nsA", ip: "1.1"},
-		{name: "Aaa", labels: labels.Set{"app": "a", "component": "a"}, namespace: "nsA", ip: "1.2"},
-		{name: "Aab", labels: labels.Set{"app": "a", "component": "b"}, namespace: "nsA", ip: "1.3"},
-		{name: "Aac", labels: labels.Set{"app": "a", "component": "c"}, namespace: "nsA", ip: "1.4"},
-		{name: "Ba", labels: labels.Set{"app": "a"}, namespace: "nsB", ip: "2.1"},
-		{name: "Baa", labels: labels.Set{"app": "a", "component": "a"}, namespace: "nsB", ip: "2.2"},
-		{name: "Bab", labels: labels.Set{"app": "a", "component": "b"}, namespace: "nsB", ip: "2.3"},
-		{name: "Ca", labels: labels.Set{"app": "a"}, namespace: "nsC", ip: "3.1"},
+		{name: "Aa", labels: labels.Set{"app": "a"}, namespace: "nsA", ips: []v1.PodIP{{IP: "1.1.1.1"}}},
+		{name: "Aaa", labels: labels.Set{"app": "a", "component": "a"}, namespace: "nsA", ips: []v1.PodIP{{IP: "1.2.3.4"}}},
+		{name: "Aab", labels: labels.Set{"app": "a", "component": "b"}, namespace: "nsA", ips: []v1.PodIP{{IP: "1.3.2.2"}}},
+		{name: "Aac", labels: labels.Set{"app": "a", "component": "c"}, namespace: "nsA", ips: []v1.PodIP{{IP: "1.4.2.2"}}},
+		{name: "Ba", labels: labels.Set{"app": "a"}, namespace: "nsB", ips: []v1.PodIP{{IP: "2.1.1.1"}}},
+		{name: "Baa", labels: labels.Set{"app": "a", "component": "a"}, namespace: "nsB", ips: []v1.PodIP{{IP: "2.2.2.2"}}},
+		{name: "Bab", labels: labels.Set{"app": "a", "component": "b"}, namespace: "nsB", ips: []v1.PodIP{{IP: "2.3.2.2"}}},
+		{name: "Ca", labels: labels.Set{"app": "a"}, namespace: "nsC", ips: []v1.PodIP{{IP: "3.1"}}},
 	}
 	namespaces := []tNamespaceMeta{
 		{name: "nsA", labels: labels.Set{"name": "a", "team": "a"}},
@@ -156,7 +159,8 @@ func tCreateFakePods(t *testing.T, podInformer cache.SharedIndexInformer, nsInfo
 	ipsUsed := make(map[string]bool)
 	for _, pod := range pods {
 		podNamespaceMap.addPod(pod)
-		ipaddr := "1.1." + pod.ip
+		// TODO: test multiple IPs
+		ipaddr := pod.ips[0].IP
 		if ipsUsed[ipaddr] {
 			t.Fatalf("there is another pod with the same Ip address %s as this pod %s namespace %s",
 				ipaddr, pod.name, pod.name)
@@ -192,8 +196,21 @@ func newUneventfulNetworkPolicyController(podInformer cache.SharedIndexInformer,
 	npc := NetworkPolicyController{}
 	npc.syncPeriod = time.Hour
 
+	npc.iptablesCmdHandlers = make(map[v1.IPFamily]utils.IPTablesHandler)
+	npc.iptablesSaveRestore = make(map[v1.IPFamily]*utils.IPTablesSaveRestore)
+	npc.filterTableRules = make(map[v1.IPFamily]*bytes.Buffer)
+	npc.ipSetHandlers = make(map[v1.IPFamily]utils.IPSetHandler)
+	npc.nodeIPs = make(map[v1.IPFamily]net.IP)
+
+	// TODO: Handle both IP families
+	npc.iptablesCmdHandlers[v1.IPv4Protocol] = newFakeIPTables(iptables.ProtocolIPv4)
+	npc.iptablesSaveRestore[v1.IPv4Protocol] = utils.NewIPTablesSaveRestore(v1.IPv4Protocol)
+	var buf bytes.Buffer
+	npc.filterTableRules[v1.IPv4Protocol] = &buf
+	npc.ipSetHandlers[v1.IPv4Protocol] = &fakeIPSet{}
+	npc.nodeIPs[v1.IPv4Protocol] = net.IPv4(10, 10, 10, 10)
+
 	npc.nodeHostName = "node"
-	npc.nodeIP = net.IPv4(10, 10, 10, 10)
 	npc.podLister = podInformer.GetIndexer()
 	npc.nsLister = nsInformer.GetIndexer()
 	npc.npLister = npInformer.GetIndexer()
@@ -426,8 +443,8 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-QHFGOTFJZFXUJVTH -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress namespace nsA\" --dport 30000 -j MARK --set-xmark 0x10000/0x10000 \n" +
-				"-A KUBE-NWPLCY-QHFGOTFJZFXUJVTH -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress namespace nsA\" --dport 30000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
+			expectedRule: "-A KUBE-NWPLCY-C23KD7UE4TAT3Y5M -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress namespace nsA\" --dport 30000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+				"-A KUBE-NWPLCY-C23KD7UE4TAT3Y5M -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress namespace nsA\" --dport 30000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 		{
 			name: "Simple Ingress/Egress Destination Port",
@@ -460,10 +477,10 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-KO52PWL34ABMMBI7 -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-ingress-egress namespace nsA\" --dport 30000 -j MARK --set-xmark 0x10000/0x10000 \n" +
-				"-A KUBE-NWPLCY-KO52PWL34ABMMBI7 -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-ingress-egress namespace nsA\" --dport 30000 -m mark --mark 0x10000/0x10000 -j RETURN \n" +
-				"-A KUBE-NWPLCY-KO52PWL34ABMMBI7 -m comment --comment \"rule to ACCEPT traffic from all sources to dest pods selected by policy name: simple-ingress-egress namespace nsA\" --dport 37000 -j MARK --set-xmark 0x10000/0x10000 \n" +
-				"-A KUBE-NWPLCY-KO52PWL34ABMMBI7 -m comment --comment \"rule to ACCEPT traffic from all sources to dest pods selected by policy name: simple-ingress-egress namespace nsA\" --dport 37000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
+			expectedRule: "-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-ingress-egress namespace nsA\" --dport 30000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+				"-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-ingress-egress namespace nsA\" --dport 30000 -m mark --mark 0x10000/0x10000 -j RETURN \n" +
+				"-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"rule to ACCEPT traffic from all sources to dest pods selected by policy name: simple-ingress-egress namespace nsA\" --dport 37000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+				"-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"rule to ACCEPT traffic from all sources to dest pods selected by policy name: simple-ingress-egress namespace nsA\" --dport 37000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 		{
 			name: "Simple Egress Destination Port Range",
@@ -492,10 +509,10 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-SQYQ7PVNG6A6Q3DU -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress-pr namespace nsA\" --dport 30000:31000 -j MARK --set-xmark 0x10000/0x10000 \n" +
-				"-A KUBE-NWPLCY-SQYQ7PVNG6A6Q3DU -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress-pr namespace nsA\" --dport 30000:31000 -m mark --mark 0x10000/0x10000 -j RETURN \n" +
-				"-A KUBE-NWPLCY-SQYQ7PVNG6A6Q3DU -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress-pr namespace nsA\" --dport 34000:35000 -j MARK --set-xmark 0x10000/0x10000 \n" +
-				"-A KUBE-NWPLCY-SQYQ7PVNG6A6Q3DU -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress-pr namespace nsA\" --dport 34000:35000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
+			expectedRule: "-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress-pr namespace nsA\" --dport 30000:31000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+				"-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress-pr namespace nsA\" --dport 30000:31000 -m mark --mark 0x10000/0x10000 -j RETURN \n" +
+				"-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress-pr namespace nsA\" --dport 34000:35000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+				"-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: simple-egress-pr namespace nsA\" --dport 34000:35000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 		{
 			name: "Port > EndPort (invalid condition, should drop endport)",
@@ -520,8 +537,8 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-2A4DPWPR5REBS66I -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: invalid-endport namespace nsA\" --dport 34000 -j MARK --set-xmark 0x10000/0x10000 \n" +
-				"-A KUBE-NWPLCY-2A4DPWPR5REBS66I -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: invalid-endport namespace nsA\" --dport 34000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
+			expectedRule: "-A KUBE-NWPLCY-N5DQE4SCQ56JEMH7 -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: invalid-endport namespace nsA\" --dport 34000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+				"-A KUBE-NWPLCY-N5DQE4SCQ56JEMH7 -m comment --comment \"rule to ACCEPT traffic from source pods to all destinations selected by policy name: invalid-endport namespace nsA\" --dport 34000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 	}
 
@@ -539,40 +556,185 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 		if err != nil {
 			t.Errorf("Problems building policies: %s", err)
 		}
-		for _, np := range netpols {
-			fmt.Printf(np.policyType)
-			if np.policyType == kubeEgressPolicyType || np.policyType == kubeBothPolicyType {
-				err = krNetPol.processEgressRules(np, "", nil, "1")
-				if err != nil {
-					t.Errorf("Error syncing the rules: %s", err)
+		for ipFamily, filterTableRules := range krNetPol.filterTableRules {
+			for _, np := range netpols {
+				fmt.Printf(np.policyType)
+				if np.policyType == kubeEgressPolicyType || np.policyType == kubeBothPolicyType {
+					err = krNetPol.processEgressRules(np, "", nil, "1", ipFamily)
+					if err != nil {
+						t.Errorf("Error syncing the rules: %s", err)
+					}
+				}
+				if np.policyType == kubeIngressPolicyType || np.policyType == kubeBothPolicyType {
+					err = krNetPol.processIngressRules(np, "", nil, "1", ipFamily)
+					if err != nil {
+						t.Errorf("Error syncing the rules: %s", err)
+					}
 				}
 			}
-			if np.policyType == kubeIngressPolicyType || np.policyType == kubeBothPolicyType {
-				err = krNetPol.processIngressRules(np, "", nil, "1")
-				if err != nil {
-					t.Errorf("Error syncing the rules: %s", err)
-				}
-			}
-		}
 
-		if !bytes.Equal([]byte(test.expectedRule), krNetPol.filterTableRules.Bytes()) {
-			t.Errorf("Invalid rule %s created:\nExpected:\n%s \nGot:\n%s", test.name, test.expectedRule, krNetPol.filterTableRules.String())
-		}
-		key := fmt.Sprintf("%s/%s", test.netpol.namespace, test.netpol.name)
-		obj, exists, err := krNetPol.npLister.GetByKey(key)
-		if err != nil {
-			t.Errorf("Failed to get Netpol from store: %s", err)
-		}
-		if exists {
-			err = krNetPol.npLister.Delete(obj)
+			if !bytes.Equal([]byte(test.expectedRule), filterTableRules.Bytes()) {
+				t.Errorf("Invalid rule %s created:\nExpected:\n%s \nGot:\n%s", test.name, test.expectedRule, filterTableRules.String())
+			}
+			key := fmt.Sprintf("%s/%s", test.netpol.namespace, test.netpol.name)
+			obj, exists, err := krNetPol.npLister.GetByKey(key)
 			if err != nil {
-				t.Errorf("Failed to remove Netpol from store: %s", err)
+				t.Errorf("Failed to get Netpol from store: %s", err)
 			}
+			if exists {
+				err = krNetPol.npLister.Delete(obj)
+				if err != nil {
+					t.Errorf("Failed to remove Netpol from store: %s", err)
+				}
+			}
+			filterTableRules.Reset()
 		}
-		krNetPol.filterTableRules.Reset()
-
 	}
 
+}
+
+type fakeIPTables struct {
+	protocol iptables.Protocol
+}
+
+func newFakeIPTables(protocol iptables.Protocol) *fakeIPTables {
+	return &fakeIPTables{protocol}
+}
+
+func (ipt *fakeIPTables) Proto() iptables.Protocol {
+	return ipt.protocol
+}
+
+func (ipt *fakeIPTables) Exists(table, chain string, rulespec ...string) (bool, error) {
+	return true, nil
+}
+
+func (ipt *fakeIPTables) Insert(table, chain string, pos int, rulespec ...string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) Append(table, chain string, rulespec ...string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) AppendUnique(table, chain string, rulespec ...string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) Delete(table, chain string, rulespec ...string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) DeleteIfExists(table, chain string, rulespec ...string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) List(table, chain string) ([]string, error) {
+	return nil, nil
+}
+
+func (ipt *fakeIPTables) ListWithCounters(table, chain string) ([]string, error) {
+	return nil, nil
+}
+
+func (ipt *fakeIPTables) ListChains(table string) ([]string, error) {
+	return nil, nil
+}
+
+func (ipt *fakeIPTables) ChainExists(table, chain string) (bool, error) {
+	return true, nil
+}
+
+func (ipt *fakeIPTables) Stats(table, chain string) ([][]string, error) {
+	return nil, nil
+}
+
+func (ipt *fakeIPTables) ParseStat(stat []string) (iptables.Stat, error) {
+	return iptables.Stat{}, nil
+}
+
+func (ipt *fakeIPTables) StructuredStats(table, chain string) ([]iptables.Stat, error) {
+	return nil, nil
+}
+
+func (ipt *fakeIPTables) NewChain(table, chain string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) ClearChain(table, chain string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) RenameChain(table, oldChain, newChain string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) DeleteChain(table, chain string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) ClearAndDeleteChain(table, chain string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) ClearAll() error {
+	return nil
+}
+
+func (ipt *fakeIPTables) DeleteAll() error {
+	return nil
+}
+
+func (ipt *fakeIPTables) ChangePolicy(table, chain, target string) error {
+	return nil
+}
+
+func (ipt *fakeIPTables) HasRandomFully() bool {
+	return true
+}
+
+func (ipt *fakeIPTables) GetIptablesVersion() (int, int, int) {
+	return 1, 8, 0
+}
+
+type fakeIPSet struct{}
+
+func (ips *fakeIPSet) Create(setName string, createOptions ...string) (*utils.Set, error) {
+	return nil, nil
+}
+
+func (ips *fakeIPSet) Add(set *utils.Set) error {
+	return nil
+}
+
+func (ips *fakeIPSet) RefreshSet(setName string, entriesWithOptions [][]string, setType string) {}
+
+func (ips *fakeIPSet) Destroy(setName string) error {
+	return nil
+}
+
+func (ips *fakeIPSet) DestroyAllWithin() error {
+	return nil
+}
+
+func (ips *fakeIPSet) Save() error {
+	return nil
+}
+
+func (ips *fakeIPSet) Restore() error {
+	return nil
+}
+
+func (ips *fakeIPSet) Flush() error {
+	return nil
+}
+
+func (ips *fakeIPSet) Get(setName string) *utils.Set {
+	return nil
+}
+
+func (ips *fakeIPSet) Sets() map[string]*utils.Set {
+	return nil
 }
 
 func TestNetworkPolicyController(t *testing.T) {
@@ -608,6 +770,18 @@ func TestNetworkPolicyController(t *testing.T) {
 			"failed to get parse --service-cluster-ip-range parameter: invalid CIDR address: 10.10.10.10",
 		},
 		{
+			"Test bad cluster CIDRs (using more than 2 ip addresses, including 2 ipv4)",
+			newMinimalKubeRouterConfig("10.96.0.0/12,10.244.0.0/16,2001:db8:42:1::/112", "", "node", nil),
+			true,
+			"too many CIDRs provided in --service-cluster-ip-range parameter, only two addresses are allowed at once for dual-stack",
+		},
+		{
+			"Test bad cluster CIDRs (using more than 2 ip addresses, including 2 ipv6)",
+			newMinimalKubeRouterConfig("10.96.0.0/12,2001:db8:42:0::/56,2001:db8:42:1::/112", "", "node", nil),
+			true,
+			"too many CIDRs provided in --service-cluster-ip-range parameter, only two addresses are allowed at once for dual-stack",
+		},
+		{
 			"Test good cluster CIDR (using single IP with a /32)",
 			newMinimalKubeRouterConfig("10.10.10.10/32", "", "node", nil),
 			false,
@@ -616,6 +790,18 @@ func TestNetworkPolicyController(t *testing.T) {
 		{
 			"Test good cluster CIDR (using normal range with /24)",
 			newMinimalKubeRouterConfig("10.10.10.0/24", "", "node", nil),
+			false,
+			"",
+		},
+		{
+			"Test good cluster CIDR (using ipv6)",
+			newMinimalKubeRouterConfig("2001:db8:42:1::/112", "", "node", nil),
+			false,
+			"",
+		},
+		{
+			"Test good cluster CIDRs (with dual-stack)",
+			newMinimalKubeRouterConfig("10.96.0.0/12,2001:db8:42:1::/112", "", "node", nil),
 			false,
 			"",
 		},
@@ -702,7 +888,14 @@ func TestNetworkPolicyController(t *testing.T) {
 	_, podInformer, nsInformer, netpolInformer := newFakeInformersFromClient(client)
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer, &sync.Mutex{})
+			// TODO: Handle IPv6
+			iptablesHandlers := make(map[v1.IPFamily]utils.IPTablesHandler, 1)
+			iptablesHandlers[v1.IPv4Protocol] = newFakeIPTables(iptables.ProtocolIPv4)
+			ipSetHandlers := make(map[v1.IPFamily]utils.IPSetHandler, 1)
+			ipSetHandlers[v1.IPv4Protocol] = &fakeIPSet{}
+
+			_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer, &sync.Mutex{},
+				iptablesHandlers, ipSetHandlers)
 			if err == nil && test.expectError {
 				t.Error("This config should have failed, but it was successful instead")
 			} else if err != nil {

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -201,6 +201,17 @@ func (npc *NetworkPolicyController) setupPodNetpolRules(pod podInfo, podFwChainN
 		"-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP", "\n"}
 	npc.filterTableRules.WriteString(strings.Join(args, " "))
 
+	// ensure statefull firewall drops INVALID state traffic from/to the pod
+	// For full context see: https://bugzilla.netfilter.org/show_bug.cgi?id=693
+	// The NAT engine ignores any packet with state INVALID, because there's no reliable way to determine what kind of
+	// NAT should be performed. So the proper way to prevent the leakage is to drop INVALID packets.
+	// In the future, if we ever allow services or nodes to disable conntrack checking, we may need to make this
+	// conditional so that non-tracked traffic doesn't get dropped as invalid.
+	comment = "\"rule to drop invalid state for pod\""
+	args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
+		"-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP", "\n"}
+	npc.filterTableRules.WriteString(strings.Join(args, " "))
+
 	// ensure statefull firewall that permits RELATED,ESTABLISHED traffic from/to the pod
 	comment = "\"rule for stateful firewall for pod\""
 	args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -79,36 +79,44 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 	activePodFwChains := make(map[string]bool)
 
 	dropUnmarkedTrafficRules := func(podName, podNamespace, podFwChainName string) {
-		// add rule to log the packets that will be dropped due to network policy enforcement
-		comment := "\"rule to log dropped traffic POD name:" + podName + " namespace: " + podNamespace + "\""
-		args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
-			"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "NFLOG",
-			"--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10", "\n"}
-		// This used to be AppendUnique when we were using iptables directly, this checks to make sure we didn't drop
-		// unmarked for this chain already
-		if strings.Contains(npc.filterTableRules.String(), strings.Join(args, " ")) {
-			return
+		for _, filterTableRules := range npc.filterTableRules {
+			// add rule to log the packets that will be dropped due to network policy enforcement
+			comment := "\"rule to log dropped traffic POD name:" + podName + " namespace: " + podNamespace + "\""
+			args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
+				"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "NFLOG",
+				"--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10", "\n"}
+			// This used to be AppendUnique when we were using iptables directly, this checks to make sure we didn't drop
+			// unmarked for this chain already
+			if strings.Contains(filterTableRules.String(), strings.Join(args, " ")) {
+				return
+			}
+			filterTableRules.WriteString(strings.Join(args, " "))
+
+			// add rule to DROP if no applicable network policy permits the traffic
+			comment = "\"rule to REJECT traffic destined for POD name:" + podName + " namespace: " + podNamespace + "\""
+			args = []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
+				"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "REJECT", "\n"}
+			filterTableRules.WriteString(strings.Join(args, " "))
+
+			// reset mark to let traffic pass through rest of the chains
+			args = []string{"-A", podFwChainName, "-j", "MARK", "--set-mark", "0/0x10000", "\n"}
+			filterTableRules.WriteString(strings.Join(args, " "))
 		}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
-
-		// add rule to DROP if no applicable network policy permits the traffic
-		comment = "\"rule to REJECT traffic destined for POD name:" + podName + " namespace: " + podNamespace + "\""
-		args = []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
-			"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "REJECT", "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
-
-		// reset mark to let traffic pass through rest of the chains
-		args = []string{"-A", podFwChainName, "-j", "MARK", "--set-mark", "0/0x10000", "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
 	}
 
 	// loop through the pods running on the node
-	allLocalPods := npc.getLocalPods(npc.nodeIP.String())
-	for _, pod := range *allLocalPods {
+	allLocalPods := make(map[string]podInfo)
+	for _, nodeIP := range npc.nodeIPs {
+		npc.getLocalPods(allLocalPods, nodeIP.String())
+		break
+	}
+	for _, pod := range allLocalPods {
 
 		// ensure pod specific firewall chain exist for all the pods that need ingress firewall
 		podFwChainName := podFirewallChainName(pod.namespace, pod.name, version)
-		npc.filterTableRules.WriteString(":" + podFwChainName + "\n")
+		for _, filterTableRules := range npc.filterTableRules {
+			filterTableRules.WriteString(":" + podFwChainName + "\n")
+		}
 
 		activePodFwChains[podFwChainName] = true
 
@@ -123,12 +131,14 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 
 		dropUnmarkedTrafficRules(pod.name, pod.namespace, podFwChainName)
 
-		// set mark to indicate traffic from/to the pod passed network policies.
-		// Mark will be checked to explicitly ACCEPT the traffic
-		comment := "\"set mark to ACCEPT traffic that comply to network policies\""
-		args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
-			"-j", "MARK", "--set-mark", "0x20000/0x20000", "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
+		for _, filterTableRules := range npc.filterTableRules {
+			// set mark to indicate traffic from/to the pod passed network policies.
+			// Mark will be checked to explicitly ACCEPT the traffic
+			comment := "\"set mark to ACCEPT traffic that comply to network policies\""
+			args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
+				"-j", "MARK", "--set-mark", "0x20000/0x20000", "\n"}
+			filterTableRules.WriteString(strings.Join(args, " "))
+		}
 	}
 
 	return activePodFwChains
@@ -141,149 +151,154 @@ func (npc *NetworkPolicyController) setupPodNetpolRules(pod podInfo, podFwChainN
 	hasIngressPolicy := false
 	hasEgressPolicy := false
 
-	// add entries in pod firewall to run through applicable network policies
-	for _, policy := range networkPoliciesInfo {
-		if _, ok := policy.targetPods[pod.ip]; !ok {
-			continue
+	for ipFamily, filterTableRules := range npc.filterTableRules {
+		var ip string
+		switch ipFamily {
+		case api.IPv4Protocol:
+			ip, _ = getPodIPv4Address(pod)
+		case api.IPv6Protocol:
+			ip, _ = getPodIPv6Address(pod)
 		}
-		comment := "\"run through nw policy " + policy.name + "\""
-		policyChainName := networkPolicyChainName(policy.namespace, policy.name, version)
-		var args []string
-		switch policy.policyType {
-		case kubeBothPolicyType:
-			hasIngressPolicy = true
-			hasEgressPolicy = true
-			args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
-				"-j", policyChainName, "\n"}
-		case kubeIngressPolicyType:
-			hasIngressPolicy = true
-			args = []string{"-I", podFwChainName, "1", "-d", pod.ip, "-m", "comment", "--comment", comment,
-				"-j", policyChainName, "\n"}
-		case kubeEgressPolicyType:
-			hasEgressPolicy = true
-			args = []string{"-I", podFwChainName, "1", "-s", pod.ip, "-m", "comment", "--comment", comment,
-				"-j", policyChainName, "\n"}
+		// add entries in pod firewall to run through applicable network policies
+		for _, policy := range networkPoliciesInfo {
+			// TODO: Take the ipv4 address, pod.ips[0] is not good
+			if _, ok := policy.targetPods[pod.ips[0].IP]; !ok {
+				continue
+			}
+			comment := "\"run through nw policy " + policy.name + "\""
+			policyChainName := networkPolicyChainName(policy.namespace, policy.name, version, ipFamily)
+			var args []string
+			switch policy.policyType {
+			case kubeBothPolicyType:
+				hasIngressPolicy = true
+				hasEgressPolicy = true
+				args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
+					"-j", policyChainName, "\n"}
+			case kubeIngressPolicyType:
+				hasIngressPolicy = true
+				args = []string{"-I", podFwChainName, "1", "-d", ip, "-m", "comment", "--comment", comment,
+					"-j", policyChainName, "\n"}
+			case kubeEgressPolicyType:
+				hasEgressPolicy = true
+				args = []string{"-I", podFwChainName, "1", "-s", ip, "-m", "comment", "--comment", comment,
+					"-j", policyChainName, "\n"}
+			}
+			filterTableRules.WriteString(strings.Join(args, " "))
 		}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
+
+		// if pod does not have any network policy which applies rules for pod's ingress traffic
+		// then apply default network policy
+		if !hasIngressPolicy {
+			comment := "\"run through default ingress network policy  chain\""
+			args := []string{"-I", podFwChainName, "1", "-d", ip, "-m", "comment", "--comment", comment,
+				"-j", kubeDefaultNetpolChain, "\n"}
+			filterTableRules.WriteString(strings.Join(args, " "))
+		}
+
+		// if pod does not have any network policy which applies rules for pod's egress traffic
+		// then apply default network policy
+		if !hasEgressPolicy {
+			comment := "\"run through default egress network policy  chain\""
+			args := []string{"-I", podFwChainName, "1", "-s", ip, "-m", "comment", "--comment", comment,
+				"-j", kubeDefaultNetpolChain, "\n"}
+			filterTableRules.WriteString(strings.Join(args, " "))
+		}
+
+		comment := "\"rule to permit the traffic traffic to pods when source is the pod's local node\""
+		args := []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
+			"-m", "addrtype", "--src-type", "LOCAL", "-d", ip, "-j", "ACCEPT", "\n"}
+		filterTableRules.WriteString(strings.Join(args, " "))
+
+		// ensure statefull firewall that permits RELATED,ESTABLISHED traffic from/to the pod
+		comment = "\"rule for stateful firewall for pod\""
+		args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
+			"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT", "\n"}
+		filterTableRules.WriteString(strings.Join(args, " "))
 	}
-
-	// if pod does not have any network policy which applies rules for pod's ingress traffic
-	// then apply default network policy
-	if !hasIngressPolicy {
-		comment := "\"run through default ingress network policy  chain\""
-		args := []string{"-I", podFwChainName, "1", "-d", pod.ip, "-m", "comment", "--comment", comment,
-			"-j", kubeDefaultNetpolChain, "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
-	}
-
-	// if pod does not have any network policy which applies rules for pod's egress traffic
-	// then apply default network policy
-	if !hasEgressPolicy {
-		comment := "\"run through default egress network policy  chain\""
-		args := []string{"-I", podFwChainName, "1", "-s", pod.ip, "-m", "comment", "--comment", comment,
-			"-j", kubeDefaultNetpolChain, "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
-	}
-
-	comment := "\"rule to permit the traffic to pods when source is the pod's local node\""
-	args := []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
-		"-m", "addrtype", "--src-type", "LOCAL", "-d", pod.ip, "-j", "ACCEPT", "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
-
-	// ensure statefull firewall drops INVALID state traffic from/to the pod
-	// For full context see: https://bugzilla.netfilter.org/show_bug.cgi?id=693
-	// The NAT engine ignores any packet with state INVALID, because there's no reliable way to determine what kind of
-	// NAT should be performed. So the proper way to prevent the leakage is to drop INVALID packets.
-	// In the future, if we ever allow services or nodes to disable conntrack checking, we may need to make this
-	// conditional so that non-tracked traffic doesn't get dropped as invalid.
-	comment = "\"rule to drop invalid state for pod\""
-	args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
-		"-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP", "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
-
-	// ensure statefull firewall drops INVALID state traffic from/to the pod
-	// For full context see: https://bugzilla.netfilter.org/show_bug.cgi?id=693
-	// The NAT engine ignores any packet with state INVALID, because there's no reliable way to determine what kind of
-	// NAT should be performed. So the proper way to prevent the leakage is to drop INVALID packets.
-	// In the future, if we ever allow services or nodes to disable conntrack checking, we may need to make this
-	// conditional so that non-tracked traffic doesn't get dropped as invalid.
-	comment = "\"rule to drop invalid state for pod\""
-	args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
-		"-m", "conntrack", "--ctstate", "INVALID", "-j", "DROP", "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
-
-	// ensure statefull firewall that permits RELATED,ESTABLISHED traffic from/to the pod
-	comment = "\"rule for stateful firewall for pod\""
-	args = []string{"-I", podFwChainName, "1", "-m", "comment", "--comment", comment,
-		"-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT", "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
-
 }
 
 func (npc *NetworkPolicyController) interceptPodInboundTraffic(pod podInfo, podFwChainName string) {
-	// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
-	// this rule applies to the traffic getting routed (coming for other node pods)
-	comment := "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
-		" to chain " + podFwChainName + "\""
-	args := []string{"-A", kubeForwardChainName, "-m", "comment", "--comment", comment, "-d", pod.ip,
-		"-j", podFwChainName + "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
+	for ipFamily, filterTableRules := range npc.filterTableRules {
+		var ip string
+		switch ipFamily {
+		case api.IPv4Protocol:
+			ip, _ = getPodIPv4Address(pod)
+		case api.IPv6Protocol:
+			ip, _ = getPodIPv6Address(pod)
+		}
 
-	// ensure there is rule in filter table and OUTPUT chain to jump to pod specific firewall chain
-	// this rule applies to the traffic from a pod getting routed back to another pod on same node by service proxy
-	args = []string{"-A", kubeOutputChainName, "-m", "comment", "--comment", comment, "-d", pod.ip,
-		"-j", podFwChainName + "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
+		// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
+		// this rule applies to the traffic getting routed (coming for other node pods)
+		comment := "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
+			" to chain " + podFwChainName + "\""
+		args := []string{"-A", kubeForwardChainName, "-m", "comment", "--comment", comment, "-d", ip,
+			"-j", podFwChainName + "\n"}
+		filterTableRules.WriteString(strings.Join(args, " "))
 
-	// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
-	// this rule applies to the traffic getting switched (coming for same node pods)
-	comment = "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
-		" to chain " + podFwChainName + "\""
-	args = []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
-		"-m", "comment", "--comment", comment,
-		"-d", pod.ip,
-		"-j", podFwChainName, "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
+		// ensure there is rule in filter table and OUTPUT chain to jump to pod specific firewall chain
+		// this rule applies to the traffic from a pod getting routed back to another pod on same node by service proxy
+		args = []string{"-A", kubeOutputChainName, "-m", "comment", "--comment", comment, "-d", ip,
+			"-j", podFwChainName + "\n"}
+		filterTableRules.WriteString(strings.Join(args, " "))
+
+		// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
+		// this rule applies to the traffic getting switched (coming for same node pods)
+		comment = "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
+			" to chain " + podFwChainName + "\""
+		args = []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
+			"-m", "comment", "--comment", comment,
+			"-d", ip,
+			"-j", podFwChainName, "\n"}
+		filterTableRules.WriteString(strings.Join(args, " "))
+	}
 }
 
 // setup iptable rules to intercept outbound traffic from pods and run it across the
 // firewall chain corresponding to the pod so that egress network policies are enforced
 func (npc *NetworkPolicyController) interceptPodOutboundTraffic(pod podInfo, podFwChainName string) {
-	for _, chain := range defaultChains {
-		// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
-		// this rule applies to the traffic getting forwarded/routed (traffic from the pod destined
-		// to pod on a different node)
+	for ipFamily, filterTableRules := range npc.filterTableRules {
+		var ip string
+		switch ipFamily {
+		case api.IPv4Protocol:
+			ip, _ = getPodIPv4Address(pod)
+		case api.IPv6Protocol:
+			ip, _ = getPodIPv6Address(pod)
+		}
+
+		for _, chain := range defaultChains {
+			// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
+			// this rule applies to the traffic getting forwarded/routed (traffic from the pod destined
+			// to pod on a different node)
+			comment := "\"rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
+				" to chain " + podFwChainName + "\""
+			args := []string{"-A", chain, "-m", "comment", "--comment", comment, "-s", ip, "-j", podFwChainName, "\n"}
+			filterTableRules.WriteString(strings.Join(args, " "))
+		}
+
+		// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
+		// this rule applies to the traffic getting switched (coming for same node pods)
 		comment := "\"rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
 			" to chain " + podFwChainName + "\""
-		args := []string{"-A", chain, "-m", "comment", "--comment", comment, "-s", pod.ip, "-j", podFwChainName, "\n"}
-		npc.filterTableRules.WriteString(strings.Join(args, " "))
+		args := []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
+			"-m", "comment", "--comment", comment,
+			"-s", ip,
+			"-j", podFwChainName, "\n"}
+		filterTableRules.WriteString(strings.Join(args, " "))
 	}
-
-	// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
-	// this rule applies to the traffic getting switched (coming for same node pods)
-	comment := "\"rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
-		" to chain " + podFwChainName + "\""
-	args := []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
-		"-m", "comment", "--comment", comment,
-		"-s", pod.ip,
-		"-j", podFwChainName, "\n"}
-	npc.filterTableRules.WriteString(strings.Join(args, " "))
 }
 
-func (npc *NetworkPolicyController) getLocalPods(nodeIP string) *map[string]podInfo {
-	localPods := make(map[string]podInfo)
+func (npc *NetworkPolicyController) getLocalPods(localPods map[string]podInfo, nodeIP string) {
 	for _, obj := range npc.podLister.List() {
 		pod := obj.(*api.Pod)
 		// ignore the pods running on the different node and pods that are not actionable
 		if strings.Compare(pod.Status.HostIP, nodeIP) != 0 || !isNetPolActionable(pod) {
 			continue
 		}
-		localPods[pod.Status.PodIP] = podInfo{ip: pod.Status.PodIP,
+		localPods[pod.Status.PodIP] = podInfo{ips: pod.Status.PodIPs,
 			name:      pod.ObjectMeta.Name,
 			namespace: pod.ObjectMeta.Namespace,
 			labels:    pod.ObjectMeta.Labels}
 	}
-	return &localPods
 }
 
 func podFirewallChainName(namespace, podName string, version string) string {

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -108,7 +108,6 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 	allLocalPods := make(map[string]podInfo)
 	for _, nodeIP := range npc.nodeIPs {
 		npc.getLocalPods(allLocalPods, nodeIP.String())
-		break
 	}
 	for _, pod := range allLocalPods {
 
@@ -161,8 +160,7 @@ func (npc *NetworkPolicyController) setupPodNetpolRules(pod podInfo, podFwChainN
 		}
 		// add entries in pod firewall to run through applicable network policies
 		for _, policy := range networkPoliciesInfo {
-			// TODO: Take the ipv4 address, pod.ips[0] is not good
-			if _, ok := policy.targetPods[pod.ips[0].IP]; !ok {
+			if _, ok := policy.targetPods[pod.ip]; !ok {
 				continue
 			}
 			comment := "\"run through nw policy " + policy.name + "\""
@@ -294,7 +292,9 @@ func (npc *NetworkPolicyController) getLocalPods(localPods map[string]podInfo, n
 		if strings.Compare(pod.Status.HostIP, nodeIP) != 0 || !isNetPolActionable(pod) {
 			continue
 		}
-		localPods[pod.Status.PodIP] = podInfo{ips: pod.Status.PodIPs,
+		localPods[pod.Status.PodIP] = podInfo{
+			ip:        pod.Status.PodIP,
+			ips:       pod.Status.PodIPs,
 			name:      pod.ObjectMeta.Name,
 			namespace: pod.ObjectMeta.Namespace,
 			labels:    pod.ObjectMeta.Labels}

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -19,7 +19,7 @@ import (
 	listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-	utilsnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 func (npc *NetworkPolicyController) newNetworkPolicyEventHandler() cache.ResourceEventHandler {
@@ -96,10 +96,10 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 		currentPodIPs := make(map[api.IPFamily][]string)
 		for _, pod := range policy.targetPods {
 			for _, ip := range pod.ips {
-				if utilsnet.IsIPv4String(ip.IP) {
+				if netutils.IsIPv4String(ip.IP) {
 					currentPodIPs[api.IPv4Protocol] = append(currentPodIPs[api.IPv4Protocol], ip.IP)
 				}
-				if utilsnet.IsIPv6String(ip.IP) {
+				if netutils.IsIPv6String(ip.IP) {
 					currentPodIPs[api.IPv6Protocol] = append(currentPodIPs[api.IPv6Protocol], ip.IP)
 				}
 			}
@@ -748,7 +748,7 @@ func (npc *NetworkPolicyController) evalIPBlockPeer(peer networking.NetworkPolic
 	if peer.PodSelector == nil && peer.NamespaceSelector == nil && peer.IPBlock != nil {
 		cidr := peer.IPBlock.CIDR
 
-		if utilsnet.IsIPv4CIDRString(cidr) {
+		if netutils.IsIPv4CIDRString(cidr) {
 			if strings.HasSuffix(cidr, "/0") {
 				ipBlock[api.IPv4Protocol] = append(
 					ipBlock[api.IPv4Protocol],
@@ -778,7 +778,7 @@ func (npc *NetworkPolicyController) evalIPBlockPeer(peer networking.NetworkPolic
 			}
 		}
 
-		if utilsnet.IsIPv6CIDRString(cidr) {
+		if netutils.IsIPv6CIDRString(cidr) {
 			if strings.HasSuffix(cidr, "/0") {
 				ipBlock[api.IPv6Protocol] = append(
 					ipBlock[api.IPv6Protocol],
@@ -815,9 +815,9 @@ func (npc *NetworkPolicyController) grabNamedPortFromPod(pod *api.Pod, namedPort
 
 	ips := make(map[api.IPFamily][]string)
 	for _, ip := range pod.Status.PodIPs {
-		if utilsnet.IsIPv4String(ip.IP) {
+		if netutils.IsIPv4String(ip.IP) {
 			ips[api.IPv4Protocol] = append(ips[api.IPv4Protocol], ip.IP)
-		} else if utilsnet.IsIPv6String(ip.IP) {
+		} else if netutils.IsIPv6String(ip.IP) {
 			ips[api.IPv6Protocol] = append(ips[api.IPv6Protocol], ip.IP)
 		}
 	}

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -89,7 +89,6 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 	activePolicyChains := make(map[string]bool)
 	activePolicyIPSets := make(map[string]bool)
 
-	// for ipFamily, ipset := range npc.ipSetHandlers {
 	// run through all network policies
 	for _, policy := range networkPoliciesInfo {
 
@@ -116,11 +115,8 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 			if policy.policyType == kubeBothPolicyType || policy.policyType == kubeIngressPolicyType {
 				// create a ipset for all destination pod ip's matched by the policy spec PodSelector
 				targetDestPodIPSetName := policyDestinationPodIPSetName(policy.namespace, policy.name, ipFamily)
-				setEntries := make([][]string, 0)
-				for _, podIP := range currentPodIPs[ipFamily] {
-					setEntries = append(setEntries, []string{podIP, utils.OptionTimeout, "0"})
-				}
-				ipset.RefreshSet(targetDestPodIPSetName, setEntries, utils.TypeHashIP)
+				npc.createGenericHashIPSet(targetDestPodIPSetName, utils.TypeHashIP, currentPodIPs[ipFamily], ipFamily)
+
 				if err := npc.processIngressRules(policy,
 					targetDestPodIPSetName, activePolicyIPSets, version, ipFamily); err != nil {
 					return nil, nil, err
@@ -130,11 +126,8 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 			if policy.policyType == kubeBothPolicyType || policy.policyType == kubeEgressPolicyType {
 				// create a ipset for all source pod ip's matched by the policy spec PodSelector
 				targetSourcePodIPSetName := policySourcePodIPSetName(policy.namespace, policy.name, ipFamily)
-				setEntries := make([][]string, 0)
-				for _, podIP := range currentPodIPs[ipFamily] {
-					setEntries = append(setEntries, []string{podIP, utils.OptionTimeout, "0"})
-				}
-				ipset.RefreshSet(targetSourcePodIPSetName, setEntries, utils.TypeHashIP)
+				npc.createGenericHashIPSet(targetSourcePodIPSetName, utils.TypeHashIP, currentPodIPs[ipFamily], ipFamily)
+
 				if err := npc.processEgressRules(policy,
 					targetSourcePodIPSetName, activePolicyIPSets, version, ipFamily); err != nil {
 					return nil, nil, err

--- a/pkg/controllers/netpol/utils.go
+++ b/pkg/controllers/netpol/utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cloudnativelabs/kube-router/pkg/utils"
 	api "k8s.io/api/core/v1"
 	klog "k8s.io/klog/v2"
-	utilsnet "k8s.io/utils/net"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -127,7 +127,7 @@ func (npc *NetworkPolicyController) createPodWithPortPolicyRule(ports []protocol
 
 func getPodIPv6Address(pod podInfo) (string, error) {
 	for _, ip := range pod.ips {
-		if utilsnet.IsIPv6String(ip.IP) {
+		if netutils.IsIPv6String(ip.IP) {
 			return ip.IP, nil
 		}
 	}
@@ -136,7 +136,7 @@ func getPodIPv6Address(pod podInfo) (string, error) {
 
 func getPodIPv4Address(pod podInfo) (string, error) {
 	for _, ip := range pod.ips {
-		if utilsnet.IsIPv4String(ip.IP) {
+		if netutils.IsIPv4String(ip.IP) {
 			return ip.IP, nil
 		}
 	}

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -721,21 +721,21 @@ func (nsc *NetworkServicesController) cleanupIpvsFirewall() {
 		return
 	}
 
-	if _, ok := ipSetHandler.Sets[localIPsIPSetName]; ok {
+	if _, ok := ipSetHandler.Sets()[localIPsIPSetName]; ok {
 		err = ipSetHandler.Destroy(localIPsIPSetName)
 		if err != nil {
 			klog.Errorf("failed to destroy ipset: %s", err.Error())
 		}
 	}
 
-	if _, ok := ipSetHandler.Sets[serviceIPsIPSetName]; ok {
+	if _, ok := ipSetHandler.Sets()[serviceIPsIPSetName]; ok {
 		err = ipSetHandler.Destroy(serviceIPsIPSetName)
 		if err != nil {
 			klog.Errorf("failed to destroy ipset: %s", err.Error())
 		}
 	}
 
-	if _, ok := ipSetHandler.Sets[ipvsServicesIPSetName]; ok {
+	if _, ok := ipSetHandler.Sets()[ipvsServicesIPSetName]; ok {
 		err = ipSetHandler.Destroy(ipvsServicesIPSetName)
 		if err != nil {
 			klog.Errorf("failed to destroy ipset: %s", err.Error())

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -216,7 +216,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Path to CRI compatible container runtime socket (used for DSR mode). Currently known working with "+
 			"containerd.")
 	fs.StringVar(&s.ClusterIPCIDR, "service-cluster-ip-range", s.ClusterIPCIDR,
-		"CIDR value from which service cluster IPs are assigned. Default: 10.96.0.0/12")
+		"CIDR value from which service cluster IPs are assigned. "+
+			"If dual-stack is used, this can be a comma-separated list of CIDR value. Default: 10.96.0.0/12")
 	fs.StringSliceVar(&s.ExternalIPCIDRs, "service-external-ip-range", s.ExternalIPCIDRs,
 		"Specify external IP CIDRs that are used for inter-cluster communication "+
 			"(can be specified multiple times)")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -137,7 +137,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableiBGP, "enable-ibgp", true,
 		"Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers")
 	fs.BoolVar(&s.EnableIPv4, "enable-ipv4", true, "Enables IPv4 support")
-	fs.BoolVar(&s.EnableIPv6, "enable-ipv6", true, "Enables IPv6 support")
+	fs.BoolVar(&s.EnableIPv6, "enable-ipv6", false, "Enables IPv6 support")
 	fs.BoolVar(&s.EnableOverlay, "enable-overlay", true,
 		"When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across "+
 			"nodes in different subnets. When set to false no tunneling is used and routing infrastructure is "+

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -32,6 +32,8 @@ type KubeRouterConfig struct {
 	DisableSrcDstCheck             bool
 	EnableCNI                      bool
 	EnableiBGP                     bool
+	EnableIPv4                     bool
+	EnableIPv6                     bool
 	EnableOverlay                  bool
 	EnablePodEgress                bool
 	EnablePprof                    bool
@@ -84,6 +86,7 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		CacheSyncTimeout:               1 * time.Minute,
 		ClusterIPCIDR:                  "10.96.0.0/12",
 		EnableOverlay:                  true,
+		EnableIPv4:                     true,
 		IPTablesSyncPeriod:             5 * time.Minute,
 		IpvsGracefulPeriod:             30 * time.Second,
 		IpvsSyncPeriod:                 5 * time.Minute,
@@ -133,6 +136,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin.")
 	fs.BoolVar(&s.EnableiBGP, "enable-ibgp", true,
 		"Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers")
+	fs.BoolVar(&s.EnableIPv4, "enable-ipv4", true, "Enables IPv4 support")
+	fs.BoolVar(&s.EnableIPv6, "enable-ipv6", true, "Enables IPv6 support")
 	fs.BoolVar(&s.EnableOverlay, "enable-overlay", true,
 		"When enable-overlay is set to true, IP-in-IP tunneling is used for pod-to-pod networking across "+
 			"nodes in different subnets. When set to false no tunneling is used and routing infrastructure is "+

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -86,7 +86,6 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		CacheSyncTimeout:               1 * time.Minute,
 		ClusterIPCIDR:                  "10.96.0.0/12",
 		EnableOverlay:                  true,
-		EnableIPv4:                     true,
 		IPTablesSyncPeriod:             5 * time.Minute,
 		IpvsGracefulPeriod:             30 * time.Second,
 		IpvsSyncPeriod:                 5 * time.Minute,

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -618,7 +618,7 @@ func (ipset *IPSet) Get(setName string) *Set {
 	return set
 }
 
-//Sets returns all sets from ipset
+// Sets returns all sets from ipset
 func (ipset *IPSet) Sets() map[string]*Set {
 	return ipset.sets
 }

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -618,6 +618,7 @@ func (ipset *IPSet) Get(setName string) *Set {
 	return set
 }
 
+//Sets returns all sets from ipset
 func (ipset *IPSet) Sets() map[string]*Set {
 	return ipset.sets
 }

--- a/pkg/utils/ipset_test.go
+++ b/pkg/utils/ipset_test.go
@@ -19,7 +19,7 @@ func Test_buildIPSetRestore(t *testing.T) {
 		{
 			name: "simple-restore",
 			args: args{
-				ipset: &IPSet{Sets: map[string]*Set{
+				ipset: &IPSet{sets: map[string]*Set{
 					"foo": {
 						Name:    "foo",
 						Options: []string{"hash:ip", "yolo", "things", "12345"},

--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -136,6 +136,11 @@ func Append(buffer *bytes.Buffer, chain string, rule []string) {
 	buffer.WriteString(ruleStr)
 }
 
+type IPTablesSaveRestorer interface {
+	SaveInto(table string, buffer *bytes.Buffer) error
+	Restore(table string, data []byte) error
+}
+
 type IPTablesSaveRestore struct {
 	saveCmd    string
 	restoreCmd string

--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -14,7 +14,7 @@ import (
 
 var hasWait bool
 
-// Interface based on the IPTables struct from github.com/coreos/go-iptables
+// IPTablesHandler interface based on the IPTables struct from github.com/coreos/go-iptables
 // which allows to mock it.
 type IPTablesHandler interface {
 	Proto() iptables.Protocol
@@ -136,16 +136,20 @@ func Append(buffer *bytes.Buffer, chain string, rule []string) {
 	buffer.WriteString(ruleStr)
 }
 
+//IPTablesSaveRestorer interface that defines functions to save and restore tables
 type IPTablesSaveRestorer interface {
 	SaveInto(table string, buffer *bytes.Buffer) error
 	Restore(table string, data []byte) error
 }
 
+//IPTablesSaveRestore struct stores shell commands to save and restore iptables state
 type IPTablesSaveRestore struct {
 	saveCmd    string
 	restoreCmd string
 }
 
+//NewIPTablesSaveRestore returns an IPTablesSaveRestore
+//with apparopriate commands based on ipFamily (IPv4 or IPv6)
 func NewIPTablesSaveRestore(ipFamily v1core.IPFamily) *IPTablesSaveRestore {
 	switch ipFamily {
 	case v1core.IPv6Protocol:
@@ -187,10 +191,12 @@ func (i *IPTablesSaveRestore) exec(cmdName string, args []string, data []byte, s
 	return nil
 }
 
+//SaveInto saves the content of iptables table into buffer
 func (i *IPTablesSaveRestore) SaveInto(table string, buffer *bytes.Buffer) error {
 	return i.exec(i.saveCmd, []string{"-t", table}, nil, buffer)
 }
 
+//Restore updates table with the content of data
 func (i *IPTablesSaveRestore) Restore(table string, data []byte) error {
 	var args []string
 	if hasWait {

--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -7,9 +7,41 @@ import (
 	"strings"
 
 	"k8s.io/klog/v2"
+
+	"github.com/coreos/go-iptables/iptables"
+	v1core "k8s.io/api/core/v1"
 )
 
 var hasWait bool
+
+// Interface based on the IPTables struct from github.com/coreos/go-iptables
+// which allows to mock it.
+type IPTablesHandler interface {
+	Proto() iptables.Protocol
+	Exists(table, chain string, rulespec ...string) (bool, error)
+	Insert(table, chain string, pos int, rulespec ...string) error
+	Append(table, chain string, rulespec ...string) error
+	AppendUnique(table, chain string, rulespec ...string) error
+	Delete(table, chain string, rulespec ...string) error
+	DeleteIfExists(table, chain string, rulespec ...string) error
+	List(table, chain string) ([]string, error)
+	ListWithCounters(table, chain string) ([]string, error)
+	ListChains(table string) ([]string, error)
+	ChainExists(table, chain string) (bool, error)
+	Stats(table, chain string) ([][]string, error)
+	ParseStat(stat []string) (iptables.Stat, error)
+	StructuredStats(table, chain string) ([]iptables.Stat, error)
+	NewChain(table, chain string) error
+	ClearChain(table, chain string) error
+	RenameChain(table, oldChain, newChain string) error
+	DeleteChain(table, chain string) error
+	ClearAndDeleteChain(table, chain string) error
+	ClearAll() error
+	DeleteAll() error
+	ChangePolicy(table, chain, target string) error
+	HasRandomFully() bool
+	GetIptablesVersion() (int, int, int)
+}
 
 //nolint:gochecknoinits // This is actually a good usage of the init() function
 func init() {
@@ -78,30 +110,88 @@ func Restore(table string, data []byte) error {
 
 // AppendUnique ensures that rule is in chain only once in the buffer and that the occurrence is at the end of the
 // buffer
-func AppendUnique(buffer bytes.Buffer, chain string, rule []string) bytes.Buffer {
-	var desiredBuffer bytes.Buffer
-
+func AppendUnique(buffer *bytes.Buffer, chain string, rule []string) {
 	// First we need to remove any previous instances of the rule that exist, so that we can be sure that our version
 	// is unique and appended to the very end of the buffer
 	rules := strings.Split(buffer.String(), "\n")
 	if len(rules) > 0 && rules[len(rules)-1] == "" {
 		rules = rules[:len(rules)-1]
 	}
+	buffer.Reset()
+
 	for _, foundRule := range rules {
 		if strings.Contains(foundRule, chain) && strings.Contains(foundRule, strings.Join(rule, " ")) {
 			continue
 		}
-		desiredBuffer.WriteString(foundRule + "\n")
+		buffer.WriteString(foundRule + "\n")
 	}
 
 	// Now append the rule that we wanted to be unique
-	desiredBuffer = Append(desiredBuffer, chain, rule)
-	return desiredBuffer
+	Append(buffer, chain, rule)
 }
 
 // Append appends rule to chain at the end of buffer
-func Append(buffer bytes.Buffer, chain string, rule []string) bytes.Buffer {
-	ruleStr := strings.Join(append([]string{"-A", chain}, rule...), " ")
-	buffer.WriteString(ruleStr + "\n")
-	return buffer
+func Append(buffer *bytes.Buffer, chain string, rule []string) {
+	ruleStr := strings.Join(append(append([]string{"-A", chain}, rule...), "\n"), " ")
+	buffer.WriteString(ruleStr)
+}
+
+type IPTablesSaveRestore struct {
+	saveCmd    string
+	restoreCmd string
+}
+
+func NewIPTablesSaveRestore(ipFamily v1core.IPFamily) *IPTablesSaveRestore {
+	switch ipFamily {
+	case v1core.IPv6Protocol:
+		return &IPTablesSaveRestore{
+			saveCmd:    "ip6tables-save",
+			restoreCmd: "ip6tables-restore",
+		}
+	case v1core.IPv4Protocol:
+		fallthrough
+	default:
+		return &IPTablesSaveRestore{
+			saveCmd:    "iptables-save",
+			restoreCmd: "iptables-restore",
+		}
+	}
+}
+
+func (i *IPTablesSaveRestore) exec(cmdName string, args []string, data []byte, stdoutBuffer *bytes.Buffer) error {
+	path, err := exec.LookPath(cmdName)
+	if err != nil {
+		return err
+	}
+	stderrBuffer := bytes.NewBuffer(nil)
+	cmd := exec.Cmd{
+		Path:   path,
+		Args:   append([]string{cmdName}, args...),
+		Stderr: stderrBuffer,
+	}
+	if data != nil {
+		cmd.Stdin = bytes.NewBuffer(data)
+	}
+	if stdoutBuffer != nil {
+		cmd.Stdout = stdoutBuffer
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to call %s: %v (%s)", cmdName, err, stderrBuffer)
+	}
+
+	return nil
+}
+
+func (i *IPTablesSaveRestore) SaveInto(table string, buffer *bytes.Buffer) error {
+	return i.exec(i.saveCmd, []string{"-t", table}, nil, buffer)
+}
+
+func (i *IPTablesSaveRestore) Restore(table string, data []byte) error {
+	var args []string
+	if hasWait {
+		args = []string{"--wait", "-T", table}
+	} else {
+		args = []string{"-T", table}
+	}
+	return i.exec(i.restoreCmd, args, data, nil)
 }

--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -136,20 +136,20 @@ func Append(buffer *bytes.Buffer, chain string, rule []string) {
 	buffer.WriteString(ruleStr)
 }
 
-//IPTablesSaveRestorer interface that defines functions to save and restore tables
+// IPTablesSaveRestorer interface that defines functions to save and restore tables
 type IPTablesSaveRestorer interface {
 	SaveInto(table string, buffer *bytes.Buffer) error
 	Restore(table string, data []byte) error
 }
 
-//IPTablesSaveRestore struct stores shell commands to save and restore iptables state
+// IPTablesSaveRestore struct stores shell commands to save and restore iptables state
 type IPTablesSaveRestore struct {
 	saveCmd    string
 	restoreCmd string
 }
 
-//NewIPTablesSaveRestore returns an IPTablesSaveRestore
-//with apparopriate commands based on ipFamily (IPv4 or IPv6)
+// NewIPTablesSaveRestore returns an IPTablesSaveRestore
+// with apparopriate commands based on ipFamily (IPv4 or IPv6)
 func NewIPTablesSaveRestore(ipFamily v1core.IPFamily) *IPTablesSaveRestore {
 	switch ipFamily {
 	case v1core.IPv6Protocol:
@@ -191,12 +191,12 @@ func (i *IPTablesSaveRestore) exec(cmdName string, args []string, data []byte, s
 	return nil
 }
 
-//SaveInto saves the content of iptables table into buffer
+// SaveInto saves the content of iptables table into buffer
 func (i *IPTablesSaveRestore) SaveInto(table string, buffer *bytes.Buffer) error {
 	return i.exec(i.saveCmd, []string{"-t", table}, nil, buffer)
 }
 
-//Restore updates table with the content of data
+// Restore updates table with the content of data
 func (i *IPTablesSaveRestore) Restore(table string, data []byte) error {
 	var args []string
 	if hasWait {

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -90,8 +90,8 @@ func GetNodeIPDualStack(node *apiv1.Node, enableIPv4, enableIPv6 bool) (net.IP, 
 	for _, address := range addresses {
 		addressesPerType.add(address)
 	}
-	if addresses, ok := addressesPerType[apiv1.NodeInternalIP]; ok {
-		for _, address := range addresses {
+	if internalAddresses, ok := addressesPerType[apiv1.NodeInternalIP]; ok {
+		for _, address := range internalAddresses {
 			if ipAddrv4 == nil && enableIPv4 && netutils.IsIPv4String(address.Address) {
 				ipAddrv4 = net.ParseIP(address.Address)
 			}
@@ -100,8 +100,8 @@ func GetNodeIPDualStack(node *apiv1.Node, enableIPv4, enableIPv6 bool) (net.IP, 
 			}
 		}
 	}
-	if addresses, ok := addressesPerType[apiv1.NodeExternalIP]; ok {
-		for _, address := range addresses {
+	if externalAddresses, ok := addressesPerType[apiv1.NodeExternalIP]; ok {
+		for _, address := range externalAddresses {
 			if ipAddrv4 == nil && enableIPv4 && netutils.IsIPv4String(address.Address) {
 				ipAddrv4 = net.ParseIP(address.Address)
 			}

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -79,7 +79,7 @@ func (m addressMap) add(address apiv1.NodeAddress) {
 	}
 }
 
-// GetNodeIP returns the most valid external facing IP address for a node (IPv4 and IPv6).
+// GetNodeIPDualStack returns the most valid external facing IP address for a node (IPv4 and IPv6).
 // Order of preference:
 // 1. NodeInternalIP
 // 2. NodeExternalIP (Only set on cloud providers usually)

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -12,6 +12,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	netutils "k8s.io/utils/net"
 )
 
 // GetNodeObject returns the node API object for the node
@@ -60,6 +61,63 @@ func GetNodeIP(node *apiv1.Node) (net.IP, error) {
 		return net.ParseIP(addresses[0].Address), nil
 	}
 	return nil, errors.New("host IP unknown")
+}
+
+// addressMap is a mapping of address types to a list of addresses of that type.
+// It preallocates the slices of addresses.
+type addressMap map[apiv1.NodeAddressType][]apiv1.NodeAddress
+
+// add adds an address of the given type to the address map. If the given type
+// was not already in the map, it creates a new preallocated entry for it.
+func (m addressMap) add(address apiv1.NodeAddress) {
+	if _, ok := m[address.Type]; ok {
+		m[address.Type] = append(m[address.Type], address)
+	} else {
+		// There can be at most 2 addresses of the same type.
+		m[address.Type] = make([]apiv1.NodeAddress, 2)
+		m[address.Type] = append(m[address.Type], address)
+	}
+}
+
+// GetNodeIP returns the most valid external facing IP address for a node (IPv4 and IPv6).
+// Order of preference:
+// 1. NodeInternalIP
+// 2. NodeExternalIP (Only set on cloud providers usually)
+func GetNodeIPDualStack(node *apiv1.Node, enableIPv4, enableIPv6 bool) (net.IP, net.IP, error) {
+	var ipAddrv4, ipAddrv6 net.IP
+	addresses := node.Status.Addresses
+	addressesPerType := make(addressMap)
+	for _, address := range addresses {
+		addressesPerType.add(address)
+	}
+	if addresses, ok := addressesPerType[apiv1.NodeInternalIP]; ok {
+		for _, address := range addresses {
+			if ipAddrv4 == nil && enableIPv4 && netutils.IsIPv4String(address.Address) {
+				ipAddrv4 = net.ParseIP(address.Address)
+			}
+			if ipAddrv6 == nil && enableIPv6 && netutils.IsIPv6String(address.Address) {
+				ipAddrv6 = net.ParseIP(address.Address)
+			}
+		}
+	}
+	if addresses, ok := addressesPerType[apiv1.NodeExternalIP]; ok {
+		for _, address := range addresses {
+			if ipAddrv4 == nil && enableIPv4 && netutils.IsIPv4String(address.Address) {
+				ipAddrv4 = net.ParseIP(address.Address)
+			}
+			if ipAddrv6 == nil && enableIPv6 && netutils.IsIPv6String(address.Address) {
+				ipAddrv6 = net.ParseIP(address.Address)
+			}
+		}
+	}
+
+	if enableIPv4 && ipAddrv4 == nil {
+		return nil, nil, errors.New("host IPv4 unknown")
+	}
+	if enableIPv6 && ipAddrv6 == nil {
+		return nil, nil, errors.New("host IPv6 unknown")
+	}
+	return ipAddrv4, ipAddrv6, nil
 }
 
 // GetMTUFromNodeIP returns the MTU by detecting it from the IP on the node and figuring in tunneling configurations

--- a/pkg/utils/pod_cidr.go
+++ b/pkg/utils/pod_cidr.go
@@ -145,7 +145,8 @@ func GetPodCidrFromNodeSpec(clientset kubernetes.Interface, hostnameOverride str
 	return node.Spec.PodCIDR, nil
 }
 
-//GetPodCidrsFromNodeSpecDualStack reads the IPv4 and IPv6 pod CIDR allocated to the node from API node object and returns them
+// GetPodCidrsFromNodeSpecDualStack reads the IPv4 and IPv6 pod CIDR allocated
+// to the node from API node object and returns them
 func GetPodCidrsFromNodeSpecDualStack(node *v1core.Node) (string, string, error) {
 	var podCidrv4, podCidrv6 string
 

--- a/pkg/utils/pod_cidr.go
+++ b/pkg/utils/pod_cidr.go
@@ -145,6 +145,7 @@ func GetPodCidrFromNodeSpec(clientset kubernetes.Interface, hostnameOverride str
 	return node.Spec.PodCIDR, nil
 }
 
+//GetPodCidrsFromNodeSpecDualStack reads the IPv4 and IPv6 pod CIDR allocated to the node from API node object and returns them
 func GetPodCidrsFromNodeSpecDualStack(node *v1core.Node) (string, string, error) {
 	var podCidrv4, podCidrv6 string
 


### PR DESCRIPTION
This PR is an update of https://github.com/cloudnativelabs/kube-router/pull/1280.
The original author left Suse so I'm following up on this instead of him.

I tried to apply all the changes requested in the original PR review.
As requested, I didn't squash the commits for now.

Original PR description:
This change allows to define two cluster CIDRs for compatibility with
Kubernetes dual-stack, with an assumption that two CIDRs are usually
IPv4 and IPv6.