### PR TITLE
logging ipset/iptables commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 _output
 _cache
 vendor
+.*.sw?

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -184,6 +186,7 @@ func getIPSetPath() (*string, error) {
 func (ipset *IPSet) run(args ...string) (string, error) {
 	var stderr bytes.Buffer
 	var stdout bytes.Buffer
+	klog.V(9).Infof("running ipset command: path=`%s` args=%+v", *ipset.ipSetPath, args)
 	cmd := exec.Cmd{
 		Path:   *ipset.ipSetPath,
 		Args:   append([]string{*ipset.ipSetPath}, args...),
@@ -202,6 +205,8 @@ func (ipset *IPSet) run(args ...string) (string, error) {
 func (ipset *IPSet) runWithStdin(stdin *bytes.Buffer, args ...string) error {
 	var stderr bytes.Buffer
 	var stdout bytes.Buffer
+	klog.V(9).Infof("running ipset command: path=`%s` args=%+v stdin ```%s```",
+		*ipset.ipSetPath, args, stdin.String())
 	cmd := exec.Cmd{
 		Path:   *ipset.ipSetPath,
 		Args:   append([]string{*ipset.ipSetPath}, args...),

--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"k8s.io/klog/v2"
 )
 
 var hasWait bool
@@ -35,6 +37,7 @@ func SaveInto(table string, buffer *bytes.Buffer) error {
 	}
 	stderrBuffer := bytes.NewBuffer(nil)
 	args := []string{"iptables-save", "-t", table}
+	klog.V(9).Infof("running iptables command: path=`%s` args=%+v", path, args)
 	cmd := exec.Cmd{
 		Path:   path,
 		Args:   args,
@@ -59,6 +62,7 @@ func Restore(table string, data []byte) error {
 	} else {
 		args = []string{"iptables-restore", "-T", table}
 	}
+	klog.V(9).Infof("running iptables command: path=`%s` args=%+v", path, args)
 	cmd := exec.Cmd{
 		Path:  path,
 		Args:  args,


### PR DESCRIPTION
This PR logs `ipset` and `iptables` commands at log level 9.

I've recently encountered an issue with Kubernetes v1.24.0 and
`kube-router` v1.5.1 where the node's network goes bonkers as soon as
`NetworkPolicyController::syncNetworkPolicyChains` is executed (last log
line is "Syncing network policy chains took 48.780838ms"). After that,
`ssh` freezes and `kubelet` becomes inacessible.

Debugging this issue proved to be quite daunting, specially due to the
lack of insight on which network policies are being applied.

Adding these logs have helped the debugging process immensely so far.