### PR TITLE
.github: Allow tagging RCs without updating :latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,28 @@ jobs:
           RUNTIME_BASE=${{ env.RUNTIME_BASE }}
         tags: cloudnativelabs/kube-router-git:PR-${{ github.event.pull_request.number }}
 
+    # Tagging a release candidate, don't update latest
     - name: Build and push - New Tag
       uses: docker/build-push-action@v3
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc') }}
+      with:
+        context: .
+        platforms: |
+          linux/amd64
+          linux/arm64
+          linux/arm/v7
+          linux/s390x
+        push: true
+        build-args: |
+          BUILDTIME_BASE=${{ env.BUILDTIME_BASE }}
+          RUNTIME_BASE=${{ env.RUNTIME_BASE }}
+        tags: |
+          cloudnativelabs/kube-router:${{ steps.extract_tag.outputs.tag }}
+
+    # Tagging a proper release, update latest
+    - name: Build and push - New Tag
+      uses: docker/build-push-action@v3
+      if: ${{ startsWith(github.ref, 'refs/tags/v') && ! contains(github.ref, '-rc') }}
       with:
         context: .
         platforms: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,3 +20,7 @@ A docker buildx command will be executed via Github Actions and it will push new
 ## After the release
 * Mark the draft release as a proper release.
 * Announce the release in [#kube-router](https://app.slack.com/client/T09NY5SBT/C8DCQGTSB) on Kubernetes Slack.
+
+## Release Candidates
+
+* Follow above instructions and ensure that the tag contains `-rc`. Don't mark the pre-release as a proper release.


### PR DESCRIPTION
@aauren I believe this should allow you to tag release candidates without updating :latest