### PR TITLE
Extend bgp sent metric

### DIFF
--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -8,6 +8,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/cloudnativelabs/kube-router/pkg/metrics"
 	"github.com/cloudnativelabs/kube-router/pkg/utils"
 
 	"strings"
@@ -44,6 +45,10 @@ func (nrc *NetworkRoutingController) bgpAdvertiseVIP(vip string) error {
 		},
 	})
 
+	if nrc.MetricsEnabled {
+		metrics.ControllerBGPadvertisementsSent.WithLabelValues("advertise-vip").Inc()
+	}
+
 	return err
 }
 
@@ -72,6 +77,10 @@ func (nrc *NetworkRoutingController) bgpWithdrawVIP(vip string) error {
 		TableType: gobgpapi.TableType_GLOBAL,
 		Path:      &path,
 	})
+
+	if nrc.MetricsEnabled {
+		metrics.ControllerBGPadvertisementsSent.WithLabelValues("withdraw-vip").Inc()
+	}
 
 	return err
 }

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -1208,6 +1208,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	if kubeRouterConfig.MetricsEnabled {
 		// Register the metrics for this controller
 		prometheus.MustRegister(metrics.ControllerBGPadvertisementsReceived)
+		prometheus.MustRegister(metrics.ControllerBGPadvertisementsSent)
 		prometheus.MustRegister(metrics.ControllerBGPInternalPeersSyncTime)
 		prometheus.MustRegister(metrics.ControllerBPGpeers)
 		prometheus.MustRegister(metrics.ControllerRoutesSyncTime)

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -488,7 +488,7 @@ func (nrc *NetworkRoutingController) watchBgpUpdates() {
 
 func (nrc *NetworkRoutingController) advertisePodRoute() error {
 	if nrc.MetricsEnabled {
-		metrics.ControllerBGPadvertisementsSent.Inc()
+		metrics.ControllerBGPadvertisementsSent.WithLabelValues("pod-route").Inc()
 	}
 
 	cidrStr := strings.Split(nrc.podCidr, "/")

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -131,11 +131,14 @@ var (
 		Help:      "BGP advertisements received",
 	})
 	// ControllerBGPadvertisementsSent Time it took to sync internal bgp peers
-	ControllerBGPadvertisementsSent = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: namespace,
-		Name:      "controller_bgp_advertisements_sent",
-		Help:      "BGP advertisements sent",
-	})
+	ControllerBGPadvertisementsSent = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "controller_bgp_advertisements_sent",
+			Help:      "BGP advertisements sent",
+		},
+		[]string{"type"},
+	)
 	// ControllerIpvsMetricsExportTime Time it took to export metrics
 	ControllerIpvsMetricsExportTime = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: namespace,


### PR DESCRIPTION
The bgp sent metric was only counted for pod routed.
VIP routes, advertised via bgp, weren't.

This will also count for VIP routes advertisements and withdraws.

To distinguish between the three types, a new label was added.