### PR TITLE
fix(NSC): add check for podCidr before use

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1294,8 +1294,11 @@ func (nsc *NetworkServicesController) deleteBadMasqueradeIptablesRules() error {
 	var argsBad = [][]string{
 		{"-m", "ipvs", "--ipvs", "--vdir", "ORIGINAL", "--vmethod", "MASQ", "-m", "comment", "--comment", "",
 			"-j", "MASQUERADE"},
-		{"-m", "ipvs", "--ipvs", "--vdir", "ORIGINAL", "--vmethod", "MASQ", "-m", "comment", "--comment", "",
-			"!", "-s", nsc.podCidr, "!", "-d", nsc.podCidr, "-j", "MASQUERADE"},
+	}
+
+	if len(nsc.podCidr) > 0 {
+		argsBad = append(argsBad, []string{"-m", "ipvs", "--ipvs", "--vdir", "ORIGINAL", "--vmethod", "MASQ",
+			"-m", "comment", "--comment", "", "!", "-s", nsc.podCidr, "!", "-d", nsc.podCidr, "-j", "MASQUERADE"})
 	}
 
 	// If random fully is supported remove the original rules as well


### PR DESCRIPTION
@mrueg @XANi

nsc.podCIDR won't exist when `--run-router` is not enabled. In all other references we gate the usage of it behind a check for it existing, somehow this one slipped through. This should fix that and allow people to use `--run-proxy` without `--run-router`.

Fixes #1434