### PR TITLE
use JoinHostPort for GRPC listen address

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -1099,7 +1099,7 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 
 	if grpcServer {
 		nrc.bgpServer = gobgp.NewBgpServer(
-			gobgp.GrpcListenAddress(nrc.primaryIP.String() + ":50051" + "," + "127.0.0.1:50051"))
+			gobgp.GrpcListenAddress(net.JoinHostPort(nrc.primaryIP.String(), "50051") + "," + "127.0.0.1:50051"))
 	} else {
 		nrc.bgpServer = gobgp.NewBgpServer()
 	}


### PR DESCRIPTION
Fixes the "too many colons in address" issue when the primary IP is an IPv6 address.

Tested on an ipv6-only cluster