### PR TITLE
Fix Service VIP Prefix Set Build

### DIFF
--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -213,7 +213,7 @@ func (nrc *NetworkRoutingController) addServiceVIPsDefinedSet() error {
 			return currentPrefixes[i].IpPrefix < currentPrefixes[j].IpPrefix
 		})
 		if reflect.DeepEqual(advIPPrefixList, currentPrefixes) {
-			return nil
+			continue
 		}
 		toAdd := make([]*gobgpapi.Prefix, 0)
 		toDelete := make([]*gobgpapi.Prefix, 0)
@@ -376,7 +376,7 @@ func (nrc *NetworkRoutingController) addiBGPPeersDefinedSet() (map[v1core.IPFami
 		sort.Strings(iBGPPeerCIDRs[family])
 		sort.Strings(currentCIDRs)
 		if reflect.DeepEqual(iBGPPeerCIDRs, currentCIDRs) {
-			return iBGPPeerCIDRs, nil
+			continue
 		}
 		toAdd := make([]string, 0)
 		toDelete := make([]string, 0)


### PR DESCRIPTION
@mrueg @rwagoner

When a single IP family's set looks to be equal, switch to continue instead of return so that other families can still be evaluated as those might have changes.

This should fix #1442 