### PR TITLE
feat(ci.yml): update github action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -107,7 +107,7 @@ jobs:
       id: extract_tag
 
     - name: Build and push - New Push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v4
       if: ${{ startsWith(github.ref, 'refs/tags/v') != true && github.event_name != 'pull_request' }}
       with:
         context: .
@@ -123,7 +123,7 @@ jobs:
         tags: cloudnativelabs/kube-router-git:${{ steps.extract_branch.outputs.branch }}
 
     - name: Build and push - New PR
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v4
       if: github.event_name == 'pull_request'
       with:
         context: .
@@ -137,7 +137,7 @@ jobs:
 
     # Tagging a release candidate, don't update latest
     - name: Build and push - New Tag (Release Candidate)
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v4
       if: ${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc') }}
       with:
         context: .
@@ -155,7 +155,7 @@ jobs:
 
     # Tagging a proper release, update latest
     - name: Build and push - New Tag
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@v4
       if: ${{ startsWith(github.ref, 'refs/tags/v') && ! contains(github.ref, '-rc') }}
       with:
         context: .
@@ -178,7 +178,7 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
@@ -187,7 +187,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v3
+      uses: goreleaser/goreleaser-action@v4
       with:
         version: latest
         args: release --rm-dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v4
       with:
         version: latest
-        args: release --rm-dist
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@mrueg 

Hopefully this removes all of the warnings that we get about NodeJS 12 not being supported any longer, but at the very least it should bring us current with new versions of actions.