### PR TITLE
Fix IP Block processing

### DIFF
--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -262,7 +262,7 @@ func (npc *NetworkPolicyController) processIngressRules(policy networkPolicyInfo
 			}
 		}
 
-		if len(ingressRule.srcIPBlocks) != 0 {
+		if len(ingressRule.srcIPBlocks[ipFamily]) != 0 {
 			srcIPBlockIPSetName := policyIndexedSourceIPBlockIPSetName(policy.namespace, policy.name, ruleIdx, ipFamily)
 			activePolicyIPSets[srcIPBlockIPSetName] = true
 			npc.ipSetHandlers[ipFamily].RefreshSet(srcIPBlockIPSetName, ingressRule.srcIPBlocks[ipFamily], utils.TypeHashNet)
@@ -407,7 +407,7 @@ func (npc *NetworkPolicyController) processEgressRules(policy networkPolicyInfo,
 			}
 		}
 
-		if len(egressRule.dstIPBlocks) != 0 {
+		if len(egressRule.dstIPBlocks[ipFamily]) != 0 {
 			dstIPBlockIPSetName := policyIndexedDestinationIPBlockIPSetName(policy.namespace, policy.name, ruleIdx, ipFamily)
 			activePolicyIPSets[dstIPBlockIPSetName] = true
 			npc.ipSetHandlers[ipFamily].RefreshSet(dstIPBlockIPSetName, egressRule.dstIPBlocks[ipFamily], utils.TypeHashNet)


### PR DESCRIPTION
Previously, IPBlocks (like srcIPBlocks) only contained a single IP Family which meant that a `len() > 0` would indicate that an IP block had been defined in the NetworkPolicy.

However, now the IPBlocks structs are IP family specific which means that they will always contain 2 entries, one for the IPv4 family and one of the IPv6 family. Which means that this condition will evaluate to true for all NetworkPolicies and waste system resources creating empty ipsets and bad iptables rules.