### PR TITLE
fix(ci): checkout before go setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
     name: ci-go-lint
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Lint kube-router code
       run: |
@@ -41,14 +41,14 @@ jobs:
     name: ci-unit-tests
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Run unit tests for kube-router
       run: |
@@ -61,14 +61,14 @@ jobs:
     name: ci-build-kube-router
     runs-on: ubuntu-latest
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Build kube-router
       run: |
@@ -177,14 +177,14 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
@mrueg 

In setup-go@v4 it changed to enabling caching by default which looks for a go modules file to check the cache. This means that the checkout needs to be processed before the setup-go action.