### PR TITLE
CI Add Caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   BUILDTIME_BASE: "golang:1.19.5-alpine3.17"
   RUNTIME_BASE: "alpine:3.17"
   GO_VERSION: "~1.19.5"
+  GO_CACHE: "/home/runner/.cache/go-build"
+  GO_MOD_CACHE: "/home/runner/go/pkg/mod"
 
 jobs:
   # Runs Golangci-lint on the source code

--- a/Makefile
+++ b/Makefile
@@ -102,28 +102,28 @@ run: kube-router ## Runs "kube-router --help".
 container: kube-router gobgp multiarch-binverify ## Builds a Docker container image.
 	@echo Starting kube-router container image build for $(GOARCH) on $(shell go env GOHOSTARCH)
 	@if [ "$(GOARCH)" != "$(shell go env GOHOSTARCH)" ]; then \
-	    echo "Using qemu to build non-native container"; \
-	    $(DOCKER) run --rm --privileged $(QEMU_IMAGE) --reset -p yes; \
+		echo "Using qemu to build non-native container"; \
+		$(DOCKER) run --rm --privileged $(QEMU_IMAGE) --reset -p yes; \
 	fi
 	$(DOCKER) build -t "$(REGISTRY_DEV):$(subst /,,$(IMG_TAG))" -f Dockerfile --build-arg ARCH="$(DOCKER_ARCH)" \
 		--build-arg BUILDTIME_BASE="$(BUILDTIME_BASE)" --build-arg RUNTIME_BASE="$(RUNTIME_BASE)" .
 	@if [ "$(GIT_BRANCH)" = "master" ]; then \
-	    $(DOCKER) tag "$(REGISTRY_DEV):$(IMG_TAG)" "$(REGISTRY_DEV)"; \
+		$(DOCKER) tag "$(REGISTRY_DEV):$(IMG_TAG)" "$(REGISTRY_DEV)"; \
 	fi
 	@echo Finished kube-router container image build.
 
 docker-login: ## Logs into a docker registry using {DOCKER,QUAY}_{USERNAME,PASSWORD} variables.
 	@echo Starting docker login target.
 	@if [ -n "$(DOCKER_USERNAME)" ] && [ -n "$(DOCKER_PASSWORD)" ]; then \
-	    echo Starting DockerHub registry login.; \
-	    $(DOCKER) login -u="$(value DOCKER_USERNAME)" -p="$(value DOCKER_PASSWORD)"; \
-	    echo Finished DockerHub registry login.; \
+		echo Starting DockerHub registry login.; \
+		$(DOCKER) login -u="$(value DOCKER_USERNAME)" -p="$(value DOCKER_PASSWORD)"; \
+		echo Finished DockerHub registry login.; \
 	fi
 
 	@if [ -n "$(QUAY_USERNAME)" ] && [ -n "$(QUAY_PASSWORD)" ]; then \
-	    echo Starting quay.io registry login.; \
-	    $(DOCKER) login -u="$(value QUAY_USERNAME)" -p="$(value QUAY_PASSWORD)" quay.io; \
-	    echo Finished quay.io registry login.; \
+		echo Starting quay.io registry login.; \
+		$(DOCKER) login -u="$(value QUAY_USERNAME)" -p="$(value QUAY_PASSWORD)" quay.io; \
+		echo Finished quay.io registry login.; \
 	fi
 	@echo Finished docker login target.
 
@@ -161,8 +161,8 @@ push-manifest-release:
 github-release:
 	@echo Starting kube-router GitHub release creation.
 	@[ -n "$(value GITHUB_TOKEN)" ] && \
-	  GITHUB_TOKEN=$(value GITHUB_TOKEN); \
-	  curl -sL https://git.io/goreleaser | VERSION=$(GORELEASER_VERSION) bash
+		GITHUB_TOKEN=$(value GITHUB_TOKEN); \
+		curl -sL https://git.io/goreleaser | VERSION=$(GORELEASER_VERSION) bash
 	@echo Finished kube-router GitHub release creation.
 
 release: push-release github-release ## Pushes a release to DockerHub and GitHub
@@ -219,7 +219,7 @@ multiarch-binverify:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
-	  awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: clean container run release goreleaser push gofmt gofmt-fix gomoqs
 .PHONY: test lint docker-login push-manifest push-manifest-release


### PR DESCRIPTION
@mrueg 

Add caching to the kube-router build, test, moq, & lint Makefile targets

With a primed cache I've found that this greatly increases the responsiveness of each of this make targets:

```
Standard: make kube-router  0.06s user 0.03s system 0% cpu 28.231 total
With Primed Cache: make kube-router  0.05s user 0.04s system 3% cpu 2.340 total

Standard: make test  0.18s user 0.07s system 0% cpu 36.072 total
With Primed Cache: make test  0.20s user 0.04s system 21% cpu 1.171 total

Standard: make lint  0.18s user 0.08s system 0% cpu 40.760 total
With Primed Cache: make lint  0.20s user 0.04s system 1% cpu 14.314 total
```

I _think_ that we might be able to gain some performance out of the `container` target as well by adding caching to the Dockerfile similar to: https://www.docker.com/blog/containerize-your-go-developer-environment-part-2/

However, I've never had much luck with that, and don't exactly know how to navigate the whole `Makefile` -> `docker build` -> `Makefile` chain that we have for that step.