### PR TITLE
Add Check for IP Family

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -692,6 +692,14 @@ func (nrc *NetworkRoutingController) injectRoute(path *gobgpapi.Path) error {
 	case sameSubnet:
 		// if the nextHop is within the same subnet, add a route for the destination so that traffic can bet routed
 		// at layer 2 and minimize the need to traverse a router
+		// First check that destination and nexthop are in the same IP family
+		dstIsIPv4 := dst.IP.To4() != nil
+		gwIsIPv4 := nextHop.To4() != nil
+		if dstIsIPv4 != gwIsIPv4 {
+			return fmt.Errorf("not able to add route as destination %s and gateway %s are not in the same IP family - "+
+				"this shouldn't ever happen from IPs that kube-router advertises, but if it does report it as a bug",
+				dst.IP, nextHop)
+		}
 		route = &netlink.Route{
 			Dst:      dst,
 			Gw:       nextHop,


### PR DESCRIPTION
Add a sanity check before attempting to insert a route. Prevents issue as seen by user: https://kubernetes.slack.com/archives/C8DCQGTSB/p1691000323278989

kube-router should have the right checks on the advertisement side to not ever do this, but its possible that we receive routes from other announcers besides kube-router.