### PR TITLE
feat(bgp_policies.go): don't override-nexthop for internal peers

### DIFF
--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -605,9 +605,6 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 		actions := gobgpapi.Actions{
 			RouteAction: gobgpapi.RouteAction_ACCEPT,
 		}
-		if nrc.overrideNextHop {
-			actions.Nexthop = &gobgpapi.NexthopAction{Self: true}
-		}
 
 		// statement to represent the export policy to permit advertising node's IPv4 & IPv6 pod CIDRs
 		for _, podSet := range []string{podCIDRSet, podCIDRSetV6} {


### PR DESCRIPTION
Previously when a user selected to override the next-hop via `GoBGP's NextHopActions: Self` functionality, we did it for all exported routes. However, in a dual-stack use-case this causes problems for internal pod IP routes that are spread via BGP advertisements.

Currently, kube-router only peers with an internal peer once over whatever it's primary IP is according to it's Kubernetes node information. This means that when overriding next-hop the IP is either an IPv4 or IPv6 address depending on how the node has configured itself. Therefore when it attempts to add a route for an IPv6 address and override next-hop is configured, if the node's primary IP was an IPv4 address this will not succeed as a next-hop for an IPv6 address cannot be an IPv4 gateway.

Rather than making the code base overly complicated with both an IPv4 and IPv6 peering for internal nodes, this change presents a bit of a middle ground. By choosing not to override the next-hop for pod subnet advertisements to internal (Kubernetes node) peers, we eliminate this problem.

This does change the functionality of kube-router a bit, but one of the foundational aspects to Kubernetes networking is that all nodes should be able to communicate freely with each other on a flat network of sorts. So I cannot currently think of a good use-case where overriding the next-hop for pod subnets of internal peers would be necessary, so I think that this is an ok concession to make.