### PR TITLE
feat(ci.yml): add ppc64le and riscv64 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
           linux/arm64
           linux/arm/v7
           linux/s390x
+          linux/ppc64le
+          linux/riscv64
         push: true
         build-args: |
           BUILDTIME_BASE=${{ env.BUILDTIME_BASE }}
@@ -148,6 +150,8 @@ jobs:
           linux/arm64
           linux/arm/v7
           linux/s390x
+          linux/ppc64le
+          linux/riscv64
         push: true
         build-args: |
           BUILDTIME_BASE=${{ env.BUILDTIME_BASE }}
@@ -166,6 +170,8 @@ jobs:
           linux/arm64
           linux/arm/v7
           linux/s390x
+          linux/ppc64le
+          linux/riscv64
         push: true
         build-args: |
           BUILDTIME_BASE=${{ env.BUILDTIME_BASE }}


### PR DESCRIPTION
@mrueg - it looks like ppc64le support was old enough to be built by Jenkins, so maybe it was intentionally left out of GitHub actions when you made that migration?

riscv64, was just added by #1525 but after merging I noticed that it didn't look to be building an image for that architecture: https://github.com/cloudnativelabs/kube-router/actions/runs/6004672360/job/16285750933

These are both architectures that are added to the Makefile, but that we don't currently build for. riscv64 was added in:
https://github.com/cloudnativelabs/kube-router/pull/1525 and ppc64le was added in: https://github.com/cloudnativelabs/kube-router/pull/847