### PR TITLE
Partially revert riscv64 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,6 @@ jobs:
           linux/arm/v7
           linux/s390x
           linux/ppc64le
-          linux/riscv64
         push: true
         build-args: |
           BUILDTIME_BASE=${{ env.BUILDTIME_BASE }}
@@ -151,7 +150,6 @@ jobs:
           linux/arm/v7
           linux/s390x
           linux/ppc64le
-          linux/riscv64
         push: true
         build-args: |
           BUILDTIME_BASE=${{ env.BUILDTIME_BASE }}
@@ -171,7 +169,6 @@ jobs:
           linux/arm/v7
           linux/s390x
           linux/ppc64le
-          linux/riscv64
         push: true
         build-args: |
           BUILDTIME_BASE=${{ env.BUILDTIME_BASE }}

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ push: container docker-login ## Pushes a Docker container image to a registry.
 push-manifest:
 	@echo Starting kube-router manifest push.
 	./manifest-tool push from-args \
-		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x,linux/ppc64le,linux/riscv64 \
+		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x,linux/ppc64le \
 		--template "$(REGISTRY_DEV):ARCH-$(MANIFEST_TAG)" \
 		--target "$(REGISTRY_DEV):$(MANIFEST_TAG)"
 
@@ -153,12 +153,12 @@ push-release: push
 push-manifest-release:
 	@echo Starting kube-router manifest push.
 	./manifest-tool push from-args \
-		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x,linux/ppc64le,linux/riscv64 \
+		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x,linux/ppc64le \
 		--template "$(REGISTRY):ARCH-${RELEASE_TAG}" \
 		--target "$(REGISTRY):$(RELEASE_TAG)"
 
 	./manifest-tool push from-args \
-		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x,linux/ppc64le,linux/riscv64 \
+		--platforms linux/amd64,linux/arm64,linux/arm,linux/s390x,linux/ppc64le \
 		--template "$(REGISTRY):ARCH-${RELEASE_TAG}" \
 		--target "$(REGISTRY):latest"
 


### PR DESCRIPTION
@iggy @aauren Since the alpine image we use does not have a riscv64 architecture, we can't build riscv64 images. We can still build a riscv64 binary with goreleaser though.

We'd need to wait for https://gitlab.alpinelinux.org/alpine/aports/-/issues/13269