### PR TITLE
feat(close_stale.yml): add workflow for closing stale issues & PRs

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -1,0 +1,26 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stale for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stale for 10 days with no activity.'
+          days-before-issue-stale: 30
+          days-before-pr-stale: 60
+          days-before-issue-close: 5
+          days-before-pr-close: 10
+          exempt-issue-labels: override-stale
+          exempt-pr-labels: override-stale,dependencies
+          enable-statistics: true


### PR DESCRIPTION
@mrueg 

This has been something that this repo has needed for a while now, and thanks to GitHub actions, this appears pretty easy to do now.

This will make it so that issues will get warned after 30 days of inactivity and closed 5 days after that if no comments have been made. PRs will be warned after 60 days of inactivity and closed after 10 days if no comments or updates have been made.

Maintainers can stop this workflow for specific issues and PRs by adding the `override-stale` label to the issue or PR. Additionally, PRs opened by dependabot and tagged with `dependencies` will not be marked or reaped.

Documentation taken from:
* https://github.com/actions/stale
* https://github.com/actions/stale/blob/main/action.yml
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions