### PR TITLE
feat: Option to disable overlay tunnel device binding

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -854,11 +854,6 @@ func (nrc *NetworkRoutingController) setupOverlayTunnel(tunnelName string, nextH
 				"setup", nrc.overlayEncap)
 		}
 
-		// need to skip binding device if nrc.nodeInterface is loopback, otherwise packets never leave
-		// from egress interface to the tunnel peer.
-		if nrc.nodeInterface != "lo" {
-			cmdArgs = append(cmdArgs, []string{"dev", nrc.nodeInterface}...)
-		}
 		klog.V(2).Infof("Executing the following command to create tunnel: ip %s", cmdArgs)
 		out, err := exec.Command("ip", cmdArgs...).CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
Hello folks,

I was having issues with binding overlay ipip tunnels to specific device. I would like to see option to disable this behavior.

My usecase is that I have many nodes on one L2 network but few (1 at this time) i have "off-site", connected with a wireguard VPN. When kube-router builds ipip tunnel it is confused and binds tunnel to interface BELOW the VPN so instead of running ip-ip through VPN it tries to run it through default VPN but with VPN local/remote addresses. Which fails obviously.

OTOH I'm not really sure why the binding is there - is there any reason for it? Maybe better solution would be to just remove it?

Thanks for your opinion