### PR TITLE
Add k3s Improvements

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -253,7 +253,6 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 	}
 
 	for ipFamily, iptablesSaveRestore := range npc.iptablesSaveRestore {
-		ipFamily := ipFamily
 		npc.filterTableRules[ipFamily].Reset()
 		saveStart := time.Now()
 		err := iptablesSaveRestore.SaveInto("filter", npc.filterTableRules[ipFamily])

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -265,7 +265,7 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 				metrics.ControllerIptablesV6SaveTime.Observe(saveEndTime.Seconds())
 			}
 		}
-		klog.V(2).Infof("Saving %v iptables rules took %v", ipFamily, saveEndTime)
+		klog.V(1).Infof("Saving %v iptables rules took %v", ipFamily, saveEndTime)
 
 		if err != nil {
 			klog.Errorf("Aborting sync. Failed to run iptables-save: %v", err.Error())
@@ -304,7 +304,7 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 				metrics.ControllerIptablesV6RestoreTime.Observe(restoreEndTime.Seconds())
 			}
 		}
-		klog.V(2).Infof("Restoring %v iptables rules took %v", ipFamily, restoreEndTime)
+		klog.V(1).Infof("Restoring %v iptables rules took %v", ipFamily, restoreEndTime)
 
 		if err != nil {
 			klog.Errorf("Aborting sync. Failed to run iptables-restore: %v\n%s",

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -257,17 +257,15 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		saveStart := time.Now()
 		err := iptablesSaveRestore.SaveInto("filter", npc.filterTableRules[ipFamily])
 		saveEndTime := time.Since(saveStart)
-		defer func() {
-			if npc.MetricsEnabled {
-				switch ipFamily {
-				case v1core.IPv4Protocol:
-					metrics.ControllerIptablesV4SaveTime.Observe(saveEndTime.Seconds())
-				case v1core.IPv6Protocol:
-					metrics.ControllerIptablesV6SaveTime.Observe(saveEndTime.Seconds())
-				}
+		if npc.MetricsEnabled {
+			switch ipFamily {
+			case v1core.IPv4Protocol:
+				metrics.ControllerIptablesV4SaveTime.Observe(saveEndTime.Seconds())
+			case v1core.IPv6Protocol:
+				metrics.ControllerIptablesV6SaveTime.Observe(saveEndTime.Seconds())
 			}
-			klog.V(2).Infof("Saving %v iptables rules took %v", ipFamily, saveEndTime)
-		}()
+		}
+		klog.V(2).Infof("Saving %v iptables rules took %v", ipFamily, saveEndTime)
 
 		if err != nil {
 			klog.Errorf("Aborting sync. Failed to run iptables-save: %v", err.Error())
@@ -298,17 +296,15 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		restoreStart := time.Now()
 		err := iptablesSaveRestore.Restore("filter", npc.filterTableRules[ipFamily].Bytes())
 		restoreEndTime := time.Since(restoreStart)
-		defer func() {
-			if npc.MetricsEnabled {
-				switch ipFamily {
-				case v1core.IPv4Protocol:
-					metrics.ControllerIptablesV4RestoreTime.Observe(restoreEndTime.Seconds())
-				case v1core.IPv6Protocol:
-					metrics.ControllerIptablesV6RestoreTime.Observe(restoreEndTime.Seconds())
-				}
+		if npc.MetricsEnabled {
+			switch ipFamily {
+			case v1core.IPv4Protocol:
+				metrics.ControllerIptablesV4RestoreTime.Observe(restoreEndTime.Seconds())
+			case v1core.IPv6Protocol:
+				metrics.ControllerIptablesV6RestoreTime.Observe(restoreEndTime.Seconds())
 			}
-			klog.V(2).Infof("Restoring %v iptables rules took %v", ipFamily, restoreEndTime)
-		}()
+		}
+		klog.V(2).Infof("Restoring %v iptables rules took %v", ipFamily, restoreEndTime)
 
 		if err != nil {
 			klog.Errorf("Aborting sync. Failed to run iptables-restore: %v\n%s",

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cloudnativelabs/kube-router/v2/pkg/options"
 	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	"github.com/coreos/go-iptables/iptables"
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/klog/v2"
 
 	v1core "k8s.io/api/core/v1"
@@ -845,8 +844,8 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 
 	if config.MetricsEnabled {
 		// Register the metrics for this controller
-		prometheus.MustRegister(metrics.ControllerIptablesSyncTime)
-		prometheus.MustRegister(metrics.ControllerPolicyChainsSyncTime)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerIptablesSyncTime)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerPolicyChainsSyncTime)
 		npc.MetricsEnabled = true
 	}
 

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -159,7 +159,7 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 				metrics.ControllerPolicyIpsetV6RestoreTime.Observe(restoreEndTime.Seconds())
 			}
 		}
-		klog.V(2).Infof("Restoring %v ipset took %v", ipFamily, restoreEndTime)
+		klog.V(1).Infof("Restoring %v ipset took %v", ipFamily, restoreEndTime)
 
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to perform ipset restore: %w", err)

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -151,17 +151,15 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 		err := ipset.Restore()
 		restoreEndTime := time.Since(restoreStart)
 
-		defer func() {
-			if npc.MetricsEnabled {
-				switch ipFamily {
-				case api.IPv4Protocol:
-					metrics.ControllerPolicyIpsetV4RestoreTime.Observe(restoreEndTime.Seconds())
-				case api.IPv6Protocol:
-					metrics.ControllerPolicyIpsetV6RestoreTime.Observe(restoreEndTime.Seconds())
-				}
+		if npc.MetricsEnabled {
+			switch ipFamily {
+			case api.IPv4Protocol:
+				metrics.ControllerPolicyIpsetV4RestoreTime.Observe(restoreEndTime.Seconds())
+			case api.IPv6Protocol:
+				metrics.ControllerPolicyIpsetV6RestoreTime.Observe(restoreEndTime.Seconds())
 			}
-			klog.V(2).Infof("Restoring %v ipset took %v", ipFamily, restoreEndTime)
-		}()
+		}
+		klog.V(2).Infof("Restoring %v ipset took %v", ipFamily, restoreEndTime)
 
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to perform ipset restore: %w", err)

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"github.com/docker/docker/client"
 	"github.com/moby/ipvs"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
 	api "k8s.io/api/core/v1"
@@ -2285,18 +2284,18 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 
 	if config.MetricsEnabled {
 		// Register the metrics for this controller
-		prometheus.MustRegister(metrics.ControllerIpvsServices)
-		prometheus.MustRegister(metrics.ControllerIpvsServicesSyncTime)
-		prometheus.MustRegister(metrics.ServiceBpsIn)
-		prometheus.MustRegister(metrics.ServiceBpsOut)
-		prometheus.MustRegister(metrics.ServiceBytesIn)
-		prometheus.MustRegister(metrics.ServiceBytesOut)
-		prometheus.MustRegister(metrics.ServiceCPS)
-		prometheus.MustRegister(metrics.ServicePacketsIn)
-		prometheus.MustRegister(metrics.ServicePacketsOut)
-		prometheus.MustRegister(metrics.ServicePpsIn)
-		prometheus.MustRegister(metrics.ServicePpsOut)
-		prometheus.MustRegister(metrics.ServiceTotalConn)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerIpvsServices)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerIpvsServicesSyncTime)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServiceBpsIn)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServiceBpsOut)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServiceBytesIn)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServiceBytesOut)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServiceCPS)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServicePacketsIn)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServicePacketsOut)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServicePpsIn)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServicePpsOut)
+		metrics.DefaultRegisterer.MustRegister(metrics.ServiceTotalConn)
 		nsc.MetricsEnabled = true
 	}
 

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	gobgpapi "github.com/osrg/gobgp/v3/api"
 	gobgp "github.com/osrg/gobgp/v3/pkg/server"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/vishvananda/netlink"
 	v1core "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -1407,11 +1406,11 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	nrc := NetworkRoutingController{ipsetMutex: ipsetMutex}
 	if kubeRouterConfig.MetricsEnabled {
 		// Register the metrics for this controller
-		prometheus.MustRegister(metrics.ControllerBGPadvertisementsReceived)
-		prometheus.MustRegister(metrics.ControllerBGPadvertisementsSent)
-		prometheus.MustRegister(metrics.ControllerBGPInternalPeersSyncTime)
-		prometheus.MustRegister(metrics.ControllerBPGpeers)
-		prometheus.MustRegister(metrics.ControllerRoutesSyncTime)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerBGPadvertisementsReceived)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerBGPadvertisementsSent)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerBGPInternalPeersSyncTime)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerBPGpeers)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerRoutesSyncTime)
 		nrc.MetricsEnabled = true
 	}
 

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -219,7 +219,8 @@ type Controller struct {
 
 // Handler returns a http.Handler for the default registerer and gatherer
 func Handler() http.Handler {
-	return promhttp.InstrumentMetricHandler(DefaultRegisterer, promhttp.HandlerFor(DefaultGatherer, promhttp.HandlerOpts{}))
+	return promhttp.InstrumentMetricHandler(DefaultRegisterer, promhttp.HandlerFor(DefaultGatherer,
+		promhttp.HandlerOpts{}))
 }
 
 // Run prometheus metrics controller

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -110,6 +110,30 @@ var (
 		Name:      "controller_iptables_sync_time",
 		Help:      "Time it took for controller to sync iptables",
 	})
+	// ControllerIptablesV4SaveTime Time it took controller to save IPv4 rules
+	ControllerIptablesV4SaveTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "controller_iptables_v4_save_time",
+		Help:      "Time it took controller to save IPv4 rules",
+	})
+	// ControllerIptablesV6SaveTime Time to took for controller to save IPv6 rules
+	ControllerIptablesV6SaveTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "controller_iptables_v6_save_time",
+		Help:      "Time to took for controller to save IPv6 rules",
+	})
+	// ControllerIptablesV4RestoreTime Time it took for controller to restore IPv4 rules
+	ControllerIptablesV4RestoreTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "controller_iptables_v4_restore_time",
+		Help:      "Time it took for controller to restore IPv4 rules",
+	})
+	// ControllerIptablesV6RestoreTime Time it took for controller to restore IPv6 rules
+	ControllerIptablesV6RestoreTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "controller_iptables_v6_restore_time",
+		Help:      "Time it took for controller to restore IPv6 rules",
+	})
 	// ControllerIpvsServicesSyncTime Time it took for controller to sync ipvs services
 	ControllerIpvsServicesSyncTime = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: namespace,
@@ -160,6 +184,30 @@ var (
 		Namespace: namespace,
 		Name:      "controller_policy_chains_sync_time",
 		Help:      "Time it took for controller to sync policy chains",
+	})
+	// ControllerPolicyIpsetV4RestoreTime Time it took for controller to restore IPv4 ipsets
+	ControllerPolicyIpsetV4RestoreTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "controller_policy_ipset_v4_restore_time",
+		Help:      "Time it took for controller to restore IPv4 ipsets",
+	})
+	// ControllerPolicyIpsetV6RestoreTime Time it took for controller to restore IPv6 ipsets
+	ControllerPolicyIpsetV6RestoreTime = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "controller_policy_ipset_v6_restore_time",
+		Help:      "Time it took for controller to restore IPv6 ipsets",
+	})
+	// ControllerPolicyChains Active policy chains
+	ControllerPolicyChains = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "controller_policy_chains",
+		Help:      "Active policy chains",
+	})
+	// ControllerPolicyIpsets Active policy ipsets
+	ControllerPolicyIpsets = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Name:      "controller_policy_ipsets",
+		Help:      "Active policy ipsets",
 	})
 )
 


### PR DESCRIPTION
@brandond @ChristianCiach

This work was taken from @brandond's fork of kube-router for k3s: https://github.com/brandond/kube-router/tree/metrics-var

The primary work done there was to:

* Improve the performance of the network policy controller (NPC) by reducing the number of shell calls made to ipset when syncing policies to help improve the performance problems reported by @ChristianCiach here: https://github.com/k3s-io/k3s/discussions/8321
* Improve observability in the NPC by adding metrics for number of iptables chain and number of ipsets that kube-router manages
* Improve observability in the NPC by adding metrics for save / restore of iptables / ipsets per family
* Added ability to swap out metrics handlers for projects that consume kube-router as a library

All the work here was thanks to @brandond and @ChristianCiach's troubleshooting and fixing

@brandond - I added a few changes on top of the ones that you had. I separated out the commits into a pretty granular set so that they would be easier for you to review. Let me know what you think of the changes that I added on top of yours. Let me also know if you'd prefer that I close this PR and allow you to submit it yourself. I'm fine either way.