### PR TITLE
prometheus metrics: add option to specify listen address

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -102,6 +102,7 @@ Usage of kube-router:
       --loadbalancer-sync-period duration             The delay between checking for missed services (e.g. '5s', '1m'). Must be greater than 0. (default 1m0s)
       --masquerade-all                                SNAT all traffic to cluster IP/node port.
       --master string                                 The address of the Kubernetes API server (overrides any value in kubeconfig).
+      --metrics-addr string                           Prometheus metrics address to listen on, (Default: all interfaces)
       --metrics-path string                           Prometheus metrics path (default "/metrics")
       --metrics-port uint16                           Prometheus metrics port, (Default 0, Disabled)
       --nodeport-bindon-all-ip                        For service of NodePort type create IPVS service that listens on all IP's of the node.

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -214,6 +214,7 @@ var (
 // Controller Holds settings for the metrics controller
 type Controller struct {
 	MetricsPath string
+	MetricsAddr string
 	MetricsPort uint16
 }
 
@@ -236,7 +237,7 @@ func (mc *Controller) Run(healthChan chan<- *healthcheck.ControllerHeartbeat, st
 	DefaultRegisterer.MustRegister(ControllerIpvsMetricsExportTime)
 
 	srv := &http.Server{
-		Addr:              ":" + strconv.Itoa(int(mc.MetricsPort)),
+		Addr:              mc.MetricsAddr + ":" + strconv.Itoa(int(mc.MetricsPort)),
 		Handler:           http.DefaultServeMux,
 		ReadHeaderTimeout: 5 * time.Second}
 
@@ -267,6 +268,7 @@ func (mc *Controller) Run(healthChan chan<- *healthcheck.ControllerHeartbeat, st
 // NewMetricsController returns new MetricController object
 func NewMetricsController(config *options.KubeRouterConfig) (*Controller, error) {
 	mc := Controller{}
+	mc.MetricsAddr = config.MetricsAddr
 	mc.MetricsPath = config.MetricsPath
 	mc.MetricsPort = config.MetricsPort
 	return &mc, nil

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -60,6 +60,7 @@ type KubeRouterConfig struct {
 	MetricsEnabled                 bool
 	MetricsPath                    string
 	MetricsPort                    uint16
+	MetricsAddr                    string
 	NodePortBindOnAllIP            bool
 	NodePortRange                  string
 	OverlayType                    string
@@ -190,6 +191,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"The address of the Kubernetes API server (overrides any value in kubeconfig).")
 	fs.StringVar(&s.MetricsPath, "metrics-path", "/metrics", "Prometheus metrics path")
 	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, (Default 0, Disabled)")
+	fs.StringVar(&s.MetricsAddr, "metrics-addr", "", "Prometheus metrics address to listen on, (Default: all interfaces)")
 	fs.BoolVar(&s.NodePortBindOnAllIP, "nodeport-bindon-all-ip", false,
 		"For service of NodePort type create IPVS service that listens on all IP's of the node.")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", true,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,8 +1,10 @@
 package utils
 
 import (
+	"fmt"
 	"io"
 	"net"
+	"strconv"
 	"sync"
 )
 
@@ -85,4 +87,15 @@ func SliceContainsString(needle string, haystack []string) bool {
 		}
 	}
 	return false
+}
+
+// TCPAddressBindable checks to see if an IP/port is bindable by attempting to open a listener then closing it
+// returns nil if successful
+func TCPAddressBindable(addr string, port uint16) error {
+	endpoint := addr + ":" + strconv.Itoa(int(port))
+	ln, err := net.Listen("tcp", endpoint)
+	if err != nil {
+		return fmt.Errorf("unable to open %s: %w", endpoint, err)
+	}
+	return ln.Close()
 }


### PR DESCRIPTION
In the situation that you have multiple interfaces/IP addresses, we want to be able to specify which one we want to expose the prometheus metrics on.

This is the follow up to #1244 with the PR feedback addressed.