### PR TITLE
Fix Ddd hostPID to Daemonsets

### DIFF
--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -143,6 +143,7 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -139,6 +139,7 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/generic-kuberouter-only-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-only-advertise-routes.yaml
@@ -64,6 +64,7 @@ spec:
           mountPath: /run/xtables.lock
           readOnly: false
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -109,6 +109,7 @@ spec:
         - mountPath: /etc/kube-router
           name: kube-router-cfg
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -104,6 +104,7 @@ spec:
         - name: kube-router-cfg
           mountPath: /etc/kube-router
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -100,6 +100,7 @@ spec:
         - name: kube-router-cfg
           mountPath: /etc/kube-router
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -99,6 +99,7 @@ spec:
         - name: kube-router-cfg
           mountPath: /etc/kube-router
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -99,6 +99,7 @@ spec:
         - name: kube-router-cfg
           mountPath: /etc/kube-router
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -120,6 +120,7 @@ spec:
         - name: kube-router-cfg
           mountPath: /etc/kube-router
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -113,6 +113,7 @@ spec:
         - name: kube-router-cfg
           mountPath: /etc/kube-router
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -112,6 +112,7 @@ spec:
         - mountPath: /etc/kube-router
           name: kube-router-cfg
       hostNetwork: true
+      hostPID: true
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -625,7 +625,9 @@ func (ln *linuxNetworking) findIfaceLinkForPid(pid int) (int, error) {
 			sysFSNetClassRelPath)
 		entries, err := os.ReadDir(ifacesPath)
 		if err != nil {
-			klog.Warningf("could not list: %s due to: %v", ifacesPath, entries)
+			klog.Warningf("Could not list: %s due to: %v", ifacesPath, err)
+			klog.Warning("If above error was 'no such file or directory' it may be that you haven't enabled " +
+				"'hostPID=true' in your kube-router deployment")
 			return
 		}
 		var sb strings.Builder


### PR DESCRIPTION
Since #1582  was merged, we now rely upon having access to the host's PID namespace in order to detect which veth device a given container doing hairpinning is using. As such, we now add it to the daemonsets in the example and attempt to direct users upon certain errors.