### PR TITLE
Pin iptables to 1.8.8-r1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,11 @@ RUN apk add --no-cache make git \
     && make gobgp
 
 FROM ${RUNTIME_BASE}
-
+# pin iptables to a less recent version, in order to support RHEL8-based OSes.
+# 1.8.8 was chosen because Cilium uses it at the time of writing. https://github.com/cilium/image-tools/blob/master/images/iptables/Dockerfile
 RUN apk add --no-cache \
-      iptables \
-      ip6tables \
+      iptables=1.8.8-r1 \
+      ip6tables=1.8.8-r1 \
       ipset \
       iproute2 \
       ipvsadm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ COPY build/image-assets/iptables-wrapper-installer.sh /
 # This is necessary because of the bug reported here: https://github.com/flannel-io/flannel/pull/1340/files
 # Basically even under QEMU emulation, it still doesn't have an ARM kernel in-play which means that calls to
 # iptables-nft will fail in the build process. The sanity check here only makes sure that we are not using
-# iptables-1.8.0-1.8.2. For now we'll manage that on our own.
-RUN /iptables-wrapper-installer.sh --no-sanity-check
+# iptables-1.8.0-1.8.2.
+RUN /iptables-wrapper-installer.sh
 
 
 # Since alpine image doesn't contain /etc/nsswitch.conf, the hosts in /etc/hosts (e.g. localhost)


### PR DESCRIPTION
As per https://github.com/cloudnativelabs/kube-router/issues/1588, pin the iptables version to 1.8.8-r1 in order to support RHEL8-based distros.