### PR TITLE
feat(NSC): add IPVS service timeouts

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -127,6 +127,9 @@ Usage of kube-router:
       --service-cluster-ip-range strings              CIDR values from which service cluster IPs are assigned (can be specified up to 2 times) (default [10.96.0.0/12])
       --service-external-ip-range strings             Specify external IP CIDRs that are used for inter-cluster communication (can be specified multiple times)
       --service-node-port-range string                NodePort range specified with either a hyphen or colon (default "30000-32767")
+      --service-tcp-timeout duration                  Specify TCP timeout for IPVS services in standard duration syntax (e.g. '5s', '1m'), default 0s preserves default system value (default: 0s)
+      --service-tcpfin-timeout duration               Specify TCP FIN timeout for IPVS services in standard duration syntax (e.g. '5s', '1m'), default 0s preserves default system value (default: 0s)
+      --service-udp-timeout duration                  Specify UDP timeout for IPVS services in standard duration syntax (e.g. '5s', '1m'), default 0s preserves default system value (default: 0s)
   -v, --v string                                      log level for V logs (default "0")
   -V, --version                                       Print version information.
 ```

--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -815,11 +815,20 @@ func (ln *linuxNetworking) getKubeDummyInterface() (netlink.Link, error) {
 	return dummyVipInterface, nil
 }
 
-func newLinuxNetworking() (*linuxNetworking, error) {
+func newLinuxNetworking(tcpTimeout, tcpFinTimeout, udpTimeout time.Duration) (*linuxNetworking, error) {
 	ln := &linuxNetworking{}
 	ipvsHandle, err := ipvs.New("")
 	if err != nil {
 		return nil, err
+	}
+	ipvsConfig := &ipvs.Config{
+		TimeoutTCP:    tcpTimeout,
+		TimeoutTCPFin: tcpFinTimeout,
+		TimeoutUDP:    udpTimeout,
+	}
+	err = ipvsHandle.SetConfig(ipvsConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure IPVS config with timeouts: %v", err)
 	}
 	ln.ipvsHandle = ipvsHandle
 	return ln, nil

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1870,7 +1870,7 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 	ipsetMutex *sync.Mutex) (*NetworkServicesController, error) {
 
 	var err error
-	ln, err := newLinuxNetworking()
+	ln, err := newLinuxNetworking(config.ServiceTCPTimeout, config.ServiceTCPFinTimeout, config.ServiceUDPTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -80,6 +80,9 @@ type KubeRouterConfig struct {
 	RunServiceProxy                bool
 	RunLoadBalancer                bool
 	RuntimeEndpoint                string
+	ServiceTCPTimeout              time.Duration
+	ServiceTCPFinTimeout           time.Duration
+	ServiceUDPTimeout              time.Duration
 	Version                        bool
 	VLevel                         string
 	// FullMeshPassword    string
@@ -95,13 +98,16 @@ func NewKubeRouterConfig() *KubeRouterConfig {
 		ClusterIPCIDRs:                 []string{"10.96.0.0/12"},
 		EnableOverlay:                  true,
 		IPTablesSyncPeriod:             5 * time.Minute,
+		InjectedRoutesSyncPeriod:       60 * time.Second,
 		IpvsGracefulPeriod:             30 * time.Second,
 		IpvsSyncPeriod:                 5 * time.Minute,
 		LoadBalancerSyncPeriod:         time.Minute,
 		NodePortRange:                  "30000-32767",
 		OverlayType:                    "subnet",
 		RoutesSyncPeriod:               5 * time.Minute,
-		InjectedRoutesSyncPeriod:       60 * time.Second,
+		ServiceTCPTimeout:              0 * time.Second,
+		ServiceTCPFinTimeout:           0 * time.Second,
+		ServiceUDPTimeout:              0 * time.Second,
 	}
 }
 
@@ -191,7 +197,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"The address of the Kubernetes API server (overrides any value in kubeconfig).")
 	fs.StringVar(&s.MetricsPath, "metrics-path", "/metrics", "Prometheus metrics path")
 	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, (Default 0, Disabled)")
-	fs.StringVar(&s.MetricsAddr, "metrics-addr", "", "Prometheus metrics address to listen on, (Default: all interfaces)")
+	fs.StringVar(&s.MetricsAddr, "metrics-addr", "", "Prometheus metrics address to listen on, (Default: all "+
+		"interfaces)")
 	fs.BoolVar(&s.NodePortBindOnAllIP, "nodeport-bindon-all-ip", false,
 		"For service of NodePort type create IPVS service that listens on all IP's of the node.")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", true,
@@ -245,6 +252,15 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 			"(can be specified multiple times)")
 	fs.StringVar(&s.NodePortRange, "service-node-port-range", s.NodePortRange,
 		"NodePort range specified with either a hyphen or colon")
+	fs.DurationVar(&s.ServiceTCPTimeout, "service-tcp-timeout", s.ServiceTCPTimeout,
+		"Specify TCP timeout for IPVS services in standard duration syntax (e.g. '5s', '1m'), default 0s preserves "+
+			"default system value (default: 0s)")
+	fs.DurationVar(&s.ServiceTCPFinTimeout, "service-tcpfin-timeout", s.ServiceTCPFinTimeout,
+		"Specify TCP FIN timeout for IPVS services in standard duration syntax (e.g. '5s', '1m'), default 0s "+
+			"preserves default system value (default: 0s)")
+	fs.DurationVar(&s.ServiceUDPTimeout, "service-udp-timeout", s.ServiceUDPTimeout,
+		"Specify UDP timeout for IPVS services in standard duration syntax (e.g. '5s', '1m'), default 0s preserves "+
+			"default system value (default: 0s)")
 	fs.StringVarP(&s.VLevel, "v", "v", "0", "log level for V logs")
 	fs.BoolVarP(&s.Version, "version", "V", false,
 		"Print version information.")


### PR DESCRIPTION
This is a feature that has been requested a few times over the years and would bring us closer to feature parity with other k8s network implementations for service proxy.

Adds the options:

```
      --service-tcp-timeout duration                  Specify TCP timeout for IPVS services in standard duration syntax (e.g. '5s', '1m'), default 0s preserves default system value (default: 0s)
      --service-tcpfin-timeout duration               Specify TCP FIN timeout for IPVS services in standard duration syntax (e.g. '5s', '1m'), default 0s preserves default system value (default: 0s)
      --service-udp-timeout duration                  Specify UDP timeout for IPVS services in standard duration syntax (e.g. '5s', '1m'), default 0s preserves default system value (default: 0s)
```

Keeps backwards compatibility by default defining them as `0s` which will keep the IPVS defaults in place (which is how these are currently set). The IPVS default appear to be the same on most systems, which should be:

```
TCP Timeout: 15 minutes
TCPFIN Timeout: 2 minutes
UDP Timeout: 5 minutes
```

Fixes #911 #521 - Without relying on the application to send keep-alives

Potentially resolves #1577 - But there isn't enough information in the ticket in order to know for sure.