### PR TITLE
Respect service.kubernetes.io Labels

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1612,24 +1612,24 @@ func (nsc *NetworkServicesController) cleanupMangleTableRule(ip string, protocol
 	args := []string{"-d", ip, "-m", protocol, "-p", protocol, "--dport", port, "-j", "MARK", "--set-mark", fwmark}
 	exists, err := iptablesCmdHandler.Exists("mangle", "PREROUTING", args...)
 	if err != nil {
-		return fmt.Errorf("Failed to cleanup iptables command to set up FWMARK due to " + err.Error())
+		return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %v", err)
 	}
 	if exists {
 		klog.V(2).Infof("removing mangle rule with: iptables -D PREROUTING -t mangle %s", args)
 		err = iptablesCmdHandler.Delete("mangle", "PREROUTING", args...)
 		if err != nil {
-			return fmt.Errorf("Failed to cleanup iptables command to set up FWMARK due to " + err.Error())
+			return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %v", err)
 		}
 	}
 	exists, err = iptablesCmdHandler.Exists("mangle", "OUTPUT", args...)
 	if err != nil {
-		return fmt.Errorf("Failed to cleanup iptables command to set up FWMARK due to " + err.Error())
+		return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %v", err)
 	}
 	if exists {
 		klog.V(2).Infof("removing mangle rule with: iptables -D OUTPUT -t mangle %s", args)
 		err = iptablesCmdHandler.Delete("mangle", "OUTPUT", args...)
 		if err != nil {
-			return fmt.Errorf("Failed to cleanup iptables command to set up FWMARK due to " + err.Error())
+			return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %v", err)
 		}
 	}
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -800,7 +800,7 @@ func (nsc *NetworkServicesController) OnEndpointsUpdate(es *discovery.EndpointSl
 		klog.Warningf("failed to lookup any service as an owner for %s/%s", es.Namespace, es.Name)
 		return
 	}
-	if utils.ServiceIsHeadless(svc) {
+	if utils.ServiceHasNoClusterIP(svc) {
 		klog.V(1).Infof("The service associated with endpoint: %s/%s is headless, skipping...",
 			es.Namespace, es.Name)
 		return
@@ -839,7 +839,7 @@ func (nsc *NetworkServicesController) OnServiceUpdate(svc *v1.Service) {
 	// skip processing as we only work with VIPs in the next section. Since the ClusterIP field is immutable we don't
 	// need to consider previous versions of the service here as we are guaranteed if is a ClusterIP now, it was a
 	// ClusterIP before.
-	if utils.ServiceIsHeadless(svc) {
+	if utils.ServiceHasNoClusterIP(svc) {
 		klog.V(1).Infof("%s/%s is headless, skipping...", svc.Namespace, svc.Name)
 		return
 	}

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -530,3 +530,15 @@ func runIPCommandsWithArgs(ipArgs []string, additionalArgs ...string) *exec.Cmd 
 	allArgs = append(allArgs, additionalArgs...)
 	return exec.Command("ip", allArgs...)
 }
+
+// getLabelFromMap checks the list of passed labels for the service.kubernetes.io/service-proxy-name
+// label and if it exists, returns it otherwise returns an error
+func getLabelFromMap(label string, labels map[string]string) (string, error) {
+	for lbl, val := range labels {
+		if lbl == label {
+			return val, nil
+		}
+	}
+
+	return "", fmt.Errorf("label doesn't exist in map")
+}

--- a/pkg/controllers/proxy/utils_test.go
+++ b/pkg/controllers/proxy/utils_test.go
@@ -131,3 +131,37 @@ func TestNetworkServicesController_lookupServiceByFWMark(t *testing.T) {
 		assert.Zero(t, foundPort, "port should be zero on error")
 	})
 }
+
+func TestNetworkServicesController_getLabelFromMap(t *testing.T) {
+	labels := map[string]string{
+		"service.kubernetes.io": "foo",
+		"kube-router.io":        "bar",
+	}
+	copyLabels := func(srcLbls map[string]string) map[string]string {
+		dstLbls := map[string]string{}
+		for k, v := range srcLbls {
+			dstLbls[k] = v
+		}
+		return dstLbls
+	}
+	t.Run("return blank when passed labels don't contain service-proxy-name label", func(t *testing.T) {
+		lbl, err := getLabelFromMap(svcProxyNameLabel, labels)
+		assert.Empty(t, lbl, "should return blank for a list of labels that don't contain a service-proxy-name label")
+		assert.Error(t, err, "should return an error when the label doesn't exist")
+	})
+
+	t.Run("return blank when empty label map is passed", func(t *testing.T) {
+		lbls := map[string]string{}
+		lbl, err := getLabelFromMap(svcProxyNameLabel, lbls)
+		assert.Empty(t, lbl, "should return blank for a map with no elements")
+		assert.Error(t, err, "should return an error when the map doesn't contain any elements")
+	})
+
+	t.Run("return value when an labels contains service-proxy-name label", func(t *testing.T) {
+		lbls := copyLabels(labels)
+		lbls[svcProxyNameLabel] = "foo"
+		lbl, err := getLabelFromMap(svcProxyNameLabel, lbls)
+		assert.Equal(t, "foo", lbl, "should return value when service-proxy-name passed")
+		assert.Nil(t, err, "error should be nil when the label exists")
+	})
+}

--- a/pkg/controllers/routing/ecmp_vip.go
+++ b/pkg/controllers/routing/ecmp_vip.go
@@ -204,7 +204,7 @@ func (nrc *NetworkRoutingController) tryHandleServiceUpdate(objOld, objNew inter
 	// skip processing as we only work with VIPs in the next section. Since the ClusterIP field is immutable we
 	// don't need to consider previous versions of the service here as we are guaranteed if is a ClusterIP now,
 	// it was a ClusterIP before.
-	if utils.ServiceIsHeadless(objNew) {
+	if utils.ServiceHasNoClusterIP(objNew) {
 		klog.V(1).Infof("%s/%s is headless, skipping...", svcNew.Namespace, svcNew.Name)
 		return
 	}
@@ -228,7 +228,7 @@ func (nrc *NetworkRoutingController) tryHandleServiceDelete(oldObj interface{}, 
 	klog.V(1).Infof(logMsgFormat, oldSvc.Namespace, oldSvc.Name)
 
 	// If the service is headless skip processing as we only work with VIPs in the next section.
-	if utils.ServiceIsHeadless(oldObj) {
+	if utils.ServiceHasNoClusterIP(oldObj) {
 		klog.V(1).Infof("%s/%s is headless, skipping...", oldSvc.Namespace, oldSvc.Name)
 		return
 	}

--- a/pkg/utils/service.go
+++ b/pkg/utils/service.go
@@ -115,11 +115,11 @@ func ServiceForEndpointSlice(ci *cache.Indexer, es *discovery.EndpointSlice) (in
 	return item, true, nil
 }
 
-// ServiceIsHeadless decides whether or not the this service is a headless service which is often useful to kube-router
-// as there is no need to execute logic on most headless changes. Function takes a generic interface as its input
-// parameter so that it can be used more easily in early processing if needed. If a non-service object is given,
+// ServiceHasNoClusterIP decides whether or not the this service is a headless service which is often useful to
+// kube-router as there is no need to execute logic on most headless changes. Function takes a generic interface as its
+// input parameter so that it can be used more easily in early processing if needed. If a non-service object is given,
 // function will return false.
-func ServiceIsHeadless(obj interface{}) bool {
+func ServiceHasNoClusterIP(obj interface{}) bool {
 	if svc, _ := obj.(*v1core.Service); svc != nil {
 		if svc.Spec.Type == v1core.ServiceTypeClusterIP {
 			if ClusterIPIsNone(svc.Spec.ClusterIP) && containsOnlyNone(svc.Spec.ClusterIPs) {


### PR DESCRIPTION
@mrueg 

This teaches kube-router about the following two kubernetes standard labels:

* `service.kubernetes.io/headless`
* `service.kubernetes.io/service-proxy-name`

It also resolves 2 of the e2e kubernetes testing failures that kube-router currently has and resolves #979