### PR TITLE
Feature: Support All Upstream Traffic Policies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,9 +51,13 @@ issues:
     - text: "G306:"
       linters:
         - gosec
-    # Exlude tests from long line linter
+    # Exclude tests from long line linter
     - linters:
         - lll
+      path: _test\.go
+    # Exclude tests from duplicate linter
+    - linters:
+      - dupl
       path: _test\.go
   # always show all issues rather than only showing 50 at a time
   max-issues-per-linter: 0

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -253,6 +253,19 @@ Advertising LoadBalancer IPs works by inspecting the services `status.loadBalanc
 LoadBalancers like for example MetalLb. This has been successfully tested together with
 [MetalLB](https://github.com/google/metallb) in ARP mode.
 
+## Controlling Service Locality / Traffic Policies
+
+Service availability both externally and locally (within the cluster) can be controlled via the Kubernetes standard
+[Traffic Policies](https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies) and via the custom
+kube-router service annotation: `kube-router.io/service.local: true`.
+
+Refer to the previously linked upstream Kubernetes documentation for more information on `spec.internalTrafficPolicy`
+and `spec.externalTrafficPolicy`.
+
+In order to keep backwards compatibility the `kube-router.io/service.local: true` annotation effectively overrides
+`spec.internalTrafficPolicy` and `spec.externalTrafficPolicy` and forces kube-router to behave as if both were set to
+`Local`.
+
 ## Hairpin Mode
 
 Communication from a Pod that is behind a Service to its own ClusterIP:Port is not supported by default.  However, it

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1025,6 +1025,7 @@ func (nsc *NetworkServicesController) buildEndpointSliceInfo() endpointSliceInfo
 	for _, obj := range nsc.epSliceLister.List() {
 		var isIPv4, isIPv6 bool
 		es := obj.(*discovery.EndpointSlice)
+		klog.V(2).Infof("Building endpoint info for EndpointSlice: %s/%s", es.Namespace, es.Name)
 		switch es.AddressType {
 		case discovery.AddressTypeIPv4:
 			isIPv4 = true
@@ -1073,6 +1074,7 @@ func (nsc *NetworkServicesController) buildEndpointSliceInfo() endpointSliceInfo
 			// changing this to .Serving which continues to include pods that are in Terminating state. For now we keep
 			// it the same.
 			if ep.Conditions.Ready == nil || !*ep.Conditions.Ready {
+				klog.V(2).Infof("Endpoint (with addresses %s) does not have a ready status, skipping...", ep.Addresses)
 				continue
 			}
 

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -107,7 +107,7 @@ func (nsc *NetworkServicesController) setupClusterIPServices(serviceInfoMap serv
 	endpointsInfoMap endpointSliceInfoMap, activeServiceEndpointMap map[string][]string) error {
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return errors.New("Failed get list of IPVS services due to: " + err.Error())
+		return fmt.Errorf("failed get list of IPVS services due to: %v", err)
 	}
 
 	for k, svc := range serviceInfoMap {
@@ -126,7 +126,7 @@ func (nsc *NetworkServicesController) setupClusterIPServices(serviceInfoMap serv
 		ipv6NodeIP := utils.FindBestIPv6NodeAddress(nsc.primaryIP, nsc.nodeIPv6Addrs)
 		dummyVipInterface, err := nsc.ln.getKubeDummyInterface()
 		if err != nil {
-			return errors.New("Failed creating dummy interface: " + err.Error())
+			return fmt.Errorf("failed creating dummy interface: %v", err)
 		}
 
 		for family, famClusIPs := range clusterIPs {

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -169,7 +169,7 @@ func (nrc *NetworkRoutingController) addServiceVIPsDefinedSet() error {
 		}
 
 		advIPPrefixList := make([]*gobgpapi.Prefix, 0)
-		advIps, _, _ := nrc.getAllVIPs()
+		advIps, _, _ := nrc.getVIPs()
 		for _, ipStr := range advIps {
 			ip := net.ParseIP(ipStr)
 			if ip == nil {

--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -21,6 +21,7 @@ type PolicyTestCase struct {
 	nrc                          *NetworkRoutingController
 	existingNodes                []*v1core.Node
 	existingServices             []*v1core.Service
+	existingEndpoints            []*v1core.Endpoints
 	podDefinedSet                *gobgpapi.DefinedSet
 	clusterIPDefinedSet          *gobgpapi.DefinedSet
 	externalPeerDefinedSet       *gobgpapi.DefinedSet
@@ -75,12 +76,32 @@ func Test_AddPolicies(t *testing.T) {
 			[]*v1core.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "svc-1",
+						Name:      "svc-1",
+						Namespace: "default",
 					},
 					Spec: v1core.ServiceSpec{
-						Type:        ClusterIPST,
-						ClusterIP:   "10.1.0.1",
-						ExternalIPs: []string{"1.1.1.1"},
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.1.0.1",
+						ExternalIPs:           []string{"1.1.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*v1core.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+					},
+					Subsets: []v1core.EndpointSubset{
+						{
+							Addresses: []v1core.EndpointAddress{
+								{
+									IP: testNodeIPv4,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -205,12 +226,32 @@ func Test_AddPolicies(t *testing.T) {
 			[]*v1core.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "svc-1",
+						Name:      "svc-1",
+						Namespace: "default",
 					},
 					Spec: v1core.ServiceSpec{
-						Type:        "ClusterIP",
-						ClusterIP:   "10.11.0.1",
-						ExternalIPs: []string{"1.11.1.1"},
+						Type:                  "ClusterIP",
+						ClusterIP:             "10.11.0.1",
+						ExternalIPs:           []string{"1.11.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*v1core.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+					},
+					Subsets: []v1core.EndpointSubset{
+						{
+							Addresses: []v1core.EndpointAddress{
+								{
+									IP: testNodeIPv4,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -428,12 +469,32 @@ func Test_AddPolicies(t *testing.T) {
 			[]*v1core.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "svc-1",
+						Name:      "svc-1",
+						Namespace: "default",
 					},
 					Spec: v1core.ServiceSpec{
-						Type:        ClusterIPST,
-						ClusterIP:   "10.12.0.1",
-						ExternalIPs: []string{"1.12.1.1"},
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.12.0.1",
+						ExternalIPs:           []string{"1.12.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*v1core.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+					},
+					Subsets: []v1core.EndpointSubset{
+						{
+							Addresses: []v1core.EndpointAddress{
+								{
+									IP: testNodeIPv4,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -613,12 +674,32 @@ func Test_AddPolicies(t *testing.T) {
 			[]*v1core.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "svc-1",
+						Name:      "svc-1",
+						Namespace: "default",
 					},
 					Spec: v1core.ServiceSpec{
-						Type:        ClusterIPST,
-						ClusterIP:   "10.13.0.1",
-						ExternalIPs: []string{"1.13.1.1"},
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.13.0.1",
+						ExternalIPs:           []string{"1.13.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*v1core.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+					},
+					Subsets: []v1core.EndpointSubset{
+						{
+							Addresses: []v1core.EndpointAddress{
+								{
+									IP: testNodeIPv4,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -783,12 +864,32 @@ func Test_AddPolicies(t *testing.T) {
 			[]*v1core.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "svc-1",
+						Name:      "svc-1",
+						Namespace: "default",
 					},
 					Spec: v1core.ServiceSpec{
-						Type:        ClusterIPST,
-						ClusterIP:   "10.14.0.1",
-						ExternalIPs: []string{"1.14.1.1"},
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.14.0.1",
+						ExternalIPs:           []string{"1.14.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*v1core.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+					},
+					Subsets: []v1core.EndpointSubset{
+						{
+							Addresses: []v1core.EndpointAddress{
+								{
+									IP: testNodeIPv4,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -973,12 +1074,32 @@ func Test_AddPolicies(t *testing.T) {
 			[]*v1core.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "svc-1",
+						Name:      "svc-1",
+						Namespace: "default",
 					},
 					Spec: v1core.ServiceSpec{
-						Type:        ClusterIPST,
-						ClusterIP:   "10.15.0.1",
-						ExternalIPs: []string{"1.15.1.1"},
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.15.0.1",
+						ExternalIPs:           []string{"1.15.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*v1core.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+					},
+					Subsets: []v1core.EndpointSubset{
+						{
+							Addresses: []v1core.EndpointAddress{
+								{
+									IP: testNodeIPv4,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1164,12 +1285,32 @@ func Test_AddPolicies(t *testing.T) {
 			[]*v1core.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "svc-1",
+						Name:      "svc-1",
+						Namespace: "default",
 					},
 					Spec: v1core.ServiceSpec{
-						Type:        ClusterIPST,
-						ClusterIP:   "10.16.0.1",
-						ExternalIPs: []string{"1.16.1.1"},
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.16.0.1",
+						ExternalIPs:           []string{"1.16.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*v1core.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+					},
+					Subsets: []v1core.EndpointSubset{
+						{
+							Addresses: []v1core.EndpointAddress{
+								{
+									IP: testNodeIPv4,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -1309,7 +1450,11 @@ func Test_AddPolicies(t *testing.T) {
 			}
 
 			if err := createServices(testcase.nrc.clientset, testcase.existingServices); err != nil {
-				t.Errorf("failed to create existing nodes: %v", err)
+				t.Errorf("failed to create existing services: %v", err)
+			}
+
+			if err := createEndpoints(testcase.nrc.clientset, testcase.existingEndpoints); err != nil {
+				t.Errorf("failed to create existing endpoints: %v", err)
 			}
 
 			err := testcase.nrc.startBgpServer(false)

--- a/pkg/controllers/routing/ecmp_vip_test.go
+++ b/pkg/controllers/routing/ecmp_vip_test.go
@@ -2,7 +2,9 @@ package routing
 
 import (
 	"context"
+	"net"
 	"testing"
+	"time"
 
 	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,98 +24,67 @@ func Equal(a, b []string) bool {
 	return true
 }
 
+var (
+	testlocalExtTrafPol   = v1core.ServiceExternalTrafficPolicyLocal
+	testClusterExtTrafPol = v1core.ServiceExternalTrafficPolicyCluster
+	testLocalIntTrafPol   = v1core.ServiceInternalTrafficPolicyLocal
+	testClusterIntTrafPol = v1core.ServiceInternalTrafficPolicyCluster
+	testNodeIPv4          = "10.1.0.1"
+	testNodeIPv6          = "2001:db8:42:2::1"
+)
+
 type ServiceAdvertisedIPs struct {
-	service       *v1core.Service
-	advertisedIPs []string
-	withdrawnIPs  []string
-	annotations   map[string]string
+	service               *v1core.Service
+	endpoints             *v1core.Endpoints
+	internalTrafficPolicy *v1core.ServiceInternalTrafficPolicyType
+	externalTrafficPolicy *v1core.ServiceExternalTrafficPolicyType
+	advertisedIPs         []string
+	withdrawnIPs          []string
+	annotations           map[string]string
 }
 
 func Test_getVIPsForService(t *testing.T) {
-	services := map[string]*v1core.Service{
-		"cluster": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "svc-cluster",
-			},
-			Spec: v1core.ServiceSpec{
-				Type:      ClusterIPST,
-				ClusterIP: "10.0.0.1",
-			},
-		},
-		"external": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "svc-external",
-			},
-			Spec: v1core.ServiceSpec{
-				Type:        ClusterIPST,
-				ClusterIP:   "10.0.0.1",
-				ExternalIPs: []string{"1.1.1.1"},
-			},
-		},
-		"nodeport": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "svc-nodeport",
-			},
-			Spec: v1core.ServiceSpec{
-				Type:        NodePortST,
-				ClusterIP:   "10.0.0.1",
-				ExternalIPs: []string{"1.1.1.1"},
-			},
-		},
-		"loadbalancer": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "svc-loadbalancer",
-			},
-			Spec: v1core.ServiceSpec{
-				Type:        LoadBalancerST,
-				ClusterIP:   "10.0.0.1",
-				ExternalIPs: []string{"1.1.1.1"},
-			},
-			Status: v1core.ServiceStatus{
-				LoadBalancer: v1core.LoadBalancerStatus{
-					Ingress: []v1core.LoadBalancerIngress{
-						{
-							IP: "10.0.255.1",
-						},
-						{
-							IP: "10.0.255.2",
-						},
-					},
-				},
-			},
-		},
-	}
-
 	tests := []struct {
-		name string
-		// cluster, external, loadbalancer
-		advertiseSettings    [3]bool
+		name                 string
+		nrc                  *NetworkRoutingController
 		serviceAdvertisedIPs []*ServiceAdvertisedIPs
 	}{
 		{
-			name:              "advertise all IPs",
-			advertiseSettings: [3]bool{true, true, true},
+			name: "advertise all IPs",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
 				{
-					service:       services["cluster"],
+					service:       getClusterSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1"},
 					withdrawnIPs:  []string{},
 					annotations:   nil,
 				},
 				{
-					service:       services["external"],
+					service:       getExternalSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1", "1.1.1.1"},
 					withdrawnIPs:  []string{},
 					annotations:   nil,
 				},
 				{
-					service:       services["nodeport"],
+					service:       getNodePortSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1", "1.1.1.1"},
 					withdrawnIPs:  []string{},
 					annotations:   nil,
 				},
 				{
-					service:       services["loadbalancer"],
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
 					withdrawnIPs:  []string{},
 					annotations:   nil,
@@ -121,29 +92,41 @@ func Test_getVIPsForService(t *testing.T) {
 			},
 		},
 		{
-			name:              "do not advertise any IPs",
-			advertiseSettings: [3]bool{false, false, false},
+			name: "do not advertise any IPs",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      false,
+				advertiseExternalIP:     false,
+				advertiseLoadBalancerIP: false,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
 				{
-					service:       services["cluster"],
+					service:       getClusterSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["external"],
+					service:       getExternalSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["nodeport"],
+					service:       getNodePortSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["loadbalancer"],
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
 					annotations:   nil,
@@ -151,29 +134,41 @@ func Test_getVIPsForService(t *testing.T) {
 			},
 		},
 		{
-			name:              "advertise cluster IPs",
-			advertiseSettings: [3]bool{true, false, false},
+			name: "advertise cluster IPs",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     false,
+				advertiseLoadBalancerIP: false,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
 				{
-					service:       services["cluster"],
+					service:       getClusterSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1"},
 					withdrawnIPs:  []string{},
 					annotations:   nil,
 				},
 				{
-					service:       services["external"],
+					service:       getExternalSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1"},
 					withdrawnIPs:  []string{"1.1.1.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["nodeport"],
+					service:       getNodePortSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1"},
 					withdrawnIPs:  []string{"1.1.1.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["loadbalancer"],
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1"},
 					withdrawnIPs:  []string{"1.1.1.1", "10.0.255.1", "10.0.255.2"},
 					annotations:   nil,
@@ -181,29 +176,41 @@ func Test_getVIPsForService(t *testing.T) {
 			},
 		},
 		{
-			name:              "advertise external IPs",
-			advertiseSettings: [3]bool{false, true, false},
+			name: "advertise external IPs",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      false,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: false,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
 				{
-					service:       services["cluster"],
+					service:       getClusterSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["external"],
+					service:       getExternalSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"1.1.1.1"},
 					withdrawnIPs:  []string{"10.0.0.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["nodeport"],
+					service:       getNodePortSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"1.1.1.1"},
 					withdrawnIPs:  []string{"10.0.0.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["loadbalancer"],
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"1.1.1.1"},
 					withdrawnIPs:  []string{"10.0.0.1", "10.0.255.1", "10.0.255.2"},
 					annotations:   nil,
@@ -211,29 +218,41 @@ func Test_getVIPsForService(t *testing.T) {
 			},
 		},
 		{
-			name:              "advertise loadbalancer IPs",
-			advertiseSettings: [3]bool{false, false, true},
+			name: "advertise loadbalancer IPs",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      false,
+				advertiseExternalIP:     false,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
 				{
-					service:       services["cluster"],
+					service:       getClusterSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["external"],
+					service:       getExternalSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["nodeport"],
+					service:       getNodePortSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
 					annotations:   nil,
 				},
 				{
-					service:       services["loadbalancer"],
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.255.1", "10.0.255.2"},
 					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
 					annotations:   nil,
@@ -241,11 +260,20 @@ func Test_getVIPsForService(t *testing.T) {
 			},
 		},
 		{
-			name:              "opt in to advertise all IPs via annotations",
-			advertiseSettings: [3]bool{false, false, false},
+			name: "opt in to advertise all IPs via annotations",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      false,
+				advertiseExternalIP:     false,
+				advertiseLoadBalancerIP: false,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
 				{
-					service:       services["cluster"],
+					service:       getClusterSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1"},
 					withdrawnIPs:  []string{},
 					annotations: map[string]string{
@@ -255,7 +283,8 @@ func Test_getVIPsForService(t *testing.T) {
 					},
 				},
 				{
-					service:       services["external"],
+					service:       getExternalSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1", "1.1.1.1"},
 					withdrawnIPs:  []string{},
 					annotations: map[string]string{
@@ -265,7 +294,8 @@ func Test_getVIPsForService(t *testing.T) {
 					},
 				},
 				{
-					service:       services["nodeport"],
+					service:       getNodePortSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1", "1.1.1.1"},
 					withdrawnIPs:  []string{},
 					annotations: map[string]string{
@@ -275,7 +305,8 @@ func Test_getVIPsForService(t *testing.T) {
 					},
 				},
 				{
-					service:       services["loadbalancer"],
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
 					withdrawnIPs:  []string{},
 					annotations: map[string]string{
@@ -286,7 +317,8 @@ func Test_getVIPsForService(t *testing.T) {
 				},
 				{
 					// Special case to test svcAdvertiseLoadBalancerAnnotation vs legacy svcSkipLbIpsAnnotation
-					service:       services["loadbalancer"],
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{"10.0.0.1", "1.1.1.1"},
 					withdrawnIPs:  []string{"10.0.255.1", "10.0.255.2"},
 					annotations: map[string]string{
@@ -299,11 +331,20 @@ func Test_getVIPsForService(t *testing.T) {
 			},
 		},
 		{
-			name:              "opt out to advertise any IPs via annotations",
-			advertiseSettings: [3]bool{true, true, true},
+			name: "opt out to advertise any IPs via annotations",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
 				{
-					service:       services["cluster"],
+					service:       getClusterSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1"},
 					annotations: map[string]string{
@@ -313,7 +354,8 @@ func Test_getVIPsForService(t *testing.T) {
 					},
 				},
 				{
-					service:       services["external"],
+					service:       getExternalSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
 					annotations: map[string]string{
@@ -323,7 +365,8 @@ func Test_getVIPsForService(t *testing.T) {
 					},
 				},
 				{
-					service:       services["nodeport"],
+					service:       getNodePortSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
 					annotations: map[string]string{
@@ -333,7 +376,8 @@ func Test_getVIPsForService(t *testing.T) {
 					},
 				},
 				{
-					service:       services["loadbalancer"],
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
 					advertisedIPs: []string{},
 					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
 					annotations: map[string]string{
@@ -344,23 +388,520 @@ func Test_getVIPsForService(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "check service local annotation with local IPv4 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:       getClusterSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
+					advertisedIPs: []string{"10.0.0.1"},
+					withdrawnIPs:  []string{},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getExternalSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
+					advertisedIPs: []string{"10.0.0.1", "1.1.1.1"},
+					withdrawnIPs:  []string{},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getNodePortSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
+					advertisedIPs: []string{"10.0.0.1", "1.1.1.1"},
+					withdrawnIPs:  []string{},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv4EPs(),
+					advertisedIPs: []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					withdrawnIPs:  []string{},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+			},
+		},
+		{
+			name: "check service local annotation with local IPv6 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv6),
+				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv6)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:       getClusterSvc(),
+					endpoints:     getContainsLocalIPv6EPs(),
+					advertisedIPs: []string{"10.0.0.1"},
+					withdrawnIPs:  []string{},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getExternalSvc(),
+					endpoints:     getContainsLocalIPv6EPs(),
+					advertisedIPs: []string{"10.0.0.1", "1.1.1.1"},
+					withdrawnIPs:  []string{},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getNodePortSvc(),
+					endpoints:     getContainsLocalIPv6EPs(),
+					advertisedIPs: []string{"10.0.0.1", "1.1.1.1"},
+					withdrawnIPs:  []string{},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getLoadBalancerSvc(),
+					endpoints:     getContainsLocalIPv6EPs(),
+					advertisedIPs: []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					withdrawnIPs:  []string{},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+			},
+		},
+		{
+			name: "check local external traffic policy with local IPv4 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:               getClusterSvc(),
+					endpoints:             getContainsLocalIPv4EPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getExternalSvc(),
+					endpoints:             getContainsLocalIPv4EPs(),
+					advertisedIPs:         []string{"10.0.0.1", "1.1.1.1"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getNodePortSvc(),
+					endpoints:             getContainsLocalIPv4EPs(),
+					advertisedIPs:         []string{"10.0.0.1", "1.1.1.1"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getLoadBalancerSvc(),
+					endpoints:             getContainsLocalIPv4EPs(),
+					advertisedIPs:         []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+			},
+		},
+		{
+			name: "check local external traffic policy with local IPv6 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv6),
+				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv6)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:               getClusterSvc(),
+					endpoints:             getContainsLocalIPv6EPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getExternalSvc(),
+					endpoints:             getContainsLocalIPv6EPs(),
+					advertisedIPs:         []string{"10.0.0.1", "1.1.1.1"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getNodePortSvc(),
+					endpoints:             getContainsLocalIPv6EPs(),
+					advertisedIPs:         []string{"10.0.0.1", "1.1.1.1"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getLoadBalancerSvc(),
+					endpoints:             getContainsLocalIPv6EPs(),
+					advertisedIPs:         []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+			},
+		},
+		{
+			name: "check service local annotation WITHOUT local IPv4 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv6)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:       getClusterSvc(),
+					endpoints:     getNoLocalAddressesEPs(),
+					advertisedIPs: []string{},
+					withdrawnIPs:  []string{"10.0.0.1"},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getExternalSvc(),
+					endpoints:     getNoLocalAddressesEPs(),
+					advertisedIPs: []string{},
+					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getNodePortSvc(),
+					endpoints:     getNoLocalAddressesEPs(),
+					advertisedIPs: []string{},
+					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getLoadBalancerSvc(),
+					endpoints:     getNoLocalAddressesEPs(),
+					advertisedIPs: []string{},
+					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+			},
+		},
+		{
+			name: "check service local annotation WITHOUT local IPv6 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv6),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:       getClusterSvc(),
+					endpoints:     getNoLocalAddressesEPs(),
+					advertisedIPs: []string{},
+					withdrawnIPs:  []string{"10.0.0.1"},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getExternalSvc(),
+					endpoints:     getNoLocalAddressesEPs(),
+					advertisedIPs: []string{},
+					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getNodePortSvc(),
+					endpoints:     getNoLocalAddressesEPs(),
+					advertisedIPs: []string{},
+					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1"},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+				{
+					service:       getLoadBalancerSvc(),
+					endpoints:     getNoLocalAddressesEPs(),
+					advertisedIPs: []string{},
+					withdrawnIPs:  []string{"10.0.0.1", "1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					annotations: map[string]string{
+						svcLocalAnnotation: "true",
+					},
+				},
+			},
+		},
+		{
+			name: "check local external traffic policy WITHOUT local IPv4 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:               getClusterSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getExternalSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{"1.1.1.1"},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getNodePortSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{"1.1.1.1"},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getLoadBalancerSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{"1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+			},
+		},
+		{
+			name: "check local external traffic policy WITHOUT local IPv6 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv6),
+				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv6)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:               getClusterSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getExternalSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{"1.1.1.1"},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getNodePortSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{"1.1.1.1"},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+				{
+					service:               getLoadBalancerSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"10.0.0.1"},
+					withdrawnIPs:          []string{"1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					annotations:           nil,
+					externalTrafficPolicy: &testlocalExtTrafPol,
+				},
+			},
+		},
+		{
+			name: "check local internal traffic policy WITHOUT local IPv4 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv4),
+				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv4)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:               getClusterSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{},
+					withdrawnIPs:          []string{"10.0.0.1"},
+					annotations:           nil,
+					internalTrafficPolicy: &testLocalIntTrafPol,
+				},
+				{
+					service:               getExternalSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"1.1.1.1"},
+					withdrawnIPs:          []string{"10.0.0.1"},
+					annotations:           nil,
+					internalTrafficPolicy: &testLocalIntTrafPol,
+				},
+				{
+					service:               getNodePortSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"1.1.1.1"},
+					withdrawnIPs:          []string{"10.0.0.1"},
+					annotations:           nil,
+					internalTrafficPolicy: &testLocalIntTrafPol,
+				},
+				{
+					service:               getLoadBalancerSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					withdrawnIPs:          []string{"10.0.0.1"},
+					annotations:           nil,
+					internalTrafficPolicy: &testLocalIntTrafPol,
+				},
+			},
+		},
+		{
+			name: "check local internal traffic policy WITHOUT local IPv6 endpoints",
+			nrc: &NetworkRoutingController{
+				advertiseClusterIP:      true,
+				advertiseExternalIP:     true,
+				advertiseLoadBalancerIP: true,
+				primaryIP:               net.ParseIP(testNodeIPv6),
+				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
+					net.ParseIP(testNodeIPv6)},
+				},
+			},
+			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
+				{
+					service:               getClusterSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{},
+					withdrawnIPs:          []string{"10.0.0.1"},
+					annotations:           nil,
+					internalTrafficPolicy: &testLocalIntTrafPol,
+				},
+				{
+					service:               getExternalSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"1.1.1.1"},
+					withdrawnIPs:          []string{"10.0.0.1"},
+					annotations:           nil,
+					internalTrafficPolicy: &testLocalIntTrafPol,
+				},
+				{
+					service:               getNodePortSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"1.1.1.1"},
+					withdrawnIPs:          []string{"10.0.0.1"},
+					annotations:           nil,
+					internalTrafficPolicy: &testLocalIntTrafPol,
+				},
+				{
+					service:               getLoadBalancerSvc(),
+					endpoints:             getNoLocalAddressesEPs(),
+					advertisedIPs:         []string{"1.1.1.1", "10.0.255.1", "10.0.255.2"},
+					withdrawnIPs:          []string{"10.0.0.1"},
+					annotations:           nil,
+					internalTrafficPolicy: &testLocalIntTrafPol,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
-		nrc := NetworkRoutingController{}
 		t.Run(test.name, func(t *testing.T) {
-			nrc.advertiseClusterIP = test.advertiseSettings[0]
-			nrc.advertiseExternalIP = test.advertiseSettings[1]
-			nrc.advertiseLoadBalancerIP = test.advertiseSettings[2]
-
 			for _, serviceAdvertisedIP := range test.serviceAdvertisedIPs {
+				endpoints := serviceAdvertisedIP.endpoints
 				clientset := fake.NewSimpleClientset()
+				startInformersForRoutes(test.nrc, clientset)
 
+				// Take care of adding annotations
 				if serviceAdvertisedIP.annotations != nil {
 					serviceAdvertisedIP.service.ObjectMeta.Annotations = serviceAdvertisedIP.annotations
 				}
+
+				if serviceAdvertisedIP.internalTrafficPolicy != nil {
+					serviceAdvertisedIP.service.Spec.InternalTrafficPolicy = serviceAdvertisedIP.internalTrafficPolicy
+				}
+
+				if serviceAdvertisedIP.externalTrafficPolicy != nil {
+					serviceAdvertisedIP.service.Spec.ExternalTrafficPolicy = *serviceAdvertisedIP.externalTrafficPolicy
+				}
+
+				// Take care of adding endpoints if needed for test
+				if endpoints != nil {
+					endpoints.ObjectMeta.Name = serviceAdvertisedIP.service.Name
+					endpoints.ObjectMeta.Namespace = serviceAdvertisedIP.service.Namespace
+					if _, err := clientset.CoreV1().Endpoints(endpoints.GetObjectMeta().GetNamespace()).Create(
+						context.Background(), endpoints, metav1.CreateOptions{}); err != nil {
+						t.Fatalf("failed to create endpoints for test: %v", err)
+					}
+					waitForListerWithTimeout(test.nrc.epLister, time.Second*10, t)
+				}
+
 				svc, _ := clientset.CoreV1().Services("default").Create(context.Background(), serviceAdvertisedIP.service, metav1.CreateOptions{})
-				advertisedIPs, withdrawnIPs, _ := nrc.getVIPsForService(svc, false)
+				advertisedIPs, withdrawnIPs, err := test.nrc.getAllVIPsForService(svc)
+				if err != nil {
+					t.Errorf("We shouldn't get an error for any of these tests, failing due to: %v", err)
+				}
 				t.Logf("AdvertisedIPs: %v\n", advertisedIPs)
 				t.Logf("WithdrawnIPs: %v\n", withdrawnIPs)
 				if !Equal(serviceAdvertisedIP.advertisedIPs, advertisedIPs) {
@@ -371,5 +912,159 @@ func Test_getVIPsForService(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func getClusterSvc() *v1core.Service {
+	return &v1core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-cluster",
+			Namespace: "default",
+		},
+		Spec: v1core.ServiceSpec{
+			Type:                  ClusterIPST,
+			ClusterIP:             "10.0.0.1",
+			InternalTrafficPolicy: &testClusterIntTrafPol,
+			ExternalTrafficPolicy: testClusterExtTrafPol,
+		},
+	}
+}
+
+func getExternalSvc() *v1core.Service {
+	return &v1core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-external",
+			Namespace: "default",
+		},
+		Spec: v1core.ServiceSpec{
+			Type:                  ClusterIPST,
+			ClusterIP:             "10.0.0.1",
+			ExternalIPs:           []string{"1.1.1.1"},
+			InternalTrafficPolicy: &testClusterIntTrafPol,
+			ExternalTrafficPolicy: testClusterExtTrafPol,
+		},
+	}
+}
+
+func getNodePortSvc() *v1core.Service {
+	return &v1core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-nodeport",
+			Namespace: "default",
+		},
+		Spec: v1core.ServiceSpec{
+			Type:                  NodePortST,
+			ClusterIP:             "10.0.0.1",
+			ExternalIPs:           []string{"1.1.1.1"},
+			InternalTrafficPolicy: &testClusterIntTrafPol,
+			ExternalTrafficPolicy: testClusterExtTrafPol,
+		},
+	}
+}
+
+func getLoadBalancerSvc() *v1core.Service {
+	return &v1core.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-loadbalancer",
+			Namespace: "default",
+		},
+		Spec: v1core.ServiceSpec{
+			Type:                  LoadBalancerST,
+			ClusterIP:             "10.0.0.1",
+			ExternalIPs:           []string{"1.1.1.1"},
+			InternalTrafficPolicy: &testClusterIntTrafPol,
+			ExternalTrafficPolicy: testClusterExtTrafPol,
+		},
+		Status: v1core.ServiceStatus{
+			LoadBalancer: v1core.LoadBalancerStatus{
+				Ingress: []v1core.LoadBalancerIngress{
+					{
+						IP: "10.0.255.1",
+					},
+					{
+						IP: "10.0.255.2",
+					},
+				},
+			},
+		},
+	}
+}
+
+func getContainsLocalIPv4EPs() *v1core.Endpoints {
+	return &v1core.Endpoints{
+		Subsets: []v1core.EndpointSubset{
+			{
+				Addresses: []v1core.EndpointAddress{
+					{
+						IP: testNodeIPv4,
+					},
+					{
+						IP: "10.1.0.2",
+					},
+				},
+			},
+			{
+				Addresses: []v1core.EndpointAddress{
+					{
+						IP: "10.1.1.1",
+					},
+				},
+			},
+		},
+	}
+}
+
+func getContainsLocalIPv6EPs() *v1core.Endpoints {
+	return &v1core.Endpoints{
+		Subsets: []v1core.EndpointSubset{
+			{
+				Addresses: []v1core.EndpointAddress{
+					{
+						IP: testNodeIPv6,
+					},
+					{
+						IP: "2001:db8:42:2::2",
+					},
+				},
+			},
+			{
+				Addresses: []v1core.EndpointAddress{
+					{
+						IP: "2001:db8:42:2::3",
+					},
+				},
+			},
+		},
+	}
+}
+
+func getNoLocalAddressesEPs() *v1core.Endpoints {
+	return &v1core.Endpoints{
+		Subsets: []v1core.EndpointSubset{
+			{
+				Addresses: []v1core.EndpointAddress{
+					{
+						IP: "2001:db8:42:2::3",
+					},
+					{
+						IP: "2001:db8:42:2::2",
+					},
+				},
+			},
+			{
+				Addresses: []v1core.EndpointAddress{
+					{
+						IP: "2001:db8:42:2::3",
+					},
+				},
+			},
+			{
+				Addresses: []v1core.EndpointAddress{
+					{
+						IP: "10.1.0.2",
+					},
+				},
+			},
+		},
 	}
 }

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -371,7 +371,7 @@ func (nrc *NetworkRoutingController) Run(healthChan chan<- *healthcheck.Controll
 		}
 
 		// advertise or withdraw IPs for the services to be reachable via host
-		toAdvertise, toWithdraw, err := nrc.getActiveVIPs()
+		toAdvertise, toWithdraw, err := nrc.getVIPs()
 		if err != nil {
 			klog.Errorf("failed to get routes to advertise/withdraw %s", err)
 		}


### PR DESCRIPTION
Adds support for `spec.internalTrafficPolicy` (introduced in k8s v1.26) and fixes `spec.externalTrafficPolicy` to behave according to upstream indicated behavior: https://kubernetes.io/docs/reference/networking/virtual-ips/#traffic-policies

At this point, we still don't handle terminating endpoints as specified in the documentation. However, I think that this is a good bit of work, so its probably best to handle that in a future PR.

Relates to #1597 - However, #1597 won't be completely finished until we implement the specialized draining procedure and pass all traffic policy related e2e tests.