### PR TITLE
Make kube router healthchecknodeport aware

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -243,6 +243,7 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 		klog.Fatalf("error cleaning up old/bad masquerade rules: %s", err.Error())
 	}
 
+	// Run the hairpin controller
 	wg.Add(1)
 	go nsc.hpc.Run(stopCh, wg, healthChan)
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1081,12 +1081,12 @@ func (nsc *NetworkServicesController) buildEndpointSliceInfo() endpointSliceInfo
 		//     protocol: TCP
 		//
 		for _, ep := range es.Endpoints {
-			// Previously, when we used endpoints, we only looked at subsets.addresses and not subsets.notReadyAddresses
-			// so here we need to limit our endpoints to only the ones that are ready. In the future, we could consider
-			// changing this to .Serving which continues to include pods that are in Terminating state. For now we keep
-			// it the same.
-			if ep.Conditions.Ready == nil || !*ep.Conditions.Ready {
-				klog.V(2).Infof("Endpoint (with addresses %s) does not have a ready status, skipping...", ep.Addresses)
+			// We should only look at serving or ready if we want to be compliant with the upstream expectantions of a
+			// network provider
+			if (ep.Conditions.Serving == nil || !*ep.Conditions.Serving) &&
+				(ep.Conditions.Ready == nil || !*ep.Conditions.Ready) {
+				klog.V(2).Infof("Endpoint (with addresses %s) does not have a ready or serving status, skipping...",
+					ep.Addresses)
 				continue
 			}
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -214,11 +214,14 @@ type serviceInfoMap map[string]*serviceInfo
 
 // internal representation of endpoints
 type endpointSliceInfo struct {
-	ip      string
-	port    int
-	isLocal bool
-	isIPv4  bool
-	isIPv6  bool
+	ip            string
+	port          int
+	isLocal       bool
+	isIPv4        bool
+	isIPv6        bool
+	isReady       bool
+	isServing     bool
+	isTerminating bool
 }
 
 // map of all endpoints, with unique service id(namespace name, service name, port) as key
@@ -1105,11 +1108,14 @@ func (nsc *NetworkServicesController) buildEndpointSliceInfo() endpointSliceInfo
 				for _, addr := range ep.Addresses {
 					isLocal := ep.NodeName != nil && *ep.NodeName == nsc.nodeHostName
 					endpoints = append(endpoints, endpointSliceInfo{
-						ip:      addr,
-						port:    int(*port.Port),
-						isLocal: isLocal,
-						isIPv4:  isIPv4,
-						isIPv6:  isIPv6,
+						ip:            addr,
+						port:          int(*port.Port),
+						isLocal:       isLocal,
+						isIPv4:        isIPv4,
+						isIPv6:        isIPv6,
+						isReady:       ep.Conditions.Ready != nil && *ep.Conditions.Ready,
+						isServing:     ep.Conditions.Serving != nil && *ep.Conditions.Serving,
+						isTerminating: ep.Conditions.Terminating != nil && *ep.Conditions.Terminating,
 					})
 				}
 				endpointsMap[svcID] = shuffle(endpoints)

--- a/pkg/controllers/proxy/nodeport_healthcheck.go
+++ b/pkg/controllers/proxy/nodeport_healthcheck.go
@@ -1,0 +1,185 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+type nodePortHealthCheckController struct {
+	nphcServicesInfo
+	activeNPHC map[int](chan<- struct{})
+	wg         *sync.WaitGroup
+	stopCh     chan struct{}
+}
+
+type serviceHealthCheck struct {
+	serviceID string
+	nodePort  int
+}
+
+type nphcServicesInfo struct {
+	serviceInfoMap   serviceInfoMap
+	endpointsInfoMap endpointSliceInfoMap
+}
+
+type nphcHandler struct {
+	svcHC *serviceHealthCheck
+	nphc  *nodePortHealthCheckController
+}
+
+func (nphc *nodePortHealthCheckController) UpdateServicesInfo(serviceInfoMap serviceInfoMap,
+	endpointsInfoMap endpointSliceInfoMap) error {
+	klog.V(1).Info("Running UpdateServicesInfo for NodePort health check")
+	nphc.serviceInfoMap = serviceInfoMap
+	nphc.endpointsInfoMap = endpointsInfoMap
+
+	newActiveServices := make(map[int]bool)
+
+	for svcID, svc := range serviceInfoMap {
+		if svc.healthCheckNodePort != 0 {
+			newActiveServices[svc.healthCheckNodePort] = true
+			svcHC := serviceHealthCheck{
+				serviceID: svcID,
+				nodePort:  svc.healthCheckNodePort,
+			}
+			if nphc.healthCheckExists(svcHC) {
+				continue
+			}
+			err := nphc.addHealthCheck(svcHC)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for np := range nphc.activeNPHC {
+		if !newActiveServices[np] {
+			err := nphc.stopHealthCheck(np)
+			if err != nil {
+				klog.Errorf("error stopping the NodePort healthcheck on NodePort %d: %v", np, err)
+			}
+		}
+	}
+
+	klog.V(1).Info("Finished UpdateServicesInfo for NodePort health check")
+	return nil
+}
+
+func (nphc *nodePortHealthCheckController) healthCheckExists(svcHC serviceHealthCheck) bool {
+	if _, ok := nphc.activeNPHC[svcHC.nodePort]; ok {
+		return true
+	}
+	return false
+}
+
+func (nphc *nodePortHealthCheckController) addHealthCheck(svcHC serviceHealthCheck) error {
+	klog.V(1).Infof("Adding NodePort health check for port: %d with svcid: %s", svcHC.nodePort, svcHC.serviceID)
+	if nphc.healthCheckExists(svcHC) {
+		return fmt.Errorf("unable to add healthcheck for NodePort %d as it is already taken", svcHC.nodePort)
+	}
+	closingChan := make(chan struct{})
+	nphc.activeNPHC[svcHC.nodePort] = closingChan
+
+	nphc.wg.Add(1)
+	go func(nphc *nodePortHealthCheckController, svcHC serviceHealthCheck, closingChan <-chan struct{}) {
+		defer nphc.wg.Done()
+		mux := http.NewServeMux()
+		srv := &http.Server{
+			Addr:              ":" + strconv.Itoa(svcHC.nodePort),
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+		}
+
+		npHandler := nphcHandler{
+			svcHC: &svcHC,
+			nphc:  nphc,
+		}
+		mux.HandleFunc("/healthz", npHandler.Handler)
+
+		nphc.wg.Add(1)
+		go func(svcHC serviceHealthCheck) {
+			defer nphc.wg.Done()
+			klog.Infof("starting NodePort health controller on NodePort: %d", svcHC.nodePort)
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				// cannot panic, because this probably is an intentional close
+				klog.Errorf("could not start NodePort health controller on NodePort %d: %s", svcHC.nodePort, err)
+			}
+		}(svcHC)
+
+		// block until we receive a shut down signal on either our private channel or the global channel
+		select {
+		case <-closingChan:
+		case <-nphc.stopCh:
+		}
+		klog.Infof("shutting down NodePort health controller on NodePort: %d", svcHC.nodePort)
+		if err := srv.Shutdown(context.Background()); err != nil {
+			klog.Errorf("could not shutdown NodePort health controller on NodePort %d: %v", svcHC.nodePort, err)
+		}
+
+	}(nphc, svcHC, closingChan)
+
+	return nil
+}
+
+func (nphc *nodePortHealthCheckController) stopHealthCheck(nodePort int) error {
+	if _, ok := nphc.activeNPHC[nodePort]; !ok {
+		return fmt.Errorf("no NodePort health check currently exists for NodePort: %d", nodePort)
+	}
+
+	svcStopCh := nphc.activeNPHC[nodePort]
+	close(svcStopCh)
+
+	delete(nphc.activeNPHC, nodePort)
+
+	return nil
+}
+
+func (npHandler *nphcHandler) Handler(w http.ResponseWriter, r *http.Request) {
+	eps := npHandler.nphc.endpointsInfoMap[npHandler.svcHC.serviceID]
+	endpointsOnNode := hasActiveEndpoints(eps)
+
+	var numActiveEndpoints int8
+	for _, endpoint := range eps {
+		if endpoint.isLocal && !endpoint.isTerminating {
+			numActiveEndpoints++
+		}
+	}
+
+	if endpointsOnNode && numActiveEndpoints > 0 {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(fmt.Sprintf("%d Service Endpoints found\n", numActiveEndpoints)))
+		if err != nil {
+			klog.Errorf("failed to write body: %s", err)
+		}
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, err := w.Write([]byte("No Service Endpoints Found\n"))
+		if err != nil {
+			klog.Errorf("Failed to write body: %s", err)
+		}
+	}
+}
+
+func (nphc *nodePortHealthCheckController) StopAll() {
+	klog.Info("Stopping all NodePort health checks")
+	close(nphc.stopCh)
+	klog.Info("Waiting for all NodePort health checks to finish shutting down")
+	nphc.wg.Wait()
+	klog.Info("All NodePort health checks are completely shut down, all done!")
+}
+
+func NewNodePortHealthCheck() *nodePortHealthCheckController {
+	nphc := nodePortHealthCheckController{
+		activeNPHC: make(map[int]chan<- struct{}),
+		wg:         &sync.WaitGroup{},
+		stopCh:     make(chan struct{}),
+	}
+
+	return &nphc
+}

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -61,6 +61,13 @@ func (nsc *NetworkServicesController) syncIpvsServices(serviceInfoMap serviceInf
 			err.Error())
 	}
 
+	klog.V(1).Info("Setting up NodePort Health Checks for LB services")
+	err = nsc.nphc.UpdateServicesInfo(serviceInfoMap, endpointsInfoMap)
+	if err != nil {
+		syncErrors = true
+		klog.Errorf("Error setting up NodePort Health Checks for LB Services: %v", err)
+	}
+
 	klog.V(1).Info("Cleaning Up Stale VIPs from dummy interface")
 	err = nsc.cleanupStaleVIPs(activeServiceEndpointMap)
 	if err != nil {


### PR DESCRIPTION
The big change here is that kube-router now implements the NodePort HealthCheck feature that is best described here: https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-loadbalancer

Blurb from the commit for this feature is:

>NodePort Health Check has long been part of the Kubernetes API, but
kube-router hasn't implemented it in the past. This is meant to be a
port that is assigned by the kube-controller-manager for LoadBalancer
services that have a traffic policy of `externalTrafficPolicy=Local`.

>When set, the k8s networking implementation is meant to open a port and
provide HTTP responses that inform parties external to the Kubernetes
cluster about whether or not a local endpoint exists on the node. It
should return a 200 status if the node contains a local endpoint and
return a 503 status if the node does not contain a local endpoint.

>This allows applications outside the cluster to choose their endpoint in
such a way that their source IP could be preserved.

Additionally, in order to become more compliant with other network providers and the upstream e2e tests, we now also add endpoints to load balancers for EndpointSlices that are either `Ready` or `Serving` as opposed to just `Ready`. This allow traffic to route to legitimate service endpoints that are in the `Terminating` state.

This is a departure from previous functionality, so there may be some impact to services that were relying on the previous `Ready` only interpretation for endpoint adding.

Fixes: #1597