### PR TITLE
dependabot: Group kubernetes dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    groups:
+      k8s-dependencies:
+        patterns:
+          - "k8s.io*"
     schedule:
       interval: "monthly"
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
@aauren this will reduce the number of PRs that dependabot makes for the Kubernetes deps.