### PR TITLE
doc(DSR): add /etc/iproute2/rt_tables caveat

### DIFF
--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -91,6 +91,9 @@ spec:
         - name: run
           mountPath: /var/run/docker.sock
           readOnly: true
+        - name: rt_tables
+          mountPath: /etc/iproute2/rt_tables
+          readOnly: false
         - name: xtables-lock
           mountPath: /run/xtables.lock
           readOnly: false
@@ -140,6 +143,9 @@ spec:
       - name: run
         hostPath:
           path: /var/run/docker.sock
+      - name: rt_tables
+        hostPath:
+          path: /etc/iproute2/rt_tables
       - name: kube-router-cfg
         configMap:
           name: kube-router-cfg

--- a/docs/dsr.md
+++ b/docs/dsr.md
@@ -27,6 +27,7 @@ Requirements:
   * `hostIPC: true` must be set for the pod
   * `hostPID: true` must be set for the pod
   * The container runtime socket must be mounted into the kube-router pod via a `hostPath` volume mount.
+  * `/etc/iproute2/rt_tables` must be read/write mounted into the kube-router pod via a `hostPath` volume mount.
 * A pod network that allows for IPIP encapsulated traffic. The most notable exception to this is that Azure does not
   transit IPIP encapsulated packets on their network. In this scenario, the end-user may be able to get around this
   issue by enabling FoU (`--overlay-encap=fou`) and full overlay networking (`--overlay-type=full`) options in
@@ -85,6 +86,9 @@ spec:
       - name: run
         hostPath:
           path: /var/run/docker.sock
+      - name: rt_tables
+        hostPath:
+          path: /etc/iproute2/rt_tables
       ...
       containers:
       - name: kube-router
@@ -94,6 +98,9 @@ spec:
         - name: run
           mountPath: /var/run/docker.sock
           readOnly: true
+        - name: rt_tables
+          mountPath: /etc/iproute2/rt_tables
+          readOnly: false
 ...
 ```
 


### PR DESCRIPTION
Add documentation to improve user DSR experience about mounting `/etc/iproute2/rt_tables` into the container when kube-router runs as a daemonset.

Based upon feedback from #1616 from @s11fsch