### PR TITLE
Fix Cleanup Code for v2.x

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -207,8 +207,23 @@ kube-router --master=http://192.168.1.99:8080/ --run-firewall=true --run-service
 Please delete kube-router daemonset and then clean up all the configurations done (to ipvs, iptables, ipset, ip routes
 etc) by kube-router on the node by running below command.
 
+### Docker
+
 ```sh
-docker run --privileged --net=host cloudnativelabs/kube-router --cleanup-config
+docker run --privileged --net=host \
+--mount type=bind,source=/lib/modules,target=/lib/modules,readonly \
+--mount type=bind,source=/run/xtables.lock,target=/run/xtables.lock,bind-propagation=rshared \
+cloudnativelabs/kube-router /usr/local/bin/kube-router --cleanup-config
+```
+
+### containerd
+
+```sh
+$ ctr image pull docker.io/cloudnativelabs/kube-router:latest
+$ ctr run --privileged -t --net-host \
+--mount type=bind,src=/lib/modules,dst=/lib/modules,options=rbind:ro \
+--mount type=bind,src=/run/xtables.lock,dst=/run/xtables.lock,options=rbind:rw \
+docker.io/cloudnativelabs/kube-router:latest kube-router-cleanup /usr/local/bin/kube-router --cleanup-config
 ```
 
 ## trying kube-router as alternative to kube-proxy

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -712,6 +712,26 @@ func (npc *NetworkPolicyController) cleanupStaleIPSets(activePolicyIPSets map[st
 func (npc *NetworkPolicyController) Cleanup() {
 	klog.Info("Cleaning up NetworkPolicyController configurations...")
 
+	if len(npc.iptablesCmdHandlers) < 1 {
+		iptablesCmdHandlers, ipSetHandlers, err := NewIPTablesHandlers(nil)
+		if err != nil {
+			klog.Errorf("unable to get iptables and ipset handlers: %v", err)
+			return
+		}
+		npc.iptablesCmdHandlers = iptablesCmdHandlers
+		npc.ipSetHandlers = ipSetHandlers
+
+		// Make other structures that we rely on
+		npc.iptablesSaveRestore = make(map[v1core.IPFamily]utils.IPTablesSaveRestorer, 2)
+		npc.iptablesSaveRestore[v1core.IPv4Protocol] = utils.NewIPTablesSaveRestore(v1core.IPv4Protocol)
+		npc.iptablesSaveRestore[v1core.IPv6Protocol] = utils.NewIPTablesSaveRestore(v1core.IPv6Protocol)
+		npc.filterTableRules = make(map[v1core.IPFamily]*bytes.Buffer, 2)
+		var buf bytes.Buffer
+		npc.filterTableRules[v1core.IPv4Protocol] = &buf
+		var buf2 bytes.Buffer
+		npc.filterTableRules[v1core.IPv6Protocol] = &buf2
+	}
+
 	var emptySet map[string]bool
 	// Take a dump (iptables-save) of the current filter table for cleanupStaleRules() to work on
 	for ipFamily, iptablesSaveRestore := range npc.iptablesSaveRestore {
@@ -751,7 +771,7 @@ func NewIPTablesHandlers(config *options.KubeRouterConfig) (
 	iptablesCmdHandlers := make(map[v1core.IPFamily]utils.IPTablesHandler, 2)
 	ipSetHandlers := make(map[v1core.IPFamily]utils.IPSetHandler, 2)
 
-	if config.EnableIPv4 {
+	if config == nil || config.EnableIPv4 {
 		iptHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv4)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create iptables handler: %w", err)
@@ -764,7 +784,7 @@ func NewIPTablesHandlers(config *options.KubeRouterConfig) (
 		}
 		ipSetHandlers[v1core.IPv4Protocol] = ipset
 	}
-	if config.EnableIPv6 {
+	if config == nil || config.EnableIPv6 {
 		iptHandler, err := iptables.NewWithProtocol(iptables.ProtocolIPv6)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create iptables handler: %w", err)

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -754,6 +755,7 @@ func (ips *fakeIPSet) Name(name string) string {
 }
 
 func TestNetworkPolicyController(t *testing.T) {
+	curHostname, _ := os.Hostname()
 	testCases := []tNetPolConfigTestCase{
 		{
 			"Default options are successful",
@@ -765,7 +767,8 @@ func TestNetworkPolicyController(t *testing.T) {
 			"Missing nodename fails appropriately",
 			newMinimalKubeRouterConfig([]string{""}, "", "", nil, nil, false),
 			true,
-			"failed to identify the node by NODE_NAME, hostname or --hostname-override",
+			fmt.Sprintf("failed to identify the node by NODE_NAME, %s or --hostname-override: nodes \"%s\""+
+				" not found", curHostname, curHostname),
 		},
 		{
 			"Test bad cluster CIDR (not properly formatting ip address)",

--- a/pkg/controllers/proxy/hairpin_controller.go
+++ b/pkg/controllers/proxy/hairpin_controller.go
@@ -75,15 +75,14 @@ func (hpc *hairpinController) ensureHairpinEnabledForPodInterface(endpointIP str
 		// WARN: This method is deprecated and will be removed once docker-shim is removed from kubelet.
 		pid, err = hpc.nsc.ln.getContainerPidWithDocker(containerID)
 		if err != nil {
-			return fmt.Errorf("failed to prepare endpoint %s to do direct server return due to %v",
-				endpointIP, err)
+			return fmt.Errorf("failed to get pod's (%s) pid for hairpinning due to %v", endpointIP, err)
 		}
 	} else {
 		// We expect CRI compliant runtimes here
 		// ugly workaround, refactoring of pkg/Proxy is required
 		pid, err = hpc.nsc.ln.getContainerPidWithCRI(hpc.nsc.dsr.runtimeEndpoint, containerID)
 		if err != nil {
-			return fmt.Errorf("failed to prepare endpoint %s to do DSR due to: %v", endpointIP, err)
+			return fmt.Errorf("failed to get pod's (%s) pid for hairpinning due to %v", endpointIP, err)
 		}
 	}
 	klog.V(2).Infof("Found PID %d for endpoint IP %s", pid, endpointIP)

--- a/pkg/utils/node_test.go
+++ b/pkg/utils/node_test.go
@@ -38,7 +38,7 @@ func Test_GetNodeObject(t *testing.T) {
 			nil,
 		},
 		{
-			"node with hostname overrie exists",
+			"node with hostname override exists",
 			"something-else",
 			"test-node",
 			&apiv1.Node{
@@ -50,8 +50,8 @@ func Test_GetNodeObject(t *testing.T) {
 		},
 		{
 			"node with current hostname exists",
-			"something-else",
-			"something-else",
+			"",
+			"",
 			&apiv1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: curHostname,
@@ -68,7 +68,7 @@ func Test_GetNodeObject(t *testing.T) {
 					Name: "another-node",
 				},
 			},
-			errors.New("failed to identify the node by NODE_NAME, hostname or --hostname-override"),
+			errors.New("unable to get node test-node, due to: nodes \"test-node\" not found"),
 		},
 	}
 


### PR DESCRIPTION
kube-router v2.X introduced the idea of iptables and ipset handlers that allow kube-router to be dual-stack capable. However, the cleanup logic for the various controllers was not properly ported when this happened. When the cleanup functions run, they often have not had their controllers fully initialized as cleanup should not be dependant on kube-router being able to reach a kube-apiserver.

As such, they were missing these handlers. And as such they either silently ended up doing noops or worse, they would run into nil pointer failures.

This corrects that, so that kube-router no longer fails this way and cleans up as it had in v1.X.

@vladimirtiukhtin - I tested this in my environment and found it worked correctly, but if you wouldn't mind checking as well, that would be helpful to ensure that there isn't something I'm missing. There should be a kube-router docker container that is built as part of this PR that you can find in the GitHub actions section if you don't want to build kube-router yourself.

Fixes: #1649 