### PR TITLE
fix(DSR): setup DSR inside pod on local eps only

### DIFF
--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -564,9 +564,13 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svc *serviceI
 				endpoint.ip, externalIP, err)
 		}
 
-		// add the external IP to a virtual interface inside the pod so that the pod can receive it
-		if err = nsc.addDSRIPInsidePodNetNamespace(externalIP.String(), endpoint.ip); err != nil {
-			return fmt.Errorf("unable to setup DSR receiver inside pod: %v", err)
+		// It's only for local endpoints that we can enter the container's namespace and add DSR receivers inside it.
+		// If we aren't local, then we should skip this step so that we don't accidentally throw an error.
+		if endpoint.isLocal {
+			// add the external IP to a virtual interface inside the pod so that the pod can receive it
+			if err = nsc.addDSRIPInsidePodNetNamespace(externalIP.String(), endpoint.ip); err != nil {
+				return fmt.Errorf("unable to setup DSR receiver inside pod: %v", err)
+			}
 		}
 
 		svcEndpointMap[externalIPServiceID] = append(svcEndpointMap[externalIPServiceID],

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -476,7 +476,7 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svc *serviceI
 
 	dummyVipInterface, err := nsc.ln.getKubeDummyInterface()
 	if err != nil {
-		return errors.New("Failed creating dummy interface: " + err.Error())
+		return errors.New("Failed getting dummy interface: " + err.Error())
 	}
 
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()


### PR DESCRIPTION
Only attempt to setup DSR inside containers for local endpoints. Setting up DSR inside the containers network namespace requires local pods / endpoints.

Fixes #1640 

@opipenbe - I tested this locally with my smaller development cluster and it appeared to work correctly, however, I would be very appreciative if you would test this in your cluster as well. A container should be built as part of the GitHub Actions CI on this PR, you can look in the CI log for a link to [kube-router-git](https://hub.docker.com/r/cloudnativelabs/kube-router-git/tags) for the newly built kube-router.

One thing that I still don't quite have an answer for though, is why this didn't also have this same error for you under kube-router v1.6.0 as the code path was essentially the same: https://github.com/cloudnativelabs/kube-router/blob/v1.6/pkg/controllers/proxy/service_endpoints_sync.go#L444-L447

Maybe something further up in the calling tree filtered it out?

Anyway, since to me, this seems like it is changing DSR logic that has existed for a long time, I'd appreciate the second test to ensure that it not only removes the error, but also still allows you to route to your service correctly.