### PR TITLE
Fix DSR Boundary Conditions

### DIFF
--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -96,11 +96,11 @@ func (ln *linuxNetworking) ipAddrDel(iface netlink.Link, ip string, nodeIP strin
 	if err != nil {
 		if err.Error() != IfaceHasNoAddr {
 			klog.Errorf("Failed to verify is external ip %s is assocated with dummy interface %s due to %s",
-				ip, KubeDummyIf, err.Error())
+				ip, iface.Attrs().Name, err.Error())
 			return err
 		} else {
-			klog.Warningf("got an IfaceHasNoAddr error while trying to delete address from netlink: %v (this is not "+
-				"normally bad enough to stop processing)", err)
+			klog.Warningf("got an IfaceHasNoAddr error while trying to delete address %s from netlink %s: %v (this "+
+				"is not normally bad enough to stop processing)", ip, iface.Attrs().Name, err)
 		}
 	}
 

--- a/pkg/controllers/proxy/network_service_graceful.go
+++ b/pkg/controllers/proxy/network_service_graceful.go
@@ -72,7 +72,7 @@ func (nsc *NetworkServicesController) addToGracefulQueue(req *gracefulRequest) {
 	}
 	if !alreadyExists {
 		// try to get get Termination grace period from the pod, if unsuccesfull use the default timeout
-		podObj, err := nsc.getPodObjectForEndpoint(req.ipvsDst.Address.String())
+		podObj, err := nsc.getPodObjectForEndpointIP(req.ipvsDst.Address.String())
 		if err != nil {
 			klog.V(1).Infof("Failed to find endpoint with ip: %s err: %s",
 				req.ipvsDst.Address.String(), err.Error())

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -893,18 +893,6 @@ func hasActiveEndpoints(endpoints []endpointSliceInfo) bool {
 	return false
 }
 
-func (nsc *NetworkServicesController) getPodObjectForEndpoint(endpointIP string) (*v1.Pod, error) {
-	for _, obj := range nsc.podLister.List() {
-		pod := obj.(*v1.Pod)
-		for _, ip := range pod.Status.PodIPs {
-			if strings.Compare(ip.IP, endpointIP) == 0 {
-				return pod, nil
-			}
-		}
-	}
-	return nil, errors.New("Failed to find pod with ip " + endpointIP)
-}
-
 func (nsc *NetworkServicesController) buildServicesInfo() serviceInfoMap {
 	serviceMap := make(serviceInfoMap)
 	for _, obj := range nsc.svcLister.List() {


### PR DESCRIPTION
Don't attempt to setup DSR for pods where `hostNetwork: true` is set.

DSR doesn't work for hostNetwork'd pods and will only end up causing bizarre problems when kube-router attempts to make it happen anyway. Now, we emit an error early and don't attempt to let it go any further before breaking.