### PR TITLE
Remove Hairpin Controller

### DIFF
--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -17,6 +17,7 @@ data:
              "type":"bridge",
              "bridge":"kube-bridge",
              "isDefaultGateway":true,
+             "hairpinMode":true,
              "ipam":{
                 "type":"host-local"
              }

--- a/pkg/controllers/proxy/hairpin_controller.go
+++ b/pkg/controllers/proxy/hairpin_controller.go
@@ -15,6 +15,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// !!!! IMPORTANT !!!! - This code is not currently used
+// Not creating the hairpin controller for now because this should be handled at the CNI level. The CNI bridge
+// plugin ensures that hairpin mode is set much more reliably than we do. However, as a lot of work was put into
+// the hairpin controller, and so that it is around to reference in the future if needed, I'm leaving the code
+// for now.
+
 type hairpinController struct {
 	epC <-chan string
 	nsc *NetworkServicesController

--- a/pkg/healthcheck/health_controller.go
+++ b/pkg/healthcheck/health_controller.go
@@ -166,11 +166,11 @@ func (hc *HealthController) CheckHealth() bool {
 			klog.Error("NetworkService Controller heartbeat missed")
 			health = false
 		}
-		if time.Since(hc.Status.HairpinControllerAlive) >
-			HPCSyncPeriod+hc.Status.HairpinControllerAliveTTL+graceTime {
-			klog.Error("Hairpin Controller heartbeat missed")
-			health = false
-		}
+		// if time.Since(hc.Status.HairpinControllerAlive) >
+		// 	HPCSyncPeriod+hc.Status.HairpinControllerAliveTTL+graceTime {
+		//	klog.Error("Hairpin Controller heartbeat missed")
+		//	health = false
+		// }
 	}
 
 	if hc.Config.MetricsEnabled {


### PR DESCRIPTION
After taking another look at it, I realized that the hairpin controller that I had originally created to ensure that hairpin mode was enabled on the pod's network namespace link was entirely superfluous. Instead, user's should be using the little known `hairpinMode` of the bridge CNI plugin for kube-router.

This plugin is already in the pod's network namespace when it needs to run and is much more reliable than the controller that I created.

For now I'm leaving the code, but just removing references to it so that I can bring it back in the future if I decide that its helpful. However, it had quite a few problems with it, as mentioned in #1630.

I've also updated the dsr reference daemonset to include this mode, as I'm not sure why this was left out in the first place. The docs in the user-guide mention this CNI option quite a bit already, so it was already well documented there.