### PR TITLE
Fix ipset Duplication Across Handlers

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -226,6 +226,22 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 	npc.mu.Lock()
 	defer npc.mu.Unlock()
 
+	for ipFamily := range npc.ipSetHandlers {
+		// Ensure that we start with clean handlers that don't contain previous save data
+		var err error
+		//nolint:exhaustive // we don't need a default condition here because we control this ourselves
+		switch ipFamily {
+		case v1core.IPv4Protocol:
+			npc.ipSetHandlers[ipFamily], err = utils.NewIPSet(false)
+		case v1core.IPv6Protocol:
+			npc.ipSetHandlers[ipFamily], err = utils.NewIPSet(true)
+		}
+		if err != nil {
+			klog.Errorf("failed to create ipset handler: %v", err)
+			return
+		}
+	}
+
 	healthcheck.SendHeartBeat(npc.healthChan, "NPC")
 	start := time.Now()
 	syncVersion := strconv.FormatInt(start.UnixNano(), syncVersionBase)

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -684,28 +684,16 @@ func (npc *NetworkPolicyController) cleanupStaleIPSets(activePolicyIPSets map[st
 		}()
 	}
 
-	for ipFamily, ipsets := range npc.ipSetHandlers {
+	for _, ipsets := range npc.ipSetHandlers {
 		cleanupPolicyIPSets := make([]*utils.Set, 0)
-
 		if err := ipsets.Save(); err != nil {
 			klog.Fatalf("failed to initialize ipsets command executor due to %s", err.Error())
 		}
-		if ipFamily == v1core.IPv6Protocol {
-			for _, set := range ipsets.Sets() {
-				if strings.HasPrefix(set.Name, fmt.Sprintf("%s:%s", utils.FamillyInet6, kubeSourceIPSetPrefix)) ||
-					strings.HasPrefix(set.Name, fmt.Sprintf("%s:%s", utils.FamillyInet6, kubeDestinationIPSetPrefix)) {
-					if _, ok := activePolicyIPSets[set.Name]; !ok {
-						cleanupPolicyIPSets = append(cleanupPolicyIPSets, set)
-					}
-				}
-			}
-		} else {
-			for _, set := range ipsets.Sets() {
-				if strings.HasPrefix(set.Name, kubeSourceIPSetPrefix) ||
-					strings.HasPrefix(set.Name, kubeDestinationIPSetPrefix) {
-					if _, ok := activePolicyIPSets[set.Name]; !ok {
-						cleanupPolicyIPSets = append(cleanupPolicyIPSets, set)
-					}
+		for _, set := range ipsets.Sets() {
+			if set.HasPrefix(kubeSourceIPSetPrefix) ||
+				set.HasPrefix(kubeDestinationIPSetPrefix) {
+				if _, ok := activePolicyIPSets[set.Name]; !ok {
+					cleanupPolicyIPSets = append(cleanupPolicyIPSets, set)
 				}
 			}
 		}

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -439,6 +439,11 @@ func (ipset *IPSet) Name(setName string) string {
 	return IPSetName(setName, ipset.isIpv6)
 }
 
+func (set *Set) HasPrefix(prefix string) bool {
+	fullPrefix := IPSetName(prefix, set.Parent.isIpv6)
+	return strings.HasPrefix(set.name(), fullPrefix)
+}
+
 func (set *Set) name() string {
 	return set.Parent.Name(set.Name)
 }

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -566,7 +566,7 @@ func (ipset *IPSet) Save() error {
 // Send formatted ipset.sets into stdin of "ipset restore" command.
 func (ipset *IPSet) Restore() error {
 	restoreString := buildIPSetRestore(ipset)
-	klog.V(3).Infof("ipset restore looks like: %s", restoreString)
+	klog.V(3).Infof("ipset (ipv6? %t) restore looks like:\n%s", ipset.isIpv6, restoreString)
 	stdin := bytes.NewBufferString(restoreString)
 	err := ipset.runWithStdin(stdin, "restore", "-exist")
 	if err != nil {


### PR DESCRIPTION
@mrueg / @manuelbuil

Attempts to separate IP families within the different ipset handlers. This has likely been an issue since the first dual-stack implementation was contributed, but hasn't been discovered until now. The problem was that ipset was being utilized the same way that iptables was where different handlers implicitly meant different families. However, the ipset command doesn't differentiate that way, it has one command that always contains both sets. This was likely missed during the port to dual stack that was contributed ~2 years ago.

Fixes #1665 