### PR TITLE
fix(nsc): TCPMSS rules are created per tcp service

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1631,7 +1631,7 @@ func (nsc *NetworkServicesController) setupMangleTableRule(ip string, protocol s
 	// setup iptables rule TCPMSS for DSR mode to fix mtu problem
 	// only reply packets from PODs are altered here
 	if protocol == tcpProtocol {
-		mtuArgs := []string{"-s", ip, "-m", tcpProtocol, "-p", tcpProtocol, "--sport", port,
+		mtuArgs := []string{"-s", ip, "-m", tcpProtocol, "-p", tcpProtocol, "--sport", port, "-i", "kube-bridge",
 			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(tcpMSS)}
 		err = iptablesCmdHandler.AppendUnique("mangle", "PREROUTING", mtuArgs...)
 		if err != nil {
@@ -1679,7 +1679,7 @@ func (nsc *NetworkServicesController) cleanupMangleTableRule(ip string, protocol
 	// cleanup iptables rule TCPMSS
 	// only reply packets from PODs are altered here
 	if protocol == tcpProtocol {
-		mtuArgs := []string{"-s", ip, "-m", tcpProtocol, "-p", tcpProtocol, "--sport", port,
+		mtuArgs := []string{"-s", ip, "-m", tcpProtocol, "-p", tcpProtocol, "--sport", port, "-i", "kube-bridge",
 			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(tcpMSS)}
 		exists, err = iptablesCmdHandler.Exists("mangle", "PREROUTING", mtuArgs...)
 		if err != nil {

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1694,6 +1694,26 @@ func (nsc *NetworkServicesController) cleanupMangleTableRule(ip string, protocol
 		}
 	}
 
+	// Previous versions of MTU args were this way, we will clean then up for the next couple of versions to ensure
+	// that old mangle table rules don't stick around
+	// TODO: remove after v2.4.X or above
+	for firstArg, chain := range map[string]string{"-s": "POSTROUTING", "-d": "PREROUTING"} {
+		prevMTUArgs := []string{firstArg, ip, "-m", tcpProtocol, "-p", tcpProtocol, "--tcp-flags", "SYN,RST", "SYN",
+			"-j", "TCPMSS", "--set-mss", strconv.Itoa(tcpMSS)}
+		klog.V(2).Infof("looking for mangle rule with: %s -t mangle %s", chain, prevMTUArgs)
+		exists, err = iptablesCmdHandler.Exists("mangle", chain, prevMTUArgs...)
+		if err != nil {
+			return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %v", err)
+		}
+		if exists {
+			klog.V(2).Infof("removing mangle rule with: iptables -D %s -t mangle %s", chain, prevMTUArgs)
+			err = iptablesCmdHandler.Delete("mangle", chain, prevMTUArgs...)
+			if err != nil {
+				return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %v", err)
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This allows VIPs to be shared between services.

Fixes #1671