### PR TITLE
feat(alpine): revert 3.19 -> 3.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,10 @@ on:
     - prep-v[1-9].*
 
 env:
-  # Upgrading to Go 1.21.{0,1,2} seems to in cause some sort of race condition that causes tests to fail sporadically.
-  # Sometimes they fail in apparent race conditions, other times they end up with nil pointer and SIGSEGV errors. We'll
-  # either need to try with a future bug fix release or do some in-depth debugging before we upgrade.
-  BUILDTIME_BASE: "golang:1.21.7-alpine3.19"
-  RUNTIME_BASE: "alpine:3.19"
+  BUILDTIME_BASE: "golang:1.21.7-alpine3.18"
+  # Do not bump past Alpine 3.18 until upstream netfilter problems in iptables v1.8.10 are resolved. See:
+  # https://github.com/cloudnativelabs/kube-router/issues/1676
+  RUNTIME_BASE: "alpine:3.18"
   GO_VERSION: "~1.21.7"
   GO_CACHE: "/home/runner/.cache/go-build"
   GO_MOD_CACHE: "/home/runner/go/pkg/mod"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ FROM ${RUNTIME_BASE}
 
 RUN apk add --no-cache \
       iptables \
-      iptables-legacy \
       ipset \
       iproute2 \
       ipvsadm \

--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,15 @@ DOCKER=$(if $(or $(IN_DOCKER_GROUP),$(IS_ROOT),$(OSX)),docker,sudo docker)
 MAKEFILE_DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 UPSTREAM_IMPORT_PATH=$(GOPATH)/src/github.com/cloudnativelabs/kube-router/
 BUILD_IN_DOCKER?=true
-DOCKER_BUILD_IMAGE?=golang:1.21.7-alpine3.19
+DOCKER_BUILD_IMAGE?=golang:1.21.7-alpine3.18
 ## These variables are used by the Dockerfile as the bases for building and creating the runtime container
 ## During CI these come from .github/workflows/ci.yaml below we define for local builds as well
 GO_CACHE?=$(shell go env GOCACHE)
 GO_MOD_CACHE?=$(shell go env GOMODCACHE)
 BUILDTIME_BASE?=$(DOCKER_BUILD_IMAGE)
-RUNTIME_BASE?=alpine:3.19
+# Do not bump past Alpine 3.18 until upstream netfilter problems in iptables v1.8.10 are resolved. See:
+# https://github.com/cloudnativelabs/kube-router/issues/1676
+RUNTIME_BASE?=alpine:3.18
 DOCKER_LINT_IMAGE?=golangci/golangci-lint:v1.56.2
 DOCKER_MARKDOWNLINT_IMAGE?=tmknom/markdownlint:0.39.0
 GOBGP_VERSION=v3.23.0


### PR DESCRIPTION
@mrueg 

Revert because of issue with iptables v1.8.10 no longer working with -C check.

Still testing this in a local cluster to make sure that the problem doesn't re-occur. Long term, this needs to be chased down with upstream netfilter, but for now this should at least help us get to a stable version of kube-router on the v2.x release line.

Fixes: #1676 