### PR TITLE
fix(utils.go): static /32 subnet mask reference

### DIFF
--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -454,7 +454,7 @@ func hairpinRuleFrom(serviceIPs []net.IP, endpointIP string, endpointFamily v1.I
 	}
 
 	for _, svcIP := range serviceIPs {
-		ruleArgs := []string{"-s", endpointIP + "/32", "-d", endpointIP + vipSubnet,
+		ruleArgs := []string{"-s", endpointIP + vipSubnet, "-d", endpointIP + vipSubnet,
 			"-m", "ipvs", "--vaddr", svcIP.String(), "--vport", strconv.Itoa(servicePort),
 			"-j", "SNAT", "--to-source", svcIP.String()}
 


### PR DESCRIPTION
Fix an instance of static subnet referencing which causes issues with IPv6 use-cases for hairpin rules.