### PR TITLE
feat: convert execs to ip to netlink calls

### DIFF
--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path"
 	"strconv"
 	"strings"
@@ -24,8 +23,10 @@ import (
 )
 
 const (
-	ipv4NetMaskBits = 32
-	ipv6NetMaskBits = 128
+	ipv4NetMaskBits  = 32
+	ipv4DefaultRoute = "0.0.0.0/0"
+	ipv6NetMaskBits  = 128
+	ipv6DefaultRoute = "::/0"
 
 	// TODO: it's bad to rely on eth0 here. While this is inside the container's namespace and is determined by the
 	// container runtime and so far we've been able to count on this being reliably set to eth0, it is possible that
@@ -67,7 +68,6 @@ type netlinkCalls interface {
 
 func (ln *linuxNetworking) ipAddrDel(iface netlink.Link, ip string, nodeIP string) error {
 	var netMask net.IPMask
-	var ipRouteCmdArgs []string
 	parsedIP := net.ParseIP(ip)
 	parsedNodeIP := net.ParseIP(nodeIP)
 	if parsedIP.To4() != nil {
@@ -77,7 +77,6 @@ func (ln *linuxNetworking) ipAddrDel(iface netlink.Link, ip string, nodeIP strin
 		}
 
 		netMask = net.CIDRMask(ipv4NetMaskBits, ipv4NetMaskBits)
-		ipRouteCmdArgs = make([]string, 0)
 	} else {
 		// If the IP family of the NodeIP and the VIP IP don't match, we can't proceed
 		if parsedNodeIP.To4() != nil {
@@ -90,7 +89,6 @@ func (ln *linuxNetworking) ipAddrDel(iface netlink.Link, ip string, nodeIP strin
 		}
 
 		netMask = net.CIDRMask(ipv6NetMaskBits, ipv6NetMaskBits)
-		ipRouteCmdArgs = []string{"-6"}
 	}
 
 	naddr := &netlink.Addr{IPNet: &net.IPNet{IP: parsedIP, Mask: netMask}, Scope: syscall.RT_SCOPE_LINK}
@@ -108,13 +106,20 @@ func (ln *linuxNetworking) ipAddrDel(iface netlink.Link, ip string, nodeIP strin
 
 	// Delete VIP addition to "local" rt table also, fail silently if not found (DSR special case)
 	// #nosec G204
-	ipRouteCmdArgs = append(ipRouteCmdArgs, "route", "delete", "local", ip, "dev", KubeDummyIf,
-		"table", "local", "proto", "kernel", "scope", "host", "src", nodeIP, "table", "local")
-	out, err := exec.Command("ip", ipRouteCmdArgs...).CombinedOutput()
+	nRoute := &netlink.Route{
+		Type:      unix.RTN_LOCAL,
+		Dst:       &net.IPNet{IP: parsedIP, Mask: netMask},
+		LinkIndex: iface.Attrs().Index,
+		Table:     syscall.RT_TABLE_LOCAL,
+		Protocol:  unix.RTPROT_KERNEL,
+		Scope:     syscall.RT_SCOPE_HOST,
+		Src:       parsedNodeIP,
+	}
+	err = netlink.RouteDel(nRoute)
 	if err != nil {
-		if !strings.Contains(string(out), "No such process") {
-			klog.Errorf("Failed to delete route to service VIP %s configured on %s. Error: %v, Output: %s",
-				ip, KubeDummyIf, err, out)
+		if !strings.Contains(err.Error(), "no such process") {
+			klog.Errorf("Failed to delete route to service VIP %s configured on %s. Error: %v",
+				ip, iface.Attrs().Name, err)
 		} else {
 			klog.Warningf("got a No such process error while trying to remove route: %v (this is not normally bad "+
 				"enough to stop processing)", err)
@@ -130,7 +135,6 @@ func (ln *linuxNetworking) ipAddrDel(iface netlink.Link, ip string, nodeIP strin
 // inside the container.
 func (ln *linuxNetworking) ipAddrAdd(iface netlink.Link, ip string, nodeIP string, addRoute bool) error {
 	var netMask net.IPMask
-	var ipRouteCmdArgs []string
 	var isIPv6 bool
 	parsedIP := net.ParseIP(ip)
 	parsedNodeIP := net.ParseIP(nodeIP)
@@ -141,7 +145,6 @@ func (ln *linuxNetworking) ipAddrAdd(iface netlink.Link, ip string, nodeIP strin
 		}
 
 		netMask = net.CIDRMask(ipv4NetMaskBits, ipv4NetMaskBits)
-		ipRouteCmdArgs = make([]string, 0)
 		isIPv6 = false
 	} else {
 		// If we're supposed to add a route and the IP family of the NodeIP and the VIP IP don't match, we can't proceed
@@ -150,11 +153,11 @@ func (ln *linuxNetworking) ipAddrAdd(iface netlink.Link, ip string, nodeIP strin
 		}
 
 		netMask = net.CIDRMask(ipv6NetMaskBits, ipv6NetMaskBits)
-		ipRouteCmdArgs = []string{"-6"}
 		isIPv6 = true
 	}
 
-	naddr := &netlink.Addr{IPNet: &net.IPNet{IP: parsedIP, Mask: netMask}, Scope: syscall.RT_SCOPE_LINK}
+	ipPrefix := &net.IPNet{IP: parsedIP, Mask: netMask}
+	naddr := &netlink.Addr{IPNet: ipPrefix, Scope: syscall.RT_SCOPE_LINK}
 	err := netlink.AddrAdd(iface, naddr)
 	if err != nil && err.Error() != IfaceHasAddr {
 		klog.Errorf("failed to assign cluster ip %s to dummy interface: %s", naddr.IP.String(), err.Error())
@@ -169,16 +172,24 @@ func (ln *linuxNetworking) ipAddrAdd(iface netlink.Link, ip string, nodeIP strin
 		return nil
 	}
 
-	// TODO: netlink.RouteReplace which is replacement for below command is not working as expected. Call succeeds but
-	// route is not replaced. For now do it with command.
-	// #nosec G204
-	ipRouteCmdArgs = append(ipRouteCmdArgs, "route", "replace", "local", ip, "dev", KubeDummyIf,
-		"table", "local", "proto", "kernel", "scope", "host", "src", nodeIP, "table", "local")
-
-	out, err := exec.Command("ip", ipRouteCmdArgs...).CombinedOutput()
+	kubeDummyLink, err := netlink.LinkByName(KubeDummyIf)
 	if err != nil {
-		klog.Errorf("Failed to replace route to service VIP %s configured on %s. Error: %v, Output: %s",
-			ip, KubeDummyIf, err, out)
+		klog.Errorf("failed to get %s link due to %v", KubeDummyIf, err)
+		return err
+	}
+	nRoute := &netlink.Route{
+		Type:      unix.RTN_LOCAL,
+		Dst:       ipPrefix,
+		LinkIndex: kubeDummyLink.Attrs().Index,
+		Table:     syscall.RT_TABLE_LOCAL,
+		Protocol:  unix.RTPROT_KERNEL,
+		Scope:     syscall.RT_SCOPE_HOST,
+		Src:       parsedNodeIP,
+	}
+	err = netlink.RouteReplace(nRoute)
+	if err != nil {
+		klog.Errorf("Failed to replace route to service VIP %s configured on %s. Error: %v",
+			ip, KubeDummyIf, err)
 		return err
 	}
 
@@ -482,24 +493,55 @@ func (ln *linuxNetworking) setupPolicyRoutingForDSR(setupIPv4, setupIPv6 bool) e
 		return fmt.Errorf("failed to setup policy routing required for DSR due to %v", err)
 	}
 
+	loNetLink, err := netlink.LinkByName("lo")
+	if err != nil {
+		return fmt.Errorf("failed to get loopback interface due to %v", err)
+	}
+
 	if setupIPv4 {
-		out, err := exec.Command("ip", "route", "list", "table", customDSRRouteTableID).Output()
-		if err != nil || !strings.Contains(string(out), " lo ") {
-			if err = exec.Command("ip", "route", "add", "local", "default", "dev", "lo", "table",
-				customDSRRouteTableID).Run(); err != nil {
-				return fmt.Errorf("failed to add route in custom route table due to: %v", err)
+		nFamily := netlink.FAMILY_V4
+		_, defaultRouteCIDR, err := net.ParseCIDR(ipv4DefaultRoute)
+		if err != nil {
+			return fmt.Errorf("failed to parse default (%s) route (this is statically defined, so if you see this "+
+				"error please report because something has gone very wrong) due to: %v", ipv4DefaultRoute, err)
+		}
+		nRoute := &netlink.Route{
+			Type:      unix.RTN_LOCAL,
+			Dst:       defaultRouteCIDR,
+			LinkIndex: loNetLink.Attrs().Index,
+			Table:     customDSRRouteTableID,
+		}
+		routes, err := netlink.RouteListFiltered(nFamily, nRoute, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF)
+		if err != nil || len(routes) < 1 {
+			err = netlink.RouteAdd(nRoute)
+			if err != nil {
+				return fmt.Errorf("failed to add route to custom route table for DSR due to: %v", err)
 			}
 		}
 	}
+
 	if setupIPv6 {
-		out, err := exec.Command("ip", "-6", "route", "list", "table", customDSRRouteTableID).Output()
-		if err != nil || !strings.Contains(string(out), " lo ") {
-			if err = exec.Command("ip", "-6", "route", "add", "local", "default", "dev", "lo", "table",
-				customDSRRouteTableID).Run(); err != nil {
-				return fmt.Errorf("failed to add route in custom route table due to: %v", err)
+		nFamily := netlink.FAMILY_V6
+		_, defaultRouteCIDR, err := net.ParseCIDR(ipv6DefaultRoute)
+		if err != nil {
+			return fmt.Errorf("failed to parse default (%s) route (this is statically defined, so if you see this "+
+				"error please report because something has gone very wrong) due to: %v", ipv6DefaultRoute, err)
+		}
+		nRoute := &netlink.Route{
+			Type:      unix.RTN_LOCAL,
+			Dst:       defaultRouteCIDR,
+			LinkIndex: loNetLink.Attrs().Index,
+			Table:     customDSRRouteTableID,
+		}
+		routes, err := netlink.RouteListFiltered(nFamily, nRoute, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF)
+		if err != nil || len(routes) < 1 {
+			err = netlink.RouteAdd(nRoute)
+			if err != nil {
+				return fmt.Errorf("failed to add route to custom route table for DSR due to: %v", err)
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -507,7 +549,6 @@ func (ln *linuxNetworking) setupPolicyRoutingForDSR(setupIPv4, setupIPv6 bool) e
 // directly responds back with source IP as external IP kernel will treat as martian packet.
 // To prevent martian packets add route to external IP through the `kube-bridge` interface
 // setupRoutesForExternalIPForDSR: setups routing so that kernel does not think return packets as martians
-
 func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap serviceInfoMap,
 	setupIPv4, setupIPv6 bool) error {
 	err := utils.RouteTableAdd(externalIPRouteTableID, externalIPRouteTableName)
@@ -515,27 +556,45 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 		return fmt.Errorf("failed to setup policy routing required for DSR due to %v", err)
 	}
 
-	setupIPRulesAndRoutes := func(ipArgs []string) error {
-		out, err := runIPCommandsWithArgs(ipArgs, "rule", "list").Output()
+	setupIPRulesAndRoutes := func(isIPv6 bool) error {
+		nFamily := netlink.FAMILY_V4
+		_, defaultPrefixCIDR, err := net.ParseCIDR(ipv4DefaultRoute)
+		if isIPv6 {
+			nFamily = netlink.FAMILY_V6
+			_, defaultPrefixCIDR, err = net.ParseCIDR(ipv6DefaultRoute)
+		}
 		if err != nil {
-			return fmt.Errorf("failed to verify if `ip rule add prio 32765 from all lookup external_ip` exists due to: %v",
-				err)
+			return fmt.Errorf("failed to parse default route (this is statically defined, so if you see this "+
+				"error please report because something has gone very wrong) due to: %v", err)
 		}
 
-		if !strings.Contains(string(out), externalIPRouteTableName) &&
-			!strings.Contains(string(out), externalIPRouteTableID) {
-			err = runIPCommandsWithArgs(ipArgs, "rule", "add", "prio", "32765", "from", "all", "lookup",
-				externalIPRouteTableID).Run()
+		nRule := &netlink.Rule{
+			Priority: defaultDSRPolicyRulePriority,
+			Src:      defaultPrefixCIDR,
+			Table:    externalIPRouteTableID,
+		}
+		rules, err := netlink.RuleListFiltered(nFamily, nRule,
+			netlink.RT_FILTER_TABLE|netlink.RT_FILTER_SRC|netlink.RT_FILTER_PRIORITY)
+		if err != nil {
+			return fmt.Errorf("failed to list rule for external IP's and verify if `ip rule add prio 32765 from all "+
+				"lookup external_ip` exists due to: %v", err)
+		}
+
+		if len(rules) < 1 {
+			err = netlink.RuleAdd(nRule)
 			if err != nil {
 				klog.Infof("Failed to add policy rule `ip rule add prio 32765 from all lookup external_ip` due to %v",
-					err.Error())
+					err)
 				return fmt.Errorf("failed to add policy rule `ip rule add prio 32765 from all lookup external_ip` "+
 					"due to %v", err)
 			}
 		}
 
-		out, _ = runIPCommandsWithArgs(ipArgs, "route", "list", "table", externalIPRouteTableID).Output()
-		outStr := string(out)
+		kubeBridgeLink, err := netlink.LinkByName(KubeBridgeIf)
+		if err != nil {
+			return fmt.Errorf("failed to get kube-bridge interface due to %v", err)
+		}
+
 		activeExternalIPs := make(map[string]bool)
 		for _, svc := range serviceInfoMap {
 			for _, externalIP := range svc.externalIPs {
@@ -548,9 +607,21 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 
 				activeExternalIPs[externalIP] = true
 
-				if !strings.Contains(outStr, externalIP) {
-					if err = runIPCommandsWithArgs(ipArgs, "route", "add", externalIP, "dev", "kube-bridge", "table",
-						externalIPRouteTableID).Run(); err != nil {
+				nDstIP := net.ParseIP(externalIP)
+				nRoute := &netlink.Route{
+					Dst:       utils.GetSingleIPNet(nDstIP),
+					LinkIndex: kubeBridgeLink.Attrs().Index,
+					Table:     externalIPRouteTableID,
+				}
+
+				routes, err := netlink.RouteListFiltered(nFamily, nRoute,
+					netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF)
+				if err != nil {
+					return fmt.Errorf("failed to list route for external IP's due to: %s", err)
+				}
+				if len(routes) < 1 {
+					err = netlink.RouteAdd(nRoute)
+					if err != nil {
 						klog.Errorf("Failed to add route for %s in custom route table for external IP's due to: %v",
 							externalIP, err)
 						continue
@@ -560,19 +631,18 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 		}
 
 		// check if there are any pbr in externalIPRouteTableID for external IP's
-		if len(outStr) > 0 {
-			// clean up stale external IPs
-			for _, line := range strings.Split(strings.Trim(outStr, "\n"), "\n") {
-				route := strings.Split(strings.Trim(line, " "), " ")
-				ip := route[0]
-				if !activeExternalIPs[ip] {
-					args := []string{"route", "del", "table", externalIPRouteTableID}
-					args = append(args, route...)
-					if err = runIPCommandsWithArgs(ipArgs, args...).Run(); err != nil {
-						klog.Errorf("Failed to del route for %v in custom route table for external IP's due to: %s",
-							ip, err)
-						continue
-					}
+		routes, err := netlink.RouteList(nil, nFamily)
+		if err != nil {
+			return fmt.Errorf("failed to list route for external IP's due to: %s", err)
+		}
+		for idx, route := range routes {
+			ip := route.Dst.IP.String()
+			if !activeExternalIPs[ip] {
+				err = netlink.RouteDel(&routes[idx])
+				if err != nil {
+					klog.Errorf("Failed to del route for %v in custom route table for external IP's due to: %s",
+						ip, err)
+					continue
 				}
 			}
 		}
@@ -581,13 +651,13 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 	}
 
 	if setupIPv4 {
-		err = setupIPRulesAndRoutes([]string{})
+		err = setupIPRulesAndRoutes(false)
 		if err != nil {
 			return err
 		}
 	}
 	if setupIPv6 {
-		err = setupIPRulesAndRoutes([]string{"-6"})
+		err = setupIPRulesAndRoutes(true)
 		if err != nil {
 			return err
 		}

--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -572,11 +572,12 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 				"error please report because something has gone very wrong) due to: %v", err)
 		}
 
-		nRule := &netlink.Rule{
-			Priority: defaultDSRPolicyRulePriority,
-			Src:      defaultPrefixCIDR,
-			Table:    externalIPRouteTableID,
-		}
+		nRule := netlink.NewRule()
+		nRule.Family = nFamily
+		nRule.Priority = defaultDSRPolicyRulePriority
+		nRule.Src = defaultPrefixCIDR
+		nRule.Table = externalIPRouteTableID
+
 		rules, err := netlink.RuleListFiltered(nFamily, nRule,
 			netlink.RT_FILTER_TABLE|netlink.RT_FILTER_SRC|netlink.RT_FILTER_PRIORITY)
 		if err != nil {
@@ -587,10 +588,10 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 		if len(rules) < 1 {
 			err = netlink.RuleAdd(nRule)
 			if err != nil {
-				klog.Infof("Failed to add policy rule `ip rule add prio 32765 from all lookup external_ip` due to %v",
-					err)
-				return fmt.Errorf("failed to add policy rule `ip rule add prio 32765 from all lookup external_ip` "+
-					"due to %v", err)
+				klog.Infof("Failed to add policy rule (equivalent to `ip rule add prio %d from %s lookup "+
+					"%d`) due to %v", defaultDSRPolicyRulePriority, defaultPrefixCIDR, externalIPRouteTableID, err)
+				return fmt.Errorf("failed to add policy rule (equivalent to `ip rule add prio %d from %s lookup "+
+					"%d`) due to %v", defaultDSRPolicyRulePriority, defaultPrefixCIDR, externalIPRouteTableID, err)
 			}
 		}
 

--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -507,9 +507,11 @@ func (ln *linuxNetworking) setupPolicyRoutingForDSR(setupIPv4, setupIPv6 bool) e
 		}
 		nRoute := &netlink.Route{
 			Type:      unix.RTN_LOCAL,
+			Family:    nFamily,
 			Dst:       defaultRouteCIDR,
 			LinkIndex: loNetLink.Attrs().Index,
 			Table:     customDSRRouteTableID,
+			Scope:     unix.RT_SCOPE_HOST,
 		}
 		routes, err := netlink.RouteListFiltered(nFamily, nRoute, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF)
 		if err != nil || len(routes) < 1 {
@@ -529,9 +531,11 @@ func (ln *linuxNetworking) setupPolicyRoutingForDSR(setupIPv4, setupIPv6 bool) e
 		}
 		nRoute := &netlink.Route{
 			Type:      unix.RTN_LOCAL,
+			Family:    nFamily,
 			Dst:       defaultRouteCIDR,
 			LinkIndex: loNetLink.Attrs().Index,
 			Table:     customDSRRouteTableID,
+			Scope:     unix.RT_SCOPE_HOST,
 		}
 		routes, err := netlink.RouteListFiltered(nFamily, nRoute, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF)
 		if err != nil || len(routes) < 1 {

--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -640,6 +640,8 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 		for _, svc := range serviceInfoMap {
 			externalIPs := getAllExternalIPs(svc, true)
 			for _, externalIP := range externalIPs[kFamily] {
+				klog.V(2).Infof("Looking at adding route for Service %s/%s externalIP: %s", svc.namespace, svc.name,
+					externalIP)
 				// Verify the DSR annotation exists
 				if !svc.directServerReturn {
 					klog.V(1).Infof("Skipping service %s/%s as it does not have DSR annotation",
@@ -669,7 +671,11 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 							externalIP, err)
 						continue
 					}
+					klog.V(2).Infof("Successfully added route for %s in custom route table for external IP's",
+						externalIP)
+					continue
 				}
+				klog.V(2).Infof("Route for %s in custom route table for external IP's already exists", externalIP)
 			}
 		}
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1747,11 +1747,11 @@ func routeVIPTrafficToDirector(fwmark string, family v1.IPFamily) error {
 		return fmt.Errorf("failed to convert fwmark to uint32: %v", err)
 	}
 
-	nRule := &netlink.Rule{
-		Mark:     uFWMark,
-		Table:    customDSRRouteTableID,
-		Priority: defaultTrafficDirectorRulePriority,
-	}
+	nRule := netlink.NewRule()
+	nRule.Family = nFamily
+	nRule.Mark = uFWMark
+	nRule.Table = customDSRRouteTableID
+	nRule.Priority = defaultTrafficDirectorRulePriority
 
 	routes, err := netlink.RuleListFiltered(nFamily, nRule, netlink.RT_FILTER_MARK|netlink.RT_FILTER_TABLE)
 	if err != nil {
@@ -1762,7 +1762,7 @@ func routeVIPTrafficToDirector(fwmark string, family v1.IPFamily) error {
 		err = netlink.RuleAdd(nRule)
 		if err != nil {
 			return fmt.Errorf("failed to add policy rule to lookup traffic to VIP through the custom "+
-				"routing table due to %v", err)
+				"routing table due to: %v", err)
 		}
 	}
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1749,10 +1749,17 @@ func routeVIPTrafficToDirector(fwmark uint32, family v1.IPFamily) error {
 	}
 
 	if len(routes) < 1 {
+		klog.V(1).Infof("adding policy rule (%s) to lookup traffic to VIP through the custom routing table", nRule)
 		err = netlink.RuleAdd(nRule)
 		if err != nil {
 			return fmt.Errorf("failed to add policy rule to lookup traffic to VIP through the custom "+
 				"routing table due to: %v", err)
+		}
+	} else {
+		klog.V(1).Infof("policy rule (%s) for mark %d already exists, skipping", nRule, fwmark)
+		klog.V(1).Info("Routes Found:")
+		for _, route := range routes {
+			klog.V(1).Infof("Route: %+v with mark %d", route, route.Mark)
 		}
 	}
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1730,26 +1730,15 @@ func (nsc *NetworkServicesController) cleanupMangleTableRule(ip string, protocol
 // For DSR it is required that we dont assign the VIP to any interface to avoid martian packets
 // http://www.austintek.com/LVS/LVS-HOWTO/HOWTO/LVS-HOWTO.routing_to_VIP-less_director.html
 // routeVIPTrafficToDirector: setups policy routing so that FWMARKed packets are delivered locally
-func routeVIPTrafficToDirector(fwmark string, family v1.IPFamily) error {
+func routeVIPTrafficToDirector(fwmark uint32, family v1.IPFamily) error {
 	nFamily := netlink.FAMILY_V4
 	if family == v1.IPv6Protocol {
 		nFamily = netlink.FAMILY_V6
 	}
 
-	iFWMark, err := strconv.Atoi(fwmark)
-	if err != nil {
-		return fmt.Errorf("failed to convert fwmark to integer due to: %v", err)
-	}
-
-	// Convert to uint32 safely
-	uFWMark, err := safecast.ToUint32(iFWMark)
-	if err != nil {
-		return fmt.Errorf("failed to convert fwmark to uint32: %v", err)
-	}
-
 	nRule := netlink.NewRule()
 	nRule.Family = nFamily
-	nRule.Mark = uFWMark
+	nRule.Mark = fwmark
 	nRule.Table = customDSRRouteTableID
 	nRule.Priority = defaultTrafficDirectorRulePriority
 

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1753,7 +1753,8 @@ func routeVIPTrafficToDirector(fwmark string, family v1.IPFamily) error {
 	nRule.Table = customDSRRouteTableID
 	nRule.Priority = defaultTrafficDirectorRulePriority
 
-	routes, err := netlink.RuleListFiltered(nFamily, nRule, netlink.RT_FILTER_MARK|netlink.RT_FILTER_TABLE)
+	routes, err := netlink.RuleListFiltered(nFamily, nRule,
+		netlink.RT_FILTER_MARK|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_PRIORITY)
 	if err != nil {
 		return fmt.Errorf("failed to verify if `ip rule` exists due to: %v", err)
 	}

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -557,7 +557,7 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svcIn *servic
 	}
 
 	// do policy routing to deliver the packet locally so that IPVS can pick the packet
-	err = routeVIPTrafficToDirector("0x"+fmt.Sprintf("%x", fwMark), family)
+	err = routeVIPTrafficToDirector(fwMark, family)
 	if err != nil {
 		return fmt.Errorf("failed to setup ip rule to lookup traffic to external IP: %s through custom "+
 			"route table due to %v", externalIP, err)

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -601,14 +600,6 @@ func getIPVSFirewallInputChainRule(family v1.IPFamily) []string {
 		"-m", "comment", "--comment", "handle traffic to IPVS service IPs in custom chain",
 		"-m", "set", "--match-set", getIPSetName(serviceIPsIPSetName, family), "dst",
 		"-j", ipvsFirewallChainName}
-}
-
-// runIPCommandsWithArgs extend the exec.Command interface to allow passing an additional array of arguments to ip
-func runIPCommandsWithArgs(ipArgs []string, additionalArgs ...string) *exec.Cmd {
-	var allArgs []string
-	allArgs = append(allArgs, ipArgs...)
-	allArgs = append(allArgs, additionalArgs...)
-	return exec.Command("ip", allArgs...)
 }
 
 // getLabelFromMap checks the list of passed labels for the service.kubernetes.io/service-proxy-name

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -278,8 +278,8 @@ func (nrc *NetworkRoutingController) addServiceVIPsDefinedSet() error {
 // create a defined set to represent just the host default route
 func (nrc *NetworkRoutingController) addDefaultRouteDefinedSet() error {
 	for setName, defaultRoute := range map[string]string{
-		defaultRouteSet:   "0.0.0.0/0",
-		defaultRouteSetV6: "::/0",
+		defaultRouteSet:   utils.IPv4DefaultRoute,
+		defaultRouteSetV6: utils.IPv6DefaultRoute,
 	} {
 		currentDefinedSet, err := nrc.getDefinedSetFromGoBGP(setName, gobgpapi.DefinedType_PREFIX)
 		if err != nil {

--- a/pkg/routes/pbr.go
+++ b/pkg/routes/pbr.go
@@ -2,15 +2,20 @@ package routes
 
 import (
 	"fmt"
-	"os/exec"
-	"strings"
+	"net"
 
 	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
+	"github.com/vishvananda/netlink"
+)
+
+const (
+	PBRRuleAdd = iota
+	PBRRuleDel
 )
 
 const (
 	// CustomTableID is the ID of the custom, iproute2 routing table that will be used for policy based routing
-	CustomTableID = "77"
+	CustomTableID = 77
 	// CustomTableName is the name of the custom, iproute2 routing table that will be used for policy based routing
 	CustomTableName = "kube-router"
 )
@@ -35,21 +40,29 @@ func NewPolicyBasedRules(nfa utils.NodeFamilyAware, podIPv4CIDRs, podIPv6CIDRs [
 // ipProtocol is the iproute2 protocol specified as a string ("-4" or "-6"). ipOp is the rule operation specified as a
 // string ("add" or "del). The cidr is the IPv4 / IPv6 source CIDR string that when received will be used to lookup
 // routes in a custom table.
-func ipRuleAbstraction(ipProtocol, ipOp, cidr string) error {
-	out, err := exec.Command("ip", ipProtocol, "rule", "list").Output()
+func ipRuleAbstraction(ipFamily int, ipOp int, cidr string) error {
+	_, nSrc, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return fmt.Errorf("failed to verify if `ip rule` exists: %s", err.Error())
+		return fmt.Errorf("failed to parse CIDR: %s", err.Error())
 	}
 
-	if strings.Contains(string(out), cidr) && ipOp == "del" {
-		err = exec.Command("ip", ipProtocol, "rule", ipOp, "from", cidr, "lookup", CustomTableID).Run()
-		if err != nil {
-			return fmt.Errorf("failed to add ip rule due to: %s", err.Error())
+	nRule := &netlink.Rule{
+		Family: ipFamily,
+		Src:    nSrc,
+		Table:  CustomTableID,
+	}
+	rules, err := netlink.RuleListFiltered(ipFamily, nRule, netlink.RT_FILTER_SRC)
+	if err != nil {
+		return fmt.Errorf("failed to list rules: %s", err.Error())
+	}
+
+	if ipOp == PBRRuleDel && len(rules) > 0 {
+		if err := netlink.RuleDel(nRule); err != nil {
+			return fmt.Errorf("failed to delete rule: %s", err.Error())
 		}
-	} else if !strings.Contains(string(out), cidr) && ipOp == "add" {
-		err = exec.Command("ip", ipProtocol, "rule", ipOp, "from", cidr, "lookup", CustomTableID).Run()
-		if err != nil {
-			return fmt.Errorf("failed to add ip rule due to: %s", err.Error())
+	} else if ipOp == PBRRuleAdd && len(rules) < 1 {
+		if err := netlink.RuleAdd(nRule); err != nil {
+			return fmt.Errorf("failed to add rule: %s", err.Error())
 		}
 	}
 
@@ -66,14 +79,14 @@ func (pbr *PolicyBasedRules) Enable() error {
 
 	if pbr.nfa.IsIPv4Capable() {
 		for _, ipv4CIDR := range pbr.podIPv4CIDRs {
-			if err := ipRuleAbstraction("-4", "add", ipv4CIDR); err != nil {
+			if err := ipRuleAbstraction(netlink.FAMILY_V4, PBRRuleAdd, ipv4CIDR); err != nil {
 				return err
 			}
 		}
 	}
 	if pbr.nfa.IsIPv6Capable() {
 		for _, ipv6CIDR := range pbr.podIPv6CIDRs {
-			if err := ipRuleAbstraction("-6", "add", ipv6CIDR); err != nil {
+			if err := ipRuleAbstraction(netlink.FAMILY_V6, PBRRuleAdd, ipv6CIDR); err != nil {
 				return err
 			}
 		}
@@ -91,14 +104,14 @@ func (pbr *PolicyBasedRules) Disable() error {
 
 	if pbr.nfa.IsIPv4Capable() {
 		for _, ipv4CIDR := range pbr.podIPv4CIDRs {
-			if err := ipRuleAbstraction("-4", "del", ipv4CIDR); err != nil {
+			if err := ipRuleAbstraction(netlink.FAMILY_V4, PBRRuleDel, ipv4CIDR); err != nil {
 				return err
 			}
 		}
 	}
 	if pbr.nfa.IsIPv6Capable() {
 		for _, ipv6CIDR := range pbr.podIPv6CIDRs {
-			if err := ipRuleAbstraction("-6", "del", ipv6CIDR); err != nil {
+			if err := ipRuleAbstraction(netlink.FAMILY_V6, PBRRuleDel, ipv6CIDR); err != nil {
 				return err
 			}
 		}

--- a/pkg/routes/pbr.go
+++ b/pkg/routes/pbr.go
@@ -46,11 +46,11 @@ func ipRuleAbstraction(ipFamily int, ipOp int, cidr string) error {
 		return fmt.Errorf("failed to parse CIDR: %s", err.Error())
 	}
 
-	nRule := &netlink.Rule{
-		Family: ipFamily,
-		Src:    nSrc,
-		Table:  CustomTableID,
-	}
+	nRule := netlink.NewRule()
+	nRule.Family = ipFamily
+	nRule.Src = nSrc
+	nRule.Table = CustomTableID
+
 	rules, err := netlink.RuleListFiltered(ipFamily, nRule, netlink.RT_FILTER_SRC)
 	if err != nil {
 		return fmt.Errorf("failed to list rules: %s", err.Error())

--- a/pkg/tunnels/linux_tunnels.go
+++ b/pkg/tunnels/linux_tunnels.go
@@ -228,14 +228,15 @@ func (o *OverlayTunnel) SetupOverlayTunnel(tunnelName string, nextHop net.IP,
 	// Now that the tunnel link exists, we need to add a route to it, so the node knows where to send traffic bound for
 	// this interface
 	//nolint:gocritic // we understand that we are appending to a new slice
-	cmdArgs := append(ipBase, "route", "list", "table", routes.CustomTableID)
+	cmdArgs := append(ipBase, "route", "list", "table", strconv.Itoa(routes.CustomTableID))
 	out, err = exec.Command("ip", cmdArgs...).CombinedOutput()
 	// This used to be "dev "+tunnelName+" scope" but this isn't consistent with IPv6's output, so we changed it to just
 	// "dev "+tunnelName, but at this point I'm unsure if there was a good reason for adding scope on before, so that's
 	// why this comment is here.
 	if err != nil || !strings.Contains(string(out), "dev "+tunnelName) {
 		//nolint:gocritic // we understand that we are appending to a new slice
-		cmdArgs = append(ipBase, "route", "add", nextHop.String(), "dev", tunnelName, "table", routes.CustomTableID)
+		cmdArgs = append(ipBase, "route", "add", nextHop.String(), "dev", tunnelName, "table",
+			strconv.Itoa(routes.CustomTableID))
 		if out, err = exec.Command("ip", cmdArgs...).CombinedOutput(); err != nil {
 			return nil, fmt.Errorf("failed to add route in custom route table, err: %s, output: %s", err, string(out))
 		}

--- a/pkg/tunnels/linux_tunnels.go
+++ b/pkg/tunnels/linux_tunnels.go
@@ -38,6 +38,7 @@ const (
 
 	// Unix tunnel encap types, unfortunately, these are not understood by the netlink library, so we need to use
 	// our own enums which as far as I can tell come from here:
+	//nolint:lll // URL is long
 	// https://github.com/iproute2/iproute2/blob/e6a170a9d4e75d206631da77e469813279c12134/include/uapi/linux/if_tunnel.h#L84-L89
 	UnixTunnelEncapTypeNone uint16 = 0
 	UnixTunnelEncapTypeFOU  uint16 = 1
@@ -48,6 +49,17 @@ const (
 var (
 	validEncapTypes = []EncapType{EncapTypeFOU, EncapTypeIPIP}
 )
+
+// tunnelConfig holds configuration for IP family-specific settings
+type tunnelConfig struct {
+	nextHopSubnet   *net.IPNet
+	bestIPForFamily net.IP
+	ipipMode        string
+	fouLinkType     string
+	isIPv6          bool
+	ipBase          []string
+	encapPortStr    string
+}
 
 // EncapType represents the type of encapsulation used for an overlay tunnel in kube-router.
 type EncapType string
@@ -119,200 +131,289 @@ func (o *OverlayTunnel) EncapPort() EncapPort {
 func (o *OverlayTunnel) SetupOverlayTunnel(tunnelName string, nextHop net.IP,
 	nextHopSubnet *net.IPNet) (netlink.Link, error) {
 	link, err := netlink.LinkByName(tunnelName)
+	if err != nil {
+		klog.Warningf("failed to get tunnel link by name %s: %v, will attempt to create it", tunnelName, err)
+		link = nil
+	}
 
-	var bestIPForFamily net.IP
-	var ipipMode, fouLinkType string
-	isIPv6 := false
-	ipBase := make([]string, 0)
-	strFormattedEncapPort := strconv.FormatInt(int64(o.encapPort), 10)
+	// Determine IP family and configuration
+	config, err := o.createTunnelConfig(nextHop, nextHopSubnet)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if tunnel needs recreation due to encap type mismatch
+	link, err = o.applyTunnelConfig(link, tunnelName, nextHop, config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add route for the tunnel
+	if err := o.addTunnelRoute(link, nextHop, config.isIPv6); err != nil {
+		return nil, err
+	}
+
+	return link, nil
+}
+
+// createTunnelConfig determines the IP family and returns appropriate configuration
+func (o *OverlayTunnel) createTunnelConfig(nextHop net.IP, nextHopSubnet *net.IPNet) (*tunnelConfig, error) {
+	config := &tunnelConfig{
+		ipBase:        make([]string, 0),
+		encapPortStr:  strconv.FormatInt(int64(o.encapPort), 10),
+		nextHopSubnet: nextHopSubnet,
+	}
 
 	if nextHop.To4() != nil {
-		bestIPForFamily = o.krNode.FindBestIPv4NodeAddress()
-		ipipMode = ipipIPv4Mode
-		fouLinkType = fouIPv4LinkMode
+		config.bestIPForFamily = o.krNode.FindBestIPv4NodeAddress()
+		config.ipipMode = ipipIPv4Mode
+		config.fouLinkType = fouIPv4LinkMode
+		config.isIPv6 = false
 	} else {
-		// Need to activate the ip command in IPv6 mode
-		ipBase = append(ipBase, "-6")
-		bestIPForFamily = o.krNode.FindBestIPv6NodeAddress()
-		ipipMode = ipipIPv6Mode
-		fouLinkType = fouIPv6LinkMode
-		isIPv6 = true
+		config.ipBase = append(config.ipBase, "-6")
+		config.bestIPForFamily = o.krNode.FindBestIPv6NodeAddress()
+		config.ipipMode = ipipIPv6Mode
+		config.fouLinkType = fouIPv6LinkMode
+		config.isIPv6 = true
 	}
-	if nil == bestIPForFamily {
+
+	if config.bestIPForFamily == nil {
 		return nil, fmt.Errorf("not able to find an appropriate configured IP address on node for destination "+
 			"IP family: %s", nextHop.String())
 	}
 
-	// This indicated that the tunnel already exists, so it's possible that there might be nothing more needed. However,
-	// it is also possible that the user changed the encap type, so we need to make sure that the encap type matches
-	// and if it doesn't, create it
-	recreate := false
-	if err == nil {
-		klog.V(1).Infof("Tunnel interface: %s with encap type %s for the node %s already exists.",
-			tunnelName, link.Attrs().EncapType, nextHop.String())
+	return config, nil
+}
 
-		switch o.encapType {
-		case EncapTypeIPIP:
-			if fouEnabled, err := linkFOUEnabled(tunnelName); err != nil || fouEnabled {
-				if err != nil {
-					klog.Errorf("failed to check if fou is enabled on the link %s: %v, going to try to clean up and "+
-						"recreate the tunnel", tunnelName, err)
-				} else {
-					klog.Infof("Was configured to use ipip tunnels, but found existing fou tunnels in place, " +
-						"cleaning up")
-				}
-				recreate = true
+// applyTunnelConfig ensures that the existing tunnel matches the desired configuration and cleans up any old tunnels
+// that do not match the config
+func (o *OverlayTunnel) applyTunnelConfig(link netlink.Link, tunnelName string, nextHop net.IP,
+	config *tunnelConfig) (netlink.Link, error) {
 
-				// Even though we are setup for IPIP tunels we have existing tunnels that are FoU tunnels, remove them
-				// so that we can recreate them as IPIP
-				CleanupTunnel(nextHopSubnet, tunnelName)
-
-				// If we are transitioning from FoU to IPIP we also need to clean up the old FoU port if it exists
-				if fouPortAndProtoExist(o.encapPort, isIPv6) {
-					fouArgs := ipBase
-					fouArgs = append(fouArgs, "fou", "del", "port", strFormattedEncapPort)
-					out, err := exec.Command("ip", fouArgs...).CombinedOutput()
-					if err != nil {
-						klog.Warningf("failed to clean up previous FoU tunnel port (this is only a warning because it "+
-							"won't stop kube-router from working for now, but still shouldn't have happened) - error: "+
-							"%v, output %s", err, out)
-					}
-				}
-			}
-		case EncapTypeFOU:
-			if fouEnabled, err := linkFOUEnabled(tunnelName); err != nil || !fouEnabled {
-				if err != nil {
-					klog.Errorf("failed to check if fou is enabled on the link %s: %v, going to try to clean up and "+
-						"recreate the tunnel", tunnelName, err)
-				} else {
-					klog.Infof("Was configured to use fou tunnels, but found existing ipip tunnels in place, " +
-						"cleaning up")
-				}
-				recreate = true
-				// Even though we are setup for FoU tunels we have existing tunnels that are IPIP tunnels, remove them
-				// so that we can recreate them as IPIP
-				CleanupTunnel(nextHopSubnet, tunnelName)
-			}
-		default:
-			return nil, fmt.Errorf("unknown tunnel encapsulation was passed: %s, unable to continue with overlay "+
-				"setup", o.encapType)
-		}
+	var recreate bool
+	switch o.encapType {
+	case EncapTypeIPIP:
+		recreate = o.checkIPIPTunnelRecreation(tunnelName, config)
+	case EncapTypeFOU:
+		recreate = o.checkFOUTunnelRecreation(tunnelName, config)
+	default:
+		return nil, fmt.Errorf("unknown tunnel encapsulation was passed: %s, unable to continue with overlay "+
+			"setup", o.encapType)
 	}
 
-	// an error here indicates that the tunnel didn't exist, so we need to create it, if it already exists there's
-	// nothing to do here
-	if err != nil || recreate {
-		klog.Infof("Creating tunnel %s with encap %s for destination %s",
-			tunnelName, o.encapType, nextHop.String())
+	// If the link doesn't exist here, then it means that it likely doesn't exist, or we encountered a random error when
+	// we originally tried to get it. In either case, we need to create a new tunnel.
+	if link == nil || recreate {
+		return o.createTunnel(tunnelName, nextHop, config)
+	}
 
-		switch o.encapType {
-		case EncapTypeIPIP:
-			// Create plain IPIP tunnel using netlink
-			var tunnelLink netlink.Link
-			if isIPv6 {
-				tunnelLink = &netlink.Ip6tnl{
-					LinkAttrs: netlink.LinkAttrs{Name: tunnelName},
-					Local:     bestIPForFamily,
-					Remote:    nextHop,
-				}
-			} else {
-				tunnelLink = &netlink.Iptun{
-					LinkAttrs: netlink.LinkAttrs{Name: tunnelName},
-					Local:     bestIPForFamily,
-					Remote:    nextHop,
-				}
-			}
+	return link, nil
+}
 
-			if err := netlink.LinkAdd(tunnelLink); err != nil {
-				return nil, fmt.Errorf("route not injected for the route advertised by the node %s "+
-					"Failed to create tunnel interface %s. error: %v", nextHop, tunnelName, err)
-			}
-
-		case EncapTypeFOU:
-			// Ensure that the FOU tunnel port is set correctly
-			if !fouPortAndProtoExist(o.encapPort, isIPv6) {
-				// Create FOU port using netlink
-				var family int
-				if isIPv6 {
-					family = netlink.FAMILY_V6
-				} else {
-					family = netlink.FAMILY_V4
-				}
-
-				fouPort := &netlink.Fou{
-					Family:    family,
-					Port:      int(o.encapPort),
-					EncapType: netlink.FOU_ENCAP_GUE,
-				}
-
-				if err := netlink.FouAdd(*fouPort); err != nil {
-					return nil, fmt.Errorf("route not injected for the route advertised by the node %s "+
-						"Failed to set FoU tunnel port - error: %v", nextHop, err)
-				}
-			}
-
-			// For FOU tunnels, we still need to use exec.Command because the netlink library doesn't support ipip &
-			// ip6ip6 secondary encapsulation modes on links. It does support GUE, but until it supports secondary
-			// encapsulation modes, we need to use the iproute2 tooling to create the tunnel.
-			cmdArgs := ipBase
-			cmdArgs = append(cmdArgs, "link", "add", "name", tunnelName, "type", fouLinkType, "remote", nextHop.String(),
-				"local", bestIPForFamily.String(), "ttl", "225", "encap", "gue", "encap-sport", "auto", "encap-dport",
-				strFormattedEncapPort, "mode", ipipMode)
-
-			klog.V(2).Infof("Executing the following command to create tunnel: ip %s", cmdArgs)
-			out, err := exec.Command("ip", cmdArgs...).CombinedOutput()
-			if err != nil {
-				return nil, fmt.Errorf("route not injected for the route advertised by the node %s "+
-					"Failed to create tunnel interface %s. error: %s, output: %s",
-					nextHop, tunnelName, err, string(out))
-			}
-		default:
-			return nil, fmt.Errorf("unknown tunnel encapsulation was passed: %s, unable to continue with overlay "+
-				"setup", o.encapType)
-		}
-
-		link, err = netlink.LinkByName(tunnelName)
+// checkIPIPTunnelRecreation checks if IPIP tunnel needs recreation and cleans up any old tunnels
+func (o *OverlayTunnel) checkIPIPTunnelRecreation(tunnelName string, config *tunnelConfig) bool {
+	fouEnabled, err := linkFOUEnabled(tunnelName)
+	if err != nil || fouEnabled {
 		if err != nil {
-			return nil, fmt.Errorf("route not injected for the route advertised by the node %s "+
-				"Failed to get tunnel interface by name error: %s", tunnelName, err)
+			klog.Infof("failed to check if fou is enabled on the link %s: %v, going to try to clean up and "+
+				"recreate the tunnel anyway", tunnelName, err)
+		} else {
+			klog.Infof("Was configured to use ipip tunnels, but found existing fou tunnels in place, " +
+				"cleaning up")
 		}
-		if err = netlink.LinkSetUp(link); err != nil {
-			return nil, fmt.Errorf("failed to bring tunnel interface %s up due to: %v", tunnelName, err)
+
+		// Clean up existing FOU tunnel
+		CleanupTunnel(config.nextHopSubnet, tunnelName)
+
+		// Clean up old FOU port if transitioning from FOU to IPIP
+		if fouPortAndProtoExist(o.encapPort, config.isIPv6) {
+			o.cleanupFOUPort(config)
+		}
+
+		return true
+	}
+	return false
+}
+
+// checkFOUTunnelRecreation checks if FOU tunnel needs recreation and cleans up any old tunnels
+func (o *OverlayTunnel) checkFOUTunnelRecreation(tunnelName string, config *tunnelConfig) bool {
+	fouEnabled, err := linkFOUEnabled(tunnelName)
+	if err != nil || !fouEnabled {
+		if err != nil {
+			klog.Errorf("failed to check if fou is enabled on the link %s: %v, going to try to clean up and "+
+				"recreate the tunnel anyway", tunnelName, err)
+		} else {
+			klog.Infof("Was configured to use fou tunnels, but found existing ipip tunnels in place, " +
+				"cleaning up")
+		}
+
+		// Clean up existing IPIP tunnel
+		CleanupTunnel(config.nextHopSubnet, tunnelName)
+		return true
+	}
+	return false
+}
+
+// cleanupFOUPort removes the FOU port configuration
+func (o *OverlayTunnel) cleanupFOUPort(config *tunnelConfig) {
+	fouArgs := config.ipBase
+	fouArgs = append(fouArgs, "fou", "del", "port", config.encapPortStr)
+	out, err := exec.Command("ip", fouArgs...).CombinedOutput()
+	if err != nil {
+		klog.Warningf("failed to clean up previous FoU tunnel port (this is only a warning because it "+
+			"won't stop kube-router from working for now, but still shouldn't have happened) - error: "+
+			"%v, output %s", err, out)
+	}
+}
+
+// createTunnel creates a new tunnel based on the encapsulation type
+func (o *OverlayTunnel) createTunnel(tunnelName string, nextHop net.IP, config *tunnelConfig) (netlink.Link, error) {
+	klog.Infof("Creating tunnel %s with encap %s for destination %s",
+		tunnelName, o.encapType, nextHop.String())
+
+	switch o.encapType {
+	case EncapTypeIPIP:
+		return o.createIPIPTunnel(tunnelName, nextHop, config)
+	case EncapTypeFOU:
+		return o.createFOUTunnel(tunnelName, nextHop, config)
+	default:
+		return nil, fmt.Errorf("unknown tunnel encapsulation was passed: %s, unable to continue with overlay "+
+			"setup", o.encapType)
+	}
+}
+
+// createIPIPTunnel creates an IPIP tunnel using netlink
+func (o *OverlayTunnel) createIPIPTunnel(tunnelName string, nextHop net.IP,
+	config *tunnelConfig) (netlink.Link, error) {
+	var tunnelLink netlink.Link
+	if config.isIPv6 {
+		tunnelLink = &netlink.Ip6tnl{
+			LinkAttrs: netlink.LinkAttrs{Name: tunnelName},
+			Local:     config.bestIPForFamily,
+			Remote:    nextHop,
+		}
+	} else {
+		tunnelLink = &netlink.Iptun{
+			LinkAttrs: netlink.LinkAttrs{Name: tunnelName},
+			Local:     config.bestIPForFamily,
+			Remote:    nextHop,
 		}
 	}
 
-	// Now that the tunnel link exists, we need to add a route to it, so the node knows where to send traffic bound for
-	// this interface
-	var routeFamily int
+	if err := netlink.LinkAdd(tunnelLink); err != nil {
+		return nil, fmt.Errorf("route not injected for the route advertised by the node %s "+
+			"Failed to create tunnel interface %s. error: %v", nextHop, tunnelName, err)
+	}
+
+	return o.bringTunnelUp(tunnelName)
+}
+
+// createFOUTunnel creates a FOU tunnel
+func (o *OverlayTunnel) createFOUTunnel(tunnelName string, nextHop net.IP, config *tunnelConfig) (netlink.Link, error) {
+	// Ensure FOU port exists
+	if err := o.ensureFOUPort(config); err != nil {
+		return nil, err
+	}
+
+	// Create FOU tunnel using iproute2
+	if err := o.createFOUTunnelWithIPRoute2(tunnelName, nextHop, config); err != nil {
+		return nil, err
+	}
+
+	return o.bringTunnelUp(tunnelName)
+}
+
+// ensureFOUPort ensures the FOU port is configured
+func (o *OverlayTunnel) ensureFOUPort(config *tunnelConfig) error {
+	if fouPortAndProtoExist(o.encapPort, config.isIPv6) {
+		return nil
+	}
+
+	var family int
+	if config.isIPv6 {
+		family = netlink.FAMILY_V6
+	} else {
+		family = netlink.FAMILY_V4
+	}
+
+	fouPort := &netlink.Fou{
+		Family:    family,
+		Port:      int(o.encapPort),
+		EncapType: netlink.FOU_ENCAP_GUE,
+	}
+
+	if err := netlink.FouAdd(*fouPort); err != nil {
+		return fmt.Errorf("failed to set FoU tunnel port - error: %v", err)
+	}
+
+	return nil
+}
+
+// createFOUTunnelWithIPRoute2 creates FOU tunnel using iproute2 command. While it would be nice to be able to do this
+// via netlink, the netlink library does not currently support creating secondary encap tunnels (IPIP over GUE). So for
+// now we have to use the iproute2 user-space tooling.
+func (o *OverlayTunnel) createFOUTunnelWithIPRoute2(tunnelName string, nextHop net.IP, config *tunnelConfig) error {
+	cmdArgs := config.ipBase
+	cmdArgs = append(cmdArgs, "link", "add", "name", tunnelName, "type", config.fouLinkType, "remote", nextHop.String(),
+		"local", config.bestIPForFamily.String(), "ttl", "225", "encap", "gue", "encap-sport", "auto", "encap-dport",
+		config.encapPortStr, "mode", config.ipipMode)
+
+	klog.V(2).Infof("Executing the following command to create tunnel: ip %s", cmdArgs)
+	out, err := exec.Command("ip", cmdArgs...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("route not injected for the route advertised by the node %s "+
+			"Failed to create tunnel interface %s. error: %s, output: %s",
+			nextHop, tunnelName, err, string(out))
+	}
+
+	return nil
+}
+
+// bringTunnelUp brings the tunnel interface up
+func (o *OverlayTunnel) bringTunnelUp(tunnelName string) (netlink.Link, error) {
+	link, err := netlink.LinkByName(tunnelName)
+	if err != nil {
+		return nil, fmt.Errorf("route not injected for the route advertised by the node %s "+
+			"Failed to get tunnel interface by name error: %s", tunnelName, err)
+	}
+
+	if err = netlink.LinkSetUp(link); err != nil {
+		return nil, fmt.Errorf("failed to bring tunnel interface %s up due to: %v", tunnelName, err)
+	}
+
+	return link, nil
+}
+
+// addTunnelRoute adds a route for the tunnel in the custom table. This is necessary to ensure that the tunnel is used
+// for all traffic destined for the tunnel's destination.
+func (o *OverlayTunnel) addTunnelRoute(link netlink.Link, nextHop net.IP, isIPv6 bool) error {
+	routeFamily := netlink.FAMILY_V4
 	if isIPv6 {
 		routeFamily = netlink.FAMILY_V6
-	} else {
-		routeFamily = netlink.FAMILY_V4
 	}
 
-	// Check if route already exists in the custom table
 	route := &netlink.Route{
 		Family:    routeFamily,
 		LinkIndex: link.Attrs().Index,
 		Table:     routes.CustomTableID,
 		Dst:       utils.GetSingleIPNet(nextHop),
 	}
+
 	routeList, err := netlink.RouteListFiltered(routeFamily, route,
 		netlink.RT_FILTER_OIF|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_DST)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list routes in custom table: %v", err)
+		return fmt.Errorf("failed to list routes in custom table: %v", err)
 	}
 
 	if len(routeList) < 1 {
-		// Add route to the custom table
 		if err = netlink.RouteAdd(route); err != nil {
-			return nil, fmt.Errorf("failed to add route in custom route table, err: %v", err)
+			return fmt.Errorf("failed to add route in custom route table, err: %v", err)
 		}
 	} else {
 		klog.V(2).Infof("Route for %s already exists in custom table", nextHop.String())
 	}
 
-	return link, nil
+	return nil
 }
 
 // cleanupTunnel removes any traces of tunnels / routes that were setup by nrc.setupOverlayTunnel() and are no longer
@@ -355,7 +456,6 @@ func GenerateTunnelName(nodeIP string) string {
 // fouPortAndProtoExist checks to see if the given FoU port is already configured on the system via iproute2
 // tooling for the given protocol
 func fouPortAndProtoExist(port EncapPort, isIPv6 bool) bool {
-	const ipRoute2IPv6Prefix = "-6"
 	strPort := strconv.FormatInt(int64(port), 10)
 	klog.V(2).Infof("Checking FOU Port and Proto... %s - %t", strPort, isIPv6)
 
@@ -366,12 +466,12 @@ func fouPortAndProtoExist(port EncapPort, isIPv6 bool) bool {
 
 	fList, err := netlink.FouList(nFamily)
 	if err != nil {
-		klog.Errorf("failed to list fou ports: %v", err)
+		klog.Warningf("failed to list fou ports: %v", err)
 		return false
 	}
 
 	for _, fou := range fList {
-		klog.V(2).Infof("Found fou port: %s", fou)
+		klog.V(2).Infof("Found fou port: %v", fou)
 		if fou.Port == int(port) && fou.Family == nFamily {
 			return true
 		}
@@ -384,7 +484,6 @@ func fouPortAndProtoExist(port EncapPort, isIPv6 bool) bool {
 // kube-router only works with GUE (Generic UDP Encapsulation) we look for that and not just FoU in general. If the
 // linkName is enabled with FoU GUE then we return true, otherwise false
 func linkFOUEnabled(linkName string) (bool, error) {
-	const gueEncapType = "gue"
 	link, err := netlink.LinkByName(linkName)
 	if err != nil {
 		return false, fmt.Errorf("failed to get link by name: %v", err)
@@ -404,7 +503,7 @@ func linkFOUEnabled(linkName string) (bool, error) {
 			return true, nil
 		}
 	default:
-		return false, fmt.Errorf("Link %s is not an IPTun or IP6Tun, this is not expected", linkName)
+		return false, fmt.Errorf("link %s is not an IPTun or IP6Tun, this is not expected", linkName)
 	}
 
 	return false, nil

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -1,0 +1,88 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+)
+
+const (
+	IPv4DefaultRoute = "0.0.0.0/0"
+	IPv6DefaultRoute = "::/0"
+)
+
+// ContainsIPv4Address checks a given string array to see if it contains a valid IPv4 address within it
+func ContainsIPv4Address(addrs []string) bool {
+	for _, addr := range addrs {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsIPv6Address checks a given string array to see if it contains a valid IPv6 address within it
+func ContainsIPv6Address(addrs []string) bool {
+	for _, addr := range addrs {
+		ip := net.ParseIP(addr)
+		if ip == nil {
+			continue
+		}
+		if ip.To4() != nil {
+			continue
+		}
+		if ip.To16() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// GetDefaultIPv4Route returns the default IPv4 route
+func GetDefaultIPv4Route() *net.IPNet {
+	_, defaultPrefixCIDR, err := net.ParseCIDR(IPv4DefaultRoute)
+	if err != nil {
+		return nil
+	}
+	return defaultPrefixCIDR
+}
+
+// GetDefaultIPv6Route returns the default IPv6 route
+func GetDefaultIPv6Route() *net.IPNet {
+	_, defaultPrefixCIDR, err := net.ParseCIDR(IPv6DefaultRoute)
+	if err != nil {
+		return nil
+	}
+	return defaultPrefixCIDR
+}
+
+// IPNetEqual checks if two IPNet objects are equal by comparing the IP and Mask
+func IPNetEqual(a, b *net.IPNet) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.IP.Equal(b.IP) && bytes.Equal(a.Mask, b.Mask)
+}
+
+// IsDefaultRoute checks if a given CIDR is a default route by comparing it to the default routes for IPv4 and IPv6
+func IsDefaultRoute(cidr *net.IPNet) (bool, error) {
+	var defaultPrefixCIDR *net.IPNet
+	var err error
+
+	if cidr.IP.To4() != nil {
+		_, defaultPrefixCIDR, err = net.ParseCIDR(IPv4DefaultRoute)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse default route: %s", err.Error())
+		}
+	} else {
+		_, defaultPrefixCIDR, err = net.ParseCIDR(IPv6DefaultRoute)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse default route: %s", err.Error())
+		}
+	}
+	return IPNetEqual(defaultPrefixCIDR, cidr), nil
+}

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -9,7 +9,36 @@ import (
 const (
 	IPv4DefaultRoute = "0.0.0.0/0"
 	IPv6DefaultRoute = "::/0"
+
+	ipv4NetMaskBits = 32
+	ipv6NetMaskBits = 128
 )
+
+// GetSingleIPNet returns an IPNet object that represents a subnet containing a single IP address for a given IP address
+// with proper handling for IPv4 and IPv6 addresses.
+func GetSingleIPNet(ip net.IP) *net.IPNet {
+	if ip.To4() != nil {
+		return &net.IPNet{
+			IP:   ip,
+			Mask: net.CIDRMask(ipv4NetMaskBits, ipv4NetMaskBits),
+		}
+	} else {
+		return &net.IPNet{
+			IP:   ip,
+			Mask: net.CIDRMask(ipv6NetMaskBits, ipv6NetMaskBits),
+		}
+	}
+}
+
+// GetIPv4NetMaxMaskBits returns the maximum mask bits for an IPv4 address
+func GetIPv4NetMaxMaskBits() uint32 {
+	return ipv4NetMaskBits
+}
+
+// GetIPv6NetMaxMaskBits returns the maximum mask bits for an IPv6 address
+func GetIPv6NetMaxMaskBits() uint32 {
+	return ipv6NetMaskBits
+}
 
 // ContainsIPv4Address checks a given string array to see if it contains a valid IPv4 address within it
 func ContainsIPv4Address(addrs []string) bool {

--- a/pkg/utils/ip_test.go
+++ b/pkg/utils/ip_test.go
@@ -292,3 +292,53 @@ func TestIP_IsPrivate(t *testing.T) {
 		})
 	}
 }
+
+func TestGetSingleIPNet(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       net.IP
+		expected *net.IPNet
+	}{
+		{
+			name: "IPv4 address",
+			ip:   net.IPv4(192, 168, 1, 1),
+			expected: &net.IPNet{
+				IP:   net.IPv4(192, 168, 1, 1),
+				Mask: net.CIDRMask(32, 32),
+			},
+		},
+		{
+			name: "IPv4-mapped IPv6 address",
+			ip:   net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 1, 1},
+			expected: &net.IPNet{
+				IP:   net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 1, 1},
+				Mask: net.CIDRMask(32, 32),
+			},
+		},
+		{
+			name: "IPv6 address",
+			ip:   net.IPv6loopback,
+			expected: &net.IPNet{
+				IP:   net.IPv6loopback,
+				Mask: net.CIDRMask(128, 128),
+			},
+		},
+		{
+			name: "Another IPv6 address",
+			ip:   net.IP{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			expected: &net.IPNet{
+				IP:   net.IP{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+				Mask: net.CIDRMask(128, 128),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetSingleIPNet(tt.ip)
+			require.NotNil(t, result)
+			assert.True(t, tt.expected.IP.Equal(result.IP))
+			assert.Equal(t, tt.expected.Mask, result.Mask)
+		})
+	}
+}

--- a/pkg/utils/ip_test.go
+++ b/pkg/utils/ip_test.go
@@ -1,0 +1,294 @@
+package utils
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIP_Equal(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip1      net.IP
+		ip2      net.IP
+		expected bool
+	}{
+		{
+			name:     "IPv4 equal",
+			ip1:      net.IPv4(192, 168, 1, 1),
+			ip2:      net.IPv4(192, 168, 1, 1),
+			expected: true,
+		},
+		{
+			name:     "IPv4 not equal",
+			ip1:      net.IPv4(192, 168, 1, 1),
+			ip2:      net.IPv4(192, 168, 1, 2),
+			expected: false,
+		},
+		{
+			name:     "IPv4 mapped IPv6 equal to IPv4",
+			ip1:      net.IPv4(192, 168, 1, 1),
+			ip2:      net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 1, 1},
+			expected: true,
+		},
+		{
+			name:     "nil IPs equal",
+			ip1:      nil,
+			ip2:      nil,
+			expected: true,
+		},
+		{
+			name:     "nil and non-nil IP not equal",
+			ip1:      nil,
+			ip2:      net.IPv4(192, 168, 1, 1),
+			expected: false,
+		},
+		{
+			name:     "IPv6 equal",
+			ip1:      net.IPv6loopback,
+			ip2:      net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.ip1.Equal(tt.ip2))
+		})
+	}
+}
+
+func TestIP_To4(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       net.IP
+		expected net.IP
+	}{
+		{
+			name:     "Valid IPv4",
+			ip:       net.IPv4(192, 168, 1, 1),
+			expected: net.IP{192, 168, 1, 1},
+		},
+		{
+			name:     "IPv4-mapped IPv6",
+			ip:       net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 192, 168, 1, 1},
+			expected: net.IP{192, 168, 1, 1},
+		},
+		{
+			name:     "Pure IPv6",
+			ip:       net.IPv6loopback,
+			expected: nil,
+		},
+		{
+			name:     "nil IP",
+			ip:       nil,
+			expected: nil,
+		},
+		{
+			name:     "Invalid length IP",
+			ip:       net.IP{1, 2, 3},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.ip.To4())
+		})
+	}
+}
+
+func TestIPNet_Contains(t *testing.T) {
+	tests := []struct {
+		name     string
+		network  *net.IPNet
+		ip       net.IP
+		expected bool
+	}{
+		{
+			name: "IPv4 in network",
+			network: &net.IPNet{
+				IP:   net.IPv4(192, 168, 1, 0),
+				Mask: net.IPv4Mask(255, 255, 255, 0),
+			},
+			ip:       net.IPv4(192, 168, 1, 1),
+			expected: true,
+		},
+		{
+			name: "IPv4 not in network",
+			network: &net.IPNet{
+				IP:   net.IPv4(192, 168, 1, 0),
+				Mask: net.IPv4Mask(255, 255, 255, 0),
+			},
+			ip:       net.IPv4(192, 168, 2, 1),
+			expected: false,
+		},
+		{
+			name: "IPv6 in network",
+			network: &net.IPNet{
+				IP:   net.IPv6loopback,
+				Mask: net.CIDRMask(128, 128),
+			},
+			ip:       net.IPv6loopback,
+			expected: true,
+		},
+		{
+			name: "Mismatched IP versions",
+			network: &net.IPNet{
+				IP:   net.IPv4(192, 168, 1, 0),
+				Mask: net.IPv4Mask(255, 255, 255, 0),
+			},
+			ip:       net.IPv6loopback,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.network.Contains(tt.ip))
+		})
+	}
+}
+
+func TestParseCIDR(t *testing.T) {
+	tests := []struct {
+		name        string
+		cidr        string
+		expectError bool
+		expectedIP  net.IP
+		expectedNet *net.IPNet
+	}{
+		{
+			name:        "Valid IPv4 CIDR",
+			cidr:        "192.168.1.0/24",
+			expectError: false,
+			expectedIP:  net.IPv4(192, 168, 1, 0),
+			expectedNet: &net.IPNet{
+				IP:   net.IPv4(192, 168, 1, 0),
+				Mask: net.IPv4Mask(255, 255, 255, 0),
+			},
+		},
+		{
+			name:        "Invalid CIDR format",
+			cidr:        "192.168.1.0",
+			expectError: true,
+		},
+		{
+			name:        "Invalid prefix length",
+			cidr:        "192.168.1.0/33",
+			expectError: true,
+		},
+		{
+			name:        "Invalid IP address",
+			cidr:        "300.168.1.0/24",
+			expectError: true,
+		},
+		{
+			name:        "Empty string",
+			cidr:        "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip, ipNet, err := net.ParseCIDR(tt.cidr)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.True(t, tt.expectedIP.Equal(ip))
+			assert.True(t, tt.expectedNet.IP.Equal(ipNet.IP))
+			assert.Equal(t, tt.expectedNet.Mask, ipNet.Mask)
+		})
+	}
+}
+
+func TestIP_DefaultMask(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       net.IP
+		expected net.IPMask
+	}{
+		{
+			name:     "Class A",
+			ip:       net.IPv4(10, 0, 0, 0),
+			expected: net.IPv4Mask(255, 0, 0, 0),
+		},
+		{
+			name:     "Class B",
+			ip:       net.IPv4(172, 16, 0, 0),
+			expected: net.IPv4Mask(255, 255, 0, 0),
+		},
+		{
+			name:     "Class C",
+			ip:       net.IPv4(192, 168, 0, 0),
+			expected: net.IPv4Mask(255, 255, 255, 0),
+		},
+		{
+			name:     "IPv6 address",
+			ip:       net.IPv6loopback,
+			expected: nil,
+		},
+		{
+			name:     "nil IP",
+			ip:       nil,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.ip.DefaultMask())
+		})
+	}
+}
+
+func TestIP_IsPrivate(t *testing.T) {
+	tests := []struct {
+		name     string
+		ip       net.IP
+		expected bool
+	}{
+		{
+			name:     "Private IPv4 10.x.x.x",
+			ip:       net.IPv4(10, 0, 0, 1),
+			expected: true,
+		},
+		{
+			name:     "Private IPv4 172.16.x.x",
+			ip:       net.IPv4(172, 16, 0, 1),
+			expected: true,
+		},
+		{
+			name:     "Private IPv4 192.168.x.x",
+			ip:       net.IPv4(192, 168, 0, 1),
+			expected: true,
+		},
+		{
+			name:     "Public IPv4",
+			ip:       net.IPv4(8, 8, 8, 8),
+			expected: false,
+		},
+		{
+			name:     "Private IPv6 fc00::/7",
+			ip:       net.IP{0xfc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			expected: true,
+		},
+		{
+			name:     "Public IPv6",
+			ip:       net.IPv6loopback,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.ip.IsPrivate())
+		})
+	}
+}

--- a/pkg/utils/linux_routing.go
+++ b/pkg/utils/linux_routing.go
@@ -28,7 +28,7 @@ type LocalLinkQuerier interface {
 }
 
 // RouteTableAdd adds a new named table to iproute's rt_tables configuration file
-func RouteTableAdd(tableNumber, tableName string) error {
+func RouteTableAdd(tableNumber int, tableName string) error {
 	var rtTablesLoc string
 	for _, possibleLoc := range rtTablesPosLoc {
 		_, err := os.Stat(possibleLoc)
@@ -53,7 +53,7 @@ func RouteTableAdd(tableNumber, tableName string) error {
 			return fmt.Errorf("failed to open: %s", err.Error())
 		}
 		defer CloseCloserDisregardError(f)
-		if _, err = f.WriteString(tableNumber + " " + tableName + "\n"); err != nil {
+		if _, err = f.WriteString(fmt.Sprint(tableNumber) + " " + tableName + "\n"); err != nil {
 			return fmt.Errorf("failed to write: %s", err.Error())
 		}
 	}

--- a/pkg/utils/linux_routing.go
+++ b/pkg/utils/linux_routing.go
@@ -37,6 +37,7 @@ func RouteTableAdd(tableNumber int, tableName string) error {
 			continue
 		}
 		rtTablesLoc = possibleLoc
+		break
 	}
 	if rtTablesLoc == "" {
 		return fmt.Errorf("did not find rt_tables in any of the expected locations: %s", rtTablesFileName)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -47,37 +47,6 @@ func CloseCloserDisregardError(handler io.Closer) {
 	_ = handler.Close()
 }
 
-// ContainsIPv4Address checks a given string array to see if it contains a valid IPv4 address within it
-func ContainsIPv4Address(addrs []string) bool {
-	for _, addr := range addrs {
-		ip := net.ParseIP(addr)
-		if ip == nil {
-			continue
-		}
-		if ip.To4() != nil {
-			return true
-		}
-	}
-	return false
-}
-
-// ContainsIPv6Address checks a given string array to see if it contains a valid IPv6 address within it
-func ContainsIPv6Address(addrs []string) bool {
-	for _, addr := range addrs {
-		ip := net.ParseIP(addr)
-		if ip == nil {
-			continue
-		}
-		if ip.To4() != nil {
-			continue
-		}
-		if ip.To16() != nil {
-			return true
-		}
-	}
-	return false
-}
-
 // SliceContainsString checks to see if needle is contained within haystack, returns true if found, otherwise
 // returns false
 func SliceContainsString(needle string, haystack []string) bool {


### PR DESCRIPTION
Not making direct exec calls to user binary interfaces has long been a principle of kube-router. When kube-router was first coded, the netlink library was missing significant features that forced us to exec out. However, now netlink seems to have most of the functionality that we need.

This converts all of the places where we can use netlink to use the netlink functionality.

The current state of this PR is untested and still needs to undergo significant testing:

* [x] Ensure IPv4 routes are getting populated correctly
* [x] Ensure IPv4 source routing is being added to custom table
* [x] Ensure IPv6 routes are getting populated correctly
* [x] Ensure IPv6 source routing is being added to custom table
* [x] Ensure IPv4 Service VIPs get added to the dummy interface
* [x] Ensure IPv6 Service VIPs get added to the dummy interface
* [x] Ensure DSR works
* [x] Ensure ipip encapsulation works
* [x] Ensure fou encapsulation works