### PR TITLE
fix(NSC): ensure kube-router owns kube-router-svip

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -2115,6 +2115,11 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 		return nil, err
 	}
 
+	// This function is responsible for quite a bit:
+	// * Sets nsc.nodeIPv4Addrs & nsc.isIPv4Capable
+	// * Sets nsc.nodeIPv6Addr & nsc.isIPv6Capable
+	// * Creates the iptables handlers for ipv4 & ipv6
+	// * Creates the ipset handlers for ipv4 & ipv6
 	err = nsc.setupHandlers(config, node)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -563,7 +563,7 @@ func getAllLocalIPs() (map[v1.IPFamily][]net.IP, error) {
 			continue
 		}
 
-		linkAddrs, err := netlink.AddrList(link, netlink.FAMILY_V4)
+		linkAddrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get IPs for interface: %v", err)
 		}


### PR DESCRIPTION
Currently, kube-router just lists all IPVS services on the host and then adds the load balancing service IPs to kube-router-svip blindly. However, this assumes that the only IPVS entries are entries that kube-router has originated and that the user isn't using IPVS.

We want to make sure that we are only creating rules for services that we are authoritative for. So to this end, we now double-check that this is one of our services before adding rules that may effect it.

Fixes: #1685 