### PR TITLE
fix: select ICMP version for common ICMP rules

### DIFF
--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -200,12 +200,22 @@ func (i *IPTablesSaveRestore) Restore(table string, data []byte) error {
 func CommonICMPRules(family v1core.IPFamily) []ICMPRule {
 	// Allow various types of ICMP that are important for routing
 	// This first block applies to both IPv4 and IPv6 type rules
+
+	var icmpProto, icmpType;
+	if family == v1core.IPv6Protocol {
+		icmpProto = ICMPv6Proto
+		icmpType = ICMPv6Type
+	} else {
+		icmpProto = ICMPv4Proto
+		icmpType = ICMPv4Type
+	}
+
 	icmpRules := []ICMPRule{
-		{ICMPv4Proto, ICMPv4Type, "echo-request", "allow icmp echo requests"},
+		{icmpProto, icmpType, "echo-request", "allow icmp echo requests"},
 		// destination-unreachable here is also responsible for handling / allowing PMTU
 		// (https://en.wikipedia.org/wiki/Path_MTU_Discovery) responses
-		{ICMPv4Proto, ICMPv4Type, "destination-unreachable", "allow icmp destination unreachable messages"},
-		{ICMPv4Proto, ICMPv4Type, "time-exceeded", "allow icmp time exceeded messages"},
+		{icmpProto, icmpType, "destination-unreachable", "allow icmp destination unreachable messages"},
+		{icmpProto, icmpType, "time-exceeded", "allow icmp time exceeded messages"},
 	}
 
 	if family == v1core.IPv6Protocol {

--- a/pkg/utils/iptables.go
+++ b/pkg/utils/iptables.go
@@ -201,7 +201,7 @@ func CommonICMPRules(family v1core.IPFamily) []ICMPRule {
 	// Allow various types of ICMP that are important for routing
 	// This first block applies to both IPv4 and IPv6 type rules
 
-	var icmpProto, icmpType;
+	var icmpProto, icmpType string
 	if family == v1core.IPv6Protocol {
 		icmpProto = ICMPv6Proto
 		icmpType = ICMPv6Type

--- a/pkg/utils/iptables_test.go
+++ b/pkg/utils/iptables_test.go
@@ -27,9 +27,9 @@ func TestCommonICMPRules(t *testing.T) {
 			name:   "IPv6",
 			family: v1core.IPv6Protocol,
 			expected: []ICMPRule{
-				{"icmp", "--icmp-type", "echo-request", "allow icmp echo requests"},
-				{"icmp", "--icmp-type", "destination-unreachable", "allow icmp destination unreachable messages"},
-				{"icmp", "--icmp-type", "time-exceeded", "allow icmp time exceeded messages"},
+				{"ipv6-icmp", "--icmpv6-type", "echo-request", "allow icmp echo requests"},
+				{"ipv6-icmp", "--icmpv6-type", "destination-unreachable", "allow icmp destination unreachable messages"},
+				{"ipv6-icmp", "--icmpv6-type", "time-exceeded", "allow icmp time exceeded messages"},
 				{"ipv6-icmp", "--icmpv6-type", "neighbor-solicitation", "allow icmp neighbor solicitation messages"},
 				{"ipv6-icmp", "--icmpv6-type", "neighbor-advertisement", "allow icmp neighbor advertisement messages"},
 				{"ipv6-icmp", "--icmpv6-type", "echo-reply", "allow icmp echo reply messages"},


### PR DESCRIPTION
This fixes kube-router trying to use `icmp` instead of `icmpv6` when creating common ICMP rules with ip6tables.

Fixes: #1712