### PR TITLE
Enhance DSR docs aroung CRI socket mounting

### DIFF
--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -57,6 +57,7 @@ spec:
         - --run-service-proxy=true
         - --bgp-graceful-restart=true
         - --kubeconfig=/var/lib/kube-router/kubeconfig
+        - --runtime-endpoint=unix:///run/containerd/containerd.sock
         env:
         - name: NODE_NAME
           valueFrom:
@@ -89,8 +90,8 @@ spec:
         - name: kubeconfig
           mountPath: /var/lib/kube-router
           readOnly: true
-        - name: run
-          mountPath: /var/run/docker.sock
+        - name: run-containerd
+          mountPath: /var/run/containerd/
           readOnly: true
         - name: rt-tables
           mountPath: /etc/iproute2/rt_tables
@@ -141,9 +142,12 @@ spec:
       - name: cni-conf-dir
         hostPath:
           path: /etc/cni/net.d
-      - name: run
+      # To mount the hosts containerd socket.
+      # We must mount the whole directory as the socket file might change due to containerd restarts
+      - name: run-containerd
         hostPath:
-          path: /var/run/docker.sock
+          path: /var/run/containerd/
+      # To mount the hosts iproute2 configuration
       - name: rt-tables
         hostPath:
           path: /etc/iproute2/rt_tables


### PR DESCRIPTION
Change the mount examples to use whole directory as the socket file might change during runtime and thus mounting the single file might break the behaviour in case of container runtime restarts.

Also simplified all the examples to use containerd as CRI as it's probably the most used CRI.

Fixes #1719 