### PR TITLE
Refactor: Abstract Node Info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/viper v1.19.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.53.0 // indirect
 	go.opentelemetry.io/otel v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,7 @@ github.com/spf13/viper v1.19.0/go.mod h1:GQUN9bilAbhU/jgc1bKs99f/suXKeUMct8Adx5+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -220,7 +220,7 @@ func (kr *KubeRouter) Run() error {
 			return fmt.Errorf("failed to create iptables handlers: %v", err)
 		}
 		npc, err := netpol.NewNetworkPolicyController(kr.Client,
-			kr.Config, podInformer, npInformer, nsInformer, &ipsetMutex, iptablesCmdHandlers, ipSetHandlers)
+			kr.Config, podInformer, npInformer, nsInformer, &ipsetMutex, nil, iptablesCmdHandlers, ipSetHandlers)
 		if err != nil {
 			return fmt.Errorf("failed to create network policy controller: %v", err)
 		}

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -63,7 +63,7 @@ var (
 
 // NetworkPolicyController struct to hold information required by NetworkPolicyController
 type NetworkPolicyController struct {
-	krNode                      utils.NodeAware
+	krNode                      utils.NodeIPAndFamilyAware
 	serviceClusterIPRanges      []net.IPNet
 	serviceExternalIPRanges     []net.IPNet
 	serviceLoadBalancerIPRanges []net.IPNet

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -115,7 +115,7 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 
 	// loop through the pods running on the node
 	allLocalPods := make(map[string]podInfo)
-	for _, nodeIP := range npc.nodeIPs {
+	for _, nodeIP := range npc.krNode.GetNodeIPAddrs() {
 		npc.getLocalPods(allLocalPods, nodeIP.String())
 	}
 	for _, pod := range allLocalPods {

--- a/pkg/controllers/proxy/network_services_controller_test.go
+++ b/pkg/controllers/proxy/network_services_controller_test.go
@@ -141,9 +141,11 @@ var _ = Describe("NetworkServicesController", func() {
 			fatalf("failed to create existing services: %v", err)
 		}
 
-		krNode := &utils.KRNode{
-			NodeName:  "node-1",
-			PrimaryIP: net.ParseIP("10.0.0.0"),
+		krNode := &utils.LocalKRNode{
+			KRNode: utils.KRNode{
+				NodeName:  "node-1",
+				PrimaryIP: net.ParseIP("10.0.0.0"),
+			},
 		}
 		nsc = &NetworkServicesController{
 			krNode: krNode,

--- a/pkg/controllers/proxy/network_services_controller_test.go
+++ b/pkg/controllers/proxy/network_services_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	"github.com/moby/ipvs"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -140,10 +141,13 @@ var _ = Describe("NetworkServicesController", func() {
 			fatalf("failed to create existing services: %v", err)
 		}
 
+		krNode := &utils.KRNode{
+			NodeName:  "node-1",
+			PrimaryIP: net.ParseIP("10.0.0.0"),
+		}
 		nsc = &NetworkServicesController{
-			primaryIP:    net.ParseIP("10.0.0.0"),
-			nodeHostName: "node-1",
-			ln:           mockedLinuxNetworking,
+			krNode: krNode,
+			ln:     mockedLinuxNetworking,
 		}
 
 		startInformersForServiceProxy(nsc, clientset)

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -158,7 +158,7 @@ func (nsc *NetworkServicesController) isValidKubeRouterServiceArtifact(address n
 						return true, nil
 					}
 				}
-			} else if address.Equal(nsc.primaryIP) {
+			} else if address.Equal(nsc.krNode.GetPrimaryNodeIP()) {
 				return true, nil
 			}
 		}
@@ -252,7 +252,7 @@ func (nsc *NetworkServicesController) findContainerRuntimeReferences(endpointIP 
 	}
 
 	// we are only concerned with endpoint pod running on current node
-	if strings.Compare(podObj.Status.HostIP, nsc.primaryIP.String()) != 0 {
+	if strings.Compare(podObj.Status.HostIP, nsc.krNode.GetPrimaryNodeIP().String()) != 0 {
 		return "", "", nil
 	}
 
@@ -318,11 +318,11 @@ func (nsc *NetworkServicesController) getPrimaryAndCIDRsByFamily(ipFamily v1.IPF
 	switch ipFamily {
 	case v1.IPv4Protocol:
 		// If we're not detected to be IPv4 capable break early
-		if !nsc.isIPv4Capable {
+		if !nsc.krNode.IsIPv4Capable() {
 			return "", nil
 		}
 
-		primaryIP = utils.FindBestIPv4NodeAddress(nsc.primaryIP, nsc.nodeIPv4Addrs).String()
+		primaryIP = nsc.krNode.FindBestIPv4NodeAddress().String()
 		if len(nsc.podCidr) > 0 && netutils.IsIPv4CIDRString(nsc.podCidr) {
 			cidrMap[nsc.podCidr] = true
 		}
@@ -335,11 +335,11 @@ func (nsc *NetworkServicesController) getPrimaryAndCIDRsByFamily(ipFamily v1.IPF
 		}
 	case v1.IPv6Protocol:
 		// If we're not detected to be IPv6 capable break early
-		if !nsc.isIPv6Capable {
+		if !nsc.krNode.IsIPv6Capable() {
 			return "", nil
 		}
 
-		primaryIP = utils.FindBestIPv6NodeAddress(nsc.primaryIP, nsc.nodeIPv6Addrs).String()
+		primaryIP = nsc.krNode.FindBestIPv6NodeAddress().String()
 		if len(nsc.podCidr) > 0 && netutils.IsIPv6CIDRString(nsc.podCidr) {
 			cidrMap[nsc.podCidr] = true
 		}

--- a/pkg/controllers/proxy/utils_test.go
+++ b/pkg/controllers/proxy/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,11 +23,15 @@ func getMoqNSC() *NetworkServicesController {
 		setupPolicyRoutingForDSRFunc:       lnm.setupPolicyRoutingForDSR,
 		setupRoutesForExternalIPForDSRFunc: lnm.setupRoutesForExternalIPForDSR,
 	}
+
+	krNode := &utils.KRNode{
+		NodeName:  "node-1",
+		PrimaryIP: net.ParseIP("10.0.0.0"),
+	}
 	return &NetworkServicesController{
-		primaryIP:    net.ParseIP("10.0.0.0"),
-		nodeHostName: "node-1",
-		ln:           mockedLinuxNetworking,
-		fwMarkMap:    map[uint32]string{},
+		krNode:    krNode,
+		ln:        mockedLinuxNetworking,
+		fwMarkMap: map[uint32]string{},
 	}
 }
 
@@ -186,14 +191,19 @@ func TestIsValidKubeRouterServiceArtifact(t *testing.T) {
 		loadBalancerIPs: []string{"172.16.0.3"},
 	}
 
+	krNode := &utils.KRNode{
+		NodeName:  "node-1",
+		PrimaryIP: net.ParseIP("192.168.1.10"),
+	}
+
 	nsc := &NetworkServicesController{
+		krNode: krNode,
 		serviceMap: map[string]*serviceInfo{
 			"service1": service1,
 			"service2": service2,
 			"service3": service3,
 		},
 		nodeportBindOnAllIP: false,
-		primaryIP:           net.ParseIP("192.168.1.10"),
 	}
 
 	tests := []struct {

--- a/pkg/controllers/proxy/utils_test.go
+++ b/pkg/controllers/proxy/utils_test.go
@@ -24,9 +24,11 @@ func getMoqNSC() *NetworkServicesController {
 		setupRoutesForExternalIPForDSRFunc: lnm.setupRoutesForExternalIPForDSR,
 	}
 
-	krNode := &utils.KRNode{
-		NodeName:  "node-1",
-		PrimaryIP: net.ParseIP("10.0.0.0"),
+	krNode := &utils.LocalKRNode{
+		KRNode: utils.KRNode{
+			NodeName:  "node-1",
+			PrimaryIP: net.ParseIP("10.0.0.0"),
+		},
 	}
 	return &NetworkServicesController{
 		krNode:    krNode,
@@ -191,9 +193,11 @@ func TestIsValidKubeRouterServiceArtifact(t *testing.T) {
 		loadBalancerIPs: []string{"172.16.0.3"},
 	}
 
-	krNode := &utils.KRNode{
-		NodeName:  "node-1",
-		PrimaryIP: net.ParseIP("192.168.1.10"),
+	krNode := &utils.LocalKRNode{
+		KRNode: utils.KRNode{
+			NodeName:  "node-1",
+			PrimaryIP: net.ParseIP("192.168.1.10"),
+		},
 	}
 
 	nsc := &NetworkServicesController{

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -343,15 +343,17 @@ func (nrc *NetworkRoutingController) addiBGPPeersDefinedSet() (map[v1core.IPFami
 	nodes := nrc.nodeLister.List()
 	for _, node := range nodes {
 		nodeObj := node.(*v1core.Node)
-		nodeIP, err := utils.GetPrimaryNodeIP(nodeObj)
+		targetNode, err := utils.NewRemoteKRNode(nodeObj)
 		if err != nil {
 			klog.Errorf("Failed to find a node IP and therefore cannot add internal BGP Peer: %v", err)
 			continue
 		}
-		if nodeIP.To4() != nil {
-			iBGPPeerCIDRs[v1core.IPv4Protocol] = append(iBGPPeerCIDRs[v1core.IPv4Protocol], nodeIP.String()+"/32")
+		if targetNode.GetPrimaryNodeIP().To4() != nil {
+			iBGPPeerCIDRs[v1core.IPv4Protocol] = append(iBGPPeerCIDRs[v1core.IPv4Protocol],
+				targetNode.GetPrimaryNodeIP().String()+"/32")
 		} else {
-			iBGPPeerCIDRs[v1core.IPv6Protocol] = append(iBGPPeerCIDRs[v1core.IPv6Protocol], nodeIP.String()+"/128")
+			iBGPPeerCIDRs[v1core.IPv6Protocol] = append(iBGPPeerCIDRs[v1core.IPv6Protocol],
+				targetNode.GetPrimaryNodeIP().String()+"/128")
 		}
 	}
 

--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -36,8 +36,10 @@ type PolicyTestCase struct {
 }
 
 func Test_AddPolicies(t *testing.T) {
-	ipv4CapableKRNode := &utils.KRNode{
-		NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.IPv4(10, 10, 10, 10)}},
+	ipv4CapableKRNode := &utils.LocalKRNode{
+		KRNode: utils.KRNode{
+			NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.IPv4(10, 10, 10, 10)}},
+		},
 	}
 	testcases := []PolicyTestCase{
 		{

--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -3,6 +3,7 @@ package routing
 import (
 	"context"
 	"fmt"
+	"net"
 	"reflect"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	gobgpapi "github.com/osrg/gobgp/v3/api"
 	gobgp "github.com/osrg/gobgp/v3/pkg/server"
 )
@@ -34,6 +36,9 @@ type PolicyTestCase struct {
 }
 
 func Test_AddPolicies(t *testing.T) {
+	ipv4CapableKRNode := &utils.KRNode{
+		NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.IPv4(10, 10, 10, 10)}},
+	}
 	testcases := []PolicyTestCase{
 		{
 			"has nodes and services",
@@ -49,7 +54,7 @@ func Test_AddPolicies(t *testing.T) {
 				activeNodes:       make(map[string]bool),
 				nodeAsnNumber:     100,
 				podCidr:           "172.20.0.0/24",
-				isIPv4Capable:     true,
+				krNode:            ipv4CapableKRNode,
 				podIPv4CIDRs:      []string{"172.20.0.0/24"},
 			},
 			[]*v1core.Node{
@@ -180,7 +185,7 @@ func Test_AddPolicies(t *testing.T) {
 				activeNodes:       make(map[string]bool),
 				nodeAsnNumber:     100,
 				podCidr:           "172.21.0.0/24",
-				isIPv4Capable:     true,
+				krNode:            ipv4CapableKRNode,
 				podIPv4CIDRs:      []string{"172.21.0.0/24"},
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
@@ -423,7 +428,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
 				podCidr:           "172.22.0.0/24",
-				isIPv4Capable:     true,
+				krNode:            ipv4CapableKRNode,
 				podIPv4CIDRs:      []string{"172.22.0.0/24"},
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
@@ -628,7 +633,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
 				podCidr:           "172.23.0.0/24",
-				isIPv4Capable:     true,
+				krNode:            ipv4CapableKRNode,
 				podIPv4CIDRs:      []string{"172.23.0.0/24"},
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
@@ -816,7 +821,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
 				podCidr:           "172.24.0.0/24",
-				isIPv4Capable:     true,
+				krNode:            ipv4CapableKRNode,
 				podIPv4CIDRs:      []string{"172.24.0.0/24"},
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
@@ -1027,7 +1032,7 @@ func Test_AddPolicies(t *testing.T) {
 				bgpServer:         gobgp.NewBgpServer(),
 				activeNodes:       make(map[string]bool),
 				podCidr:           "172.25.0.0/24",
-				isIPv4Capable:     true,
+				krNode:            ipv4CapableKRNode,
 				podIPv4CIDRs:      []string{"172.25.0.0/24"},
 				globalPeerRouters: []*gobgpapi.Peer{
 					{
@@ -1238,7 +1243,7 @@ func Test_AddPolicies(t *testing.T) {
 				advertisePodCidr:  true,
 				activeNodes:       make(map[string]bool),
 				podCidr:           "172.26.0.0/24",
-				isIPv4Capable:     true,
+				krNode:            ipv4CapableKRNode,
 				podIPv4CIDRs:      []string{"172.26.0.0/24"},
 				globalPeerRouters: []*gobgpapi.Peer{
 					{

--- a/pkg/controllers/routing/ecmp_vip_test.go
+++ b/pkg/controllers/routing/ecmp_vip_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -55,9 +56,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -97,9 +98,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      false,
 				advertiseExternalIP:     false,
 				advertiseLoadBalancerIP: false,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -139,9 +140,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     false,
 				advertiseLoadBalancerIP: false,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -181,9 +182,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      false,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: false,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -223,9 +224,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      false,
 				advertiseExternalIP:     false,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -265,9 +266,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      false,
 				advertiseExternalIP:     false,
 				advertiseLoadBalancerIP: false,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -336,9 +337,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -394,9 +395,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -444,9 +445,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv6),
-				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv6)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv6),
+					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -494,9 +495,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -540,9 +541,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv6),
-				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv6)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv6),
+					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -586,9 +587,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv6)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -636,9 +637,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv6),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv6),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -686,9 +687,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -732,9 +733,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv6),
-				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv6)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv6),
+					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -778,9 +779,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -824,9 +825,9 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				primaryIP:               net.ParseIP(testNodeIPv6),
-				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv6)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv6),
+					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{

--- a/pkg/controllers/routing/ecmp_vip_test.go
+++ b/pkg/controllers/routing/ecmp_vip_test.go
@@ -56,9 +56,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -98,9 +100,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      false,
 				advertiseExternalIP:     false,
 				advertiseLoadBalancerIP: false,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -140,9 +144,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     false,
 				advertiseLoadBalancerIP: false,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -182,9 +188,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      false,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: false,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -224,9 +232,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      false,
 				advertiseExternalIP:     false,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -266,9 +276,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      false,
 				advertiseExternalIP:     false,
 				advertiseLoadBalancerIP: false,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -337,9 +349,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -395,9 +409,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -445,9 +461,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv6),
-					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv6),
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -495,9 +513,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -541,9 +561,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv6),
-					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv6),
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -587,9 +609,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -637,9 +661,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv6),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv6),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -687,9 +713,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -733,9 +761,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv6),
-					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv6),
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -779,9 +809,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{
@@ -825,9 +857,11 @@ func Test_getVIPsForService(t *testing.T) {
 				advertiseClusterIP:      true,
 				advertiseExternalIP:     true,
 				advertiseLoadBalancerIP: true,
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv6),
-					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv6),
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv6)}},
+					},
 				},
 			},
 			serviceAdvertisedIPs: []*ServiceAdvertisedIPs{

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -984,7 +984,7 @@ func (nrc *NetworkRoutingController) syncNodeIPSets(nodeIPAware utils.NodeIPAwar
 		}
 
 		var ipv4Addrs, ipv6Addrs [][]string
-		for _, nodeIPv4 := range nodeIPAware.GetNodeIPv6Addrs() {
+		for _, nodeIPv4 := range nodeIPAware.GetNodeIPv4Addrs() {
 			ipv4Addrs = append(ipv4Addrs, []string{nodeIPv4.String(), utils.OptionTimeout, "0"})
 		}
 		for _, nodeIPv6 := range nodeIPAware.GetNodeIPv6Addrs() {

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -38,9 +38,11 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for service with ClusterIP",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -82,9 +84,11 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for service with ClusterIP/NodePort/LoadBalancer",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -182,9 +186,11 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for invalid service type",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -252,9 +258,11 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for headless service",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -467,9 +475,11 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for service with external IPs",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP("10.0.0.1"),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP("10.0.0.1"),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -513,9 +523,11 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for services with external IPs of type ClusterIP/NodePort/LoadBalancer",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -617,9 +629,11 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for invalid service type",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -690,9 +704,11 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for headless service",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -791,9 +807,11 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"skip bgp path to loadbalancerIP for service without LoadBalancer IP",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -842,9 +860,11 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path to loadbalancerIP for service with LoadBalancer IP",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -899,9 +919,11 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"no bgp path to nil loadbalancerIPs for service with LoadBalancer",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -946,9 +968,11 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"no bgp path to loadbalancerIPs for service with LoadBalancer and skiplbips annotation",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -1120,9 +1144,11 @@ func Test_advertiseAnnotationOptOut(t *testing.T) {
 			"add bgp paths for all service IPs",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -1241,9 +1267,11 @@ func Test_advertiseAnnotationOptOut(t *testing.T) {
 			"opt out to advertise any IPs via annotations",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -1419,9 +1447,11 @@ func Test_advertiseAnnotationOptIn(t *testing.T) {
 			"no bgp paths for any service IPs",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -1532,9 +1562,11 @@ func Test_advertiseAnnotationOptIn(t *testing.T) {
 			"opt in to advertise all IPs via annotations",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				krNode: &utils.KRNode{
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			[]*v1core.Service{
@@ -1786,10 +1818,12 @@ func Test_nodeHasEndpointsForService(t *testing.T) {
 		{
 			"node has endpoints for service",
 			&NetworkRoutingController{
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			&v1core.Service{
@@ -1831,10 +1865,12 @@ func Test_nodeHasEndpointsForService(t *testing.T) {
 		{
 			"node has no endpoints for service",
 			&NetworkRoutingController{
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			&v1core.Service{
@@ -1925,10 +1961,12 @@ func Test_advertisePodRoute(t *testing.T) {
 				bgpServer:    gobgp.NewBgpServer(),
 				podCidr:      "172.20.0.0/24",
 				podIPv4CIDRs: []string{"172.20.0.0/24"},
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			"node-1",
@@ -1955,10 +1993,12 @@ func Test_advertisePodRoute(t *testing.T) {
 				hostnameOverride: "node-1",
 				podCidr:          "172.20.0.0/24",
 				podIPv4CIDRs:     []string{"172.20.0.0/24"},
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 			},
 			"",
@@ -1985,12 +2025,14 @@ func Test_advertisePodRoute(t *testing.T) {
 				hostnameOverride: "node-1",
 				podCidr:          "2001:db8:42:2::/64",
 				podIPv6CIDRs:     []string{"2001:db8:42:2::/64"},
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
-					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{
-						v1core.NodeInternalIP: {net.IPv6loopback},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{
+							v1core.NodeInternalIP: {net.IPv6loopback},
+						},
 					},
 				},
 			},
@@ -2163,10 +2205,12 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: true,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				bgpServer:   gobgp.NewBgpServer(),
 				activeNodes: make(map[string]bool),
@@ -2195,10 +2239,12 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: true,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				bgpServer:   gobgp.NewBgpServer(),
 				activeNodes: make(map[string]bool),
@@ -2241,10 +2287,12 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: true,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				bgpServer: gobgp.NewBgpServer(),
 				activeNodes: map[string]bool{
@@ -2275,10 +2323,12 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: false,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				bgpServer:     gobgp.NewBgpServer(),
 				activeNodes:   make(map[string]bool),
@@ -2388,10 +2438,12 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				routerID:         testNodeIPv4,
 				bgpServer:        gobgp.NewBgpServer(),
@@ -2419,10 +2471,12 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				routerID:         testNodeIPv4,
 				bgpServer:        gobgp.NewBgpServer(),
@@ -2450,10 +2504,12 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				routerID:         testNodeIPv4,
 				bgpServer:        gobgp.NewBgpServer(),
@@ -2481,10 +2537,12 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				routerID:         testNodeIPv4,
 				bgpServer:        gobgp.NewBgpServer(),
@@ -2512,10 +2570,12 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),
@@ -2542,10 +2602,12 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				krNode: &utils.KRNode{
-					NodeName:      "node-1",
-					PrimaryIP:     net.ParseIP(testNodeIPv4),
-					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP(testNodeIPv4),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					},
 				},
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -1893,7 +1894,7 @@ func Test_nodeHasEndpointsForService(t *testing.T) {
 			waitForListerWithTimeout(testcase.nrc.epLister, time.Second*10, t)
 
 			nodeHasEndpoints, err := testcase.nrc.nodeHasEndpointsForService(testcase.existingService)
-			if !reflect.DeepEqual(err, testcase.err) {
+			if !errors.Is(err, testcase.err) {
 				t.Logf("actual err: %v", err)
 				t.Logf("expected err: %v", testcase.err)
 				t.Error("unexpected error")

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,9 +37,9 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for service with ClusterIP",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -80,9 +81,9 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for service with ClusterIP/NodePort/LoadBalancer",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -180,9 +181,9 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for invalid service type",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -250,9 +251,9 @@ func Test_advertiseClusterIPs(t *testing.T) {
 			"add bgp path for headless service",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -465,9 +466,9 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for service with external IPs",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP("10.0.0.1"),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP("10.0.0.1"),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -511,9 +512,9 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for services with external IPs of type ClusterIP/NodePort/LoadBalancer",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -615,9 +616,9 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for invalid service type",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -688,9 +689,9 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path for headless service",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -789,9 +790,9 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"skip bgp path to loadbalancerIP for service without LoadBalancer IP",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -840,9 +841,9 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"add bgp path to loadbalancerIP for service with LoadBalancer IP",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -897,9 +898,9 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"no bgp path to nil loadbalancerIPs for service with LoadBalancer",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -944,9 +945,9 @@ func Test_advertiseExternalIPs(t *testing.T) {
 			"no bgp path to loadbalancerIPs for service with LoadBalancer and skiplbips annotation",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -1118,9 +1119,9 @@ func Test_advertiseAnnotationOptOut(t *testing.T) {
 			"add bgp paths for all service IPs",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -1239,9 +1240,9 @@ func Test_advertiseAnnotationOptOut(t *testing.T) {
 			"opt out to advertise any IPs via annotations",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -1417,9 +1418,9 @@ func Test_advertiseAnnotationOptIn(t *testing.T) {
 			"no bgp paths for any service IPs",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -1530,9 +1531,9 @@ func Test_advertiseAnnotationOptIn(t *testing.T) {
 			"opt in to advertise all IPs via annotations",
 			&NetworkRoutingController{
 				bgpServer: gobgp.NewBgpServer(),
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			[]*v1core.Service{
@@ -1784,10 +1785,10 @@ func Test_nodeHasEndpointsForService(t *testing.T) {
 		{
 			"node has endpoints for service",
 			&NetworkRoutingController{
-				nodeName:  "node-1",
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			&v1core.Service{
@@ -1829,10 +1830,10 @@ func Test_nodeHasEndpointsForService(t *testing.T) {
 		{
 			"node has no endpoints for service",
 			&NetworkRoutingController{
-				nodeName:  "node-1",
-				primaryIP: net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			&v1core.Service{
@@ -1920,13 +1921,13 @@ func Test_advertisePodRoute(t *testing.T) {
 		{
 			"add bgp path for pod cidr using NODE_NAME",
 			&NetworkRoutingController{
-				bgpServer:     gobgp.NewBgpServer(),
-				podCidr:       "172.20.0.0/24",
-				isIPv4Capable: true,
-				podIPv4CIDRs:  []string{"172.20.0.0/24"},
-				primaryIP:     net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				bgpServer:    gobgp.NewBgpServer(),
+				podCidr:      "172.20.0.0/24",
+				podIPv4CIDRs: []string{"172.20.0.0/24"},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			"node-1",
@@ -1952,11 +1953,11 @@ func Test_advertisePodRoute(t *testing.T) {
 				bgpServer:        gobgp.NewBgpServer(),
 				hostnameOverride: "node-1",
 				podCidr:          "172.20.0.0/24",
-				isIPv4Capable:    true,
 				podIPv4CIDRs:     []string{"172.20.0.0/24"},
-				primaryIP:        net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 			},
 			"",
@@ -1983,13 +1984,13 @@ func Test_advertisePodRoute(t *testing.T) {
 				hostnameOverride: "node-1",
 				podCidr:          "2001:db8:42:2::/64",
 				podIPv6CIDRs:     []string{"2001:db8:42:2::/64"},
-				nodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{
-					v1core.NodeInternalIP: {net.IPv6loopback},
-				},
-				isIPv6Capable: true,
-				primaryIP:     net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
+					NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{
+						v1core.NodeInternalIP: {net.IPv6loopback},
+					},
 				},
 			},
 			"",
@@ -2161,9 +2162,10 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: true,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				bgpServer:   gobgp.NewBgpServer(),
 				activeNodes: make(map[string]bool),
@@ -2192,9 +2194,10 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: true,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				bgpServer:   gobgp.NewBgpServer(),
 				activeNodes: make(map[string]bool),
@@ -2237,9 +2240,10 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: true,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				bgpServer: gobgp.NewBgpServer(),
 				activeNodes: map[string]bool{
@@ -2270,9 +2274,10 @@ func Test_syncInternalPeers(t *testing.T) {
 			&NetworkRoutingController{
 				bgpFullMeshMode: false,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				bgpServer:     gobgp.NewBgpServer(),
 				activeNodes:   make(map[string]bool),
@@ -2382,9 +2387,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				routerID:         testNodeIPv4,
 				bgpServer:        gobgp.NewBgpServer(),
@@ -2412,9 +2418,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				routerID:         testNodeIPv4,
 				bgpServer:        gobgp.NewBgpServer(),
@@ -2442,9 +2449,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				routerID:         testNodeIPv4,
 				bgpServer:        gobgp.NewBgpServer(),
@@ -2472,9 +2480,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				routerID:         testNodeIPv4,
 				bgpServer:        gobgp.NewBgpServer(),
@@ -2502,9 +2511,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),
@@ -2531,9 +2541,10 @@ func Test_routeReflectorConfiguration(t *testing.T) {
 				bgpFullMeshMode: false,
 				bgpPort:         10000,
 				clientset:       fake.NewSimpleClientset(),
-				primaryIP:       net.ParseIP(testNodeIPv4),
-				nodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {
-					net.ParseIP(testNodeIPv4)},
+				krNode: &utils.KRNode{
+					NodeName:      "node-1",
+					PrimaryIP:     net.ParseIP(testNodeIPv4),
+					NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP(testNodeIPv4)}},
 				},
 				bgpServer:        gobgp.NewBgpServer(),
 				activeNodes:      make(map[string]bool),

--- a/pkg/controllers/routing/pbr.go
+++ b/pkg/controllers/routing/pbr.go
@@ -41,14 +41,14 @@ func (nrc *NetworkRoutingController) enablePolicyBasedRouting() error {
 		return fmt.Errorf("failed to update rt_tables file: %s", err)
 	}
 
-	if nrc.isIPv4Capable {
+	if nrc.krNode.IsIPv4Capable() {
 		for _, ipv4CIDR := range nrc.podIPv4CIDRs {
 			if err := ipRuleAbstraction("-4", "add", ipv4CIDR); err != nil {
 				return err
 			}
 		}
 	}
-	if nrc.isIPv6Capable {
+	if nrc.krNode.IsIPv6Capable() {
 		for _, ipv6CIDR := range nrc.podIPv6CIDRs {
 			if err := ipRuleAbstraction("-6", "add", ipv6CIDR); err != nil {
 				return err
@@ -65,14 +65,14 @@ func (nrc *NetworkRoutingController) disablePolicyBasedRouting() error {
 		return fmt.Errorf("failed to update rt_tables file: %s", err)
 	}
 
-	if nrc.isIPv4Capable {
+	if nrc.krNode.IsIPv4Capable() {
 		for _, ipv4CIDR := range nrc.podIPv4CIDRs {
 			if err := ipRuleAbstraction("-4", "del", ipv4CIDR); err != nil {
 				return err
 			}
 		}
 	}
-	if nrc.isIPv6Capable {
+	if nrc.krNode.IsIPv6Capable() {
 		for _, ipv6CIDR := range nrc.podIPv6CIDRs {
 			if err := ipRuleAbstraction("-6", "del", ipv6CIDR); err != nil {
 				return err

--- a/pkg/utils/linux_routing.go
+++ b/pkg/utils/linux_routing.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/vishvananda/netlink"
 	"k8s.io/klog/v2"
 )
 
@@ -20,6 +21,11 @@ var (
 		fmt.Sprintf("/usr/share/%s/%s", iproutePkg, rtTablesFileName),
 	}
 )
+
+type LocalLinkQuerier interface {
+	LinkList() ([]netlink.Link, error)
+	AddrList(link netlink.Link, family int) ([]netlink.Addr, error)
+}
 
 // RouteTableAdd adds a new named table to iproute's rt_tables configuration file
 func RouteTableAdd(tableNumber, tableName string) error {

--- a/pkg/utils/linux_routingtest.go
+++ b/pkg/utils/linux_routingtest.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/vishvananda/netlink"
+)
+
+type FakeLocalLinkQuerier struct {
+	links []netlink.Link
+	addrs []*net.IPNet
+}
+
+func NewFakeLocalLinkQuerier(addrStrings []string, mtus []int) *FakeLocalLinkQuerier {
+	links := make([]netlink.Link, len(addrStrings))
+	for idx := range addrStrings {
+		mtu := 1
+		if idx < len(mtus) {
+			mtu = mtus[idx]
+		}
+		linkAttrs := netlink.LinkAttrs{
+			Index: idx,
+			MTU:   mtu,
+		}
+		linkDevice := netlink.Device{LinkAttrs: linkAttrs}
+		links[idx] = &linkDevice
+	}
+	addrs := make([]*net.IPNet, len(addrStrings))
+	for idx, addr := range addrStrings {
+		ip := net.ParseIP(addr)
+		var netMask net.IPMask
+		if ip.To4() != nil {
+			//nolint:gomnd // Hardcoded value is used for testing purposes
+			netMask = net.CIDRMask(24, 32)
+		} else {
+			//nolint:gomnd // Hardcoded value is used for testing purposes
+			netMask = net.CIDRMask(64, 128)
+		}
+		ipNet := &net.IPNet{
+			IP:   ip,
+			Mask: netMask,
+		}
+		addrs[idx] = ipNet
+	}
+	return &FakeLocalLinkQuerier{
+		links: links,
+		addrs: addrs,
+	}
+}
+
+func (f *FakeLocalLinkQuerier) LinkList() ([]netlink.Link, error) {
+	return f.links, nil
+}
+
+func (f *FakeLocalLinkQuerier) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	addrs := make([]netlink.Addr, 1)
+	addrs[0] = netlink.Addr{IPNet: f.addrs[link.Attrs().Index]}
+	if link.Attrs().MTU == 0 {
+		return nil, fmt.Errorf("MTU was set to 0 to simulate an error")
+	}
+	return addrs, nil
+}
+
+type MockLocalLinkQuerier struct {
+	mock.Mock
+}
+
+func (m *MockLocalLinkQuerier) LinkList() ([]netlink.Link, error) {
+	args := m.Called()
+	return args.Get(0).([]netlink.Link), args.Error(1)
+}
+
+func (m *MockLocalLinkQuerier) AddrList(link netlink.Link, family int) ([]netlink.Addr, error) {
+	args := m.Called(link, family)
+	return args.Get(0).([]netlink.Addr), args.Error(1)
+}

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -369,7 +369,7 @@ func GetNodeSubnet(nodeIP net.IP, linkQ LocalLinkQuerier) (net.IPNet, string, er
 	for _, link := range links {
 		addresses, err := linkQ.AddrList(link, netlink.FAMILY_ALL)
 		if err != nil {
-			return net.IPNet{}, "", errors.New("failed to get list of addr")
+			return net.IPNet{}, "", errors.New("failed to get list of addrs")
 		}
 		for _, addr := range addresses {
 			if addr.IPNet.IP.Equal(nodeIP) {

--- a/pkg/utils/node_test.go
+++ b/pkg/utils/node_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/vishvananda/netlink"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -190,6 +192,691 @@ func Test_GetNodeIP(t *testing.T) {
 			}
 
 			assert.Equal(t, testcase.ip, ip)
+		})
+	}
+}
+
+func Test_GetNodeIPv4Addrs(t *testing.T) {
+	testcases := []struct {
+		name     string
+		node     *apiv1.Node
+		expected []net.IP
+		err      error
+	}{
+		{
+			"node with internal and external IPv4 addresses",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "192.168.1.1",
+						},
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			[]net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("192.168.1.1")},
+			nil,
+		},
+		{
+			"node with only internal IPv4 address",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "2001:db8::2",
+						},
+					},
+				},
+			},
+			[]net.IP{net.ParseIP("10.0.0.1")},
+			nil,
+		},
+		{
+			"node with only external IPv4 address",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "192.168.1.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			[]net.IP{net.ParseIP("192.168.1.1")},
+			nil,
+		},
+		{
+			"node with no IPv4 addresses",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{},
+				},
+			},
+			[]net.IP{},
+			errors.New("error getting primary NodeIP: host IP unknown"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			krNode, err := NewRemoteKRNode(testcase.node)
+			if err != nil {
+				if testcase.err == nil {
+					t.Fatalf("failed to create KRNode: %v", err)
+				}
+				assert.EqualError(t, err, testcase.err.Error())
+				return
+			}
+			ipv4Addrs := krNode.GetNodeIPv4Addrs()
+			assert.Equal(t, testcase.expected, ipv4Addrs)
+		})
+	}
+}
+
+func Test_GetNodeIPv6Addrs(t *testing.T) {
+	testcases := []struct {
+		name     string
+		node     *apiv1.Node
+		expected []net.IP
+		err      error
+	}{
+		{
+			"node with internal and external IPv4 addresses",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "192.168.1.1",
+						},
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			[]net.IP{net.ParseIP("2001:db8::1")},
+			nil,
+		},
+		{
+			"node with only internal IPv4 address",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "2001:db8::2",
+						},
+					},
+				},
+			},
+			[]net.IP{net.ParseIP("2001:db8::1"), net.ParseIP("2001:db8::2")},
+			nil,
+		},
+		{
+			"node with only external IPv4 address",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "192.168.1.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			[]net.IP{net.ParseIP("2001:db8::1")},
+			nil,
+		},
+		{
+			"node with no IPv4 addresses",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{},
+				},
+			},
+			[]net.IP{},
+			errors.New("error getting primary NodeIP: host IP unknown"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			krNode, err := NewRemoteKRNode(testcase.node)
+			if err != nil {
+				if testcase.err == nil {
+					t.Fatalf("failed to create KRNode: %v", err)
+				}
+				assert.EqualError(t, err, testcase.err.Error())
+				return
+			}
+			ipv4Addrs := krNode.GetNodeIPv6Addrs()
+			assert.Equal(t, testcase.expected, ipv4Addrs)
+		})
+	}
+}
+
+func Test_FindBestIPv6NodeAddress(t *testing.T) {
+	testcases := []struct {
+		name     string
+		node     *apiv1.Node
+		expected net.IP
+	}{
+		{
+			"primary IP is already IPv6",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			net.ParseIP("2001:db8::1"),
+		},
+		{
+			"internal IPv6 address available",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "2001:db8::2",
+						},
+					},
+				},
+			},
+			net.ParseIP("2001:db8::1"),
+		},
+		{
+			"external IPv6 address available",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "2001:db8::2",
+						},
+					},
+				},
+			},
+			net.ParseIP("2001:db8::2"),
+		},
+		{
+			"no IPv6 address available",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+					},
+				},
+			},
+			nil,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			krNode, err := NewRemoteKRNode(testcase.node)
+			if err != nil {
+				t.Fatalf("failed to create KRNode: %v", err)
+			}
+			ip := krNode.FindBestIPv6NodeAddress()
+			assert.Equal(t, testcase.expected, ip)
+		})
+	}
+}
+
+func Test_FindBestIPv4NodeAddress(t *testing.T) {
+	testcases := []struct {
+		name     string
+		node     *apiv1.Node
+		expected net.IP
+	}{
+		{
+			"primary IP is already IPv4",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			net.ParseIP("10.0.0.1"),
+		},
+		{
+			"internal IPv4 address available",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "192.168.1.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			net.ParseIP("10.0.0.1"),
+		},
+		{
+			"external IPv4 address available",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeExternalIP,
+							Address: "192.168.1.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			net.ParseIP("192.168.1.1"),
+		},
+		{
+			"no IPv4 address available",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			nil,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			krNode, err := NewRemoteKRNode(testcase.node)
+			if err != nil {
+				t.Fatalf("failed to create KRNode: %v", err)
+			}
+			ip := krNode.FindBestIPv4NodeAddress()
+			assert.Equal(t, testcase.expected, ip)
+		})
+	}
+}
+
+func Test_NewKRNode(t *testing.T) {
+	testcases := []struct {
+		name        string
+		node        *apiv1.Node
+		linkQ       LocalLinkQuerier
+		enableIPv4  bool
+		enableIPv6  bool
+		expectedErr error
+	}{
+		{
+			"valid node with IPv4 and IPv6",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			NewFakeLocalLinkQuerier([]string{"10.0.0.1", "2001:db8::1"}, nil),
+			true,
+			true,
+			nil,
+		},
+		{
+			"node with no IPv4 address",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			NewFakeLocalLinkQuerier([]string{"2001:db8::1"}, nil),
+			true,
+			true,
+			errors.New("IPv4 was enabled, but no IPv4 address was found on the node"),
+		},
+		{
+			"node with no IPv6 address",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+					},
+				},
+			},
+			NewFakeLocalLinkQuerier([]string{"10.0.0.1"}, nil),
+			true,
+			true,
+			errors.New("IPv6 was enabled, but no IPv6 address was found on the node"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			_, err := NewKRNode(testcase.node, testcase.linkQ, testcase.enableIPv4, testcase.enableIPv6)
+			if testcase.expectedErr != nil {
+				assert.EqualError(t, err, testcase.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_NewRemoteKRNode(t *testing.T) {
+	testcases := []struct {
+		name        string
+		node        *apiv1.Node
+		expectedErr error
+	}{
+		{
+			"valid node with IPv4 and IPv6",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"node with no addresses",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{},
+				},
+			},
+			errors.New("error getting primary NodeIP: host IP unknown"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			_, err := NewRemoteKRNode(testcase.node)
+			if testcase.expectedErr != nil {
+				assert.EqualError(t, err, testcase.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_GetNodeMTU(t *testing.T) {
+	testcases := []struct {
+		name        string
+		node        *apiv1.Node
+		linkQ       LocalLinkQuerier
+		expectedMTU int
+		expectedErr error
+	}{
+		{
+			"valid node with MTU",
+			&apiv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+				},
+				Status: apiv1.NodeStatus{
+					Addresses: []apiv1.NodeAddress{
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "10.0.0.1",
+						},
+						{
+							Type:    apiv1.NodeInternalIP,
+							Address: "2001:db8::1",
+						},
+					},
+				},
+			},
+			NewFakeLocalLinkQuerier([]string{"10.0.0.1", "2001:db8::1"}, []int{1480, 1500}),
+			1480,
+			nil,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			krNode, err := NewKRNode(testcase.node, testcase.linkQ, true, true)
+			if err != nil {
+				t.Fatalf("failed to create KRNode: %v", err)
+			}
+			mtu, err := krNode.GetNodeMTU()
+			if testcase.expectedErr != nil {
+				assert.EqualError(t, err, testcase.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, testcase.expectedMTU, mtu)
+			}
+		})
+	}
+}
+func Test_GetNodeSubnet(t *testing.T) {
+	testcases := []struct {
+		name        string
+		nodeIP      net.IP
+		setupMock   func(*MockLocalLinkQuerier)
+		expectedNet net.IPNet
+		expectedInt string
+		expectedErr error
+	}{
+		{
+			"valid node with subnet",
+			net.ParseIP("10.0.0.1"),
+			func(myMock *MockLocalLinkQuerier) {
+				myMock.On("LinkList").Return(
+					[]netlink.Link{&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}}, nil)
+				myMock.On("AddrList", mock.Anything, mock.Anything).Return(
+					[]netlink.Addr{{IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1"), Mask: net.CIDRMask(24, 32)}}}, nil)
+			},
+			net.IPNet{IP: net.ParseIP("10.0.0.1"), Mask: net.CIDRMask(24, 32)},
+			"eth0",
+			nil,
+		},
+		{
+			"node with no matching IP",
+			net.ParseIP("10.0.0.2"),
+			func(myMock *MockLocalLinkQuerier) {
+				myMock.On("LinkList").Return(
+					[]netlink.Link{&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}}, nil)
+				myMock.On("AddrList", mock.Anything, mock.Anything).Return(
+					[]netlink.Addr{{IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1"), Mask: net.CIDRMask(24, 32)}}}, nil)
+			},
+			net.IPNet{},
+			"",
+			errors.New("failed to find interface with specified node ip"),
+		},
+		{
+			"error getting list of links",
+			net.ParseIP("10.0.0.1"),
+			func(myMock *MockLocalLinkQuerier) {
+				myMock.On("LinkList").Return([]netlink.Link{}, errors.New("failed to get list of links"))
+			},
+			net.IPNet{},
+			"",
+			errors.New("failed to get list of links"),
+		},
+		{
+			"error getting addrs",
+			net.ParseIP("10.0.0.1"),
+			func(myMock *MockLocalLinkQuerier) {
+				myMock.On("LinkList").Return(
+					[]netlink.Link{&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}}, nil)
+				myMock.On("AddrList", mock.Anything, mock.Anything).Return(
+					[]netlink.Addr{}, errors.New("failed to get list of addrs"))
+			},
+			net.IPNet{},
+			"",
+			errors.New("failed to get list of addrs"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			mockLinkQ := &MockLocalLinkQuerier{}
+			testcase.setupMock(mockLinkQ)
+			subnet, iface, err := GetNodeSubnet(testcase.nodeIP, mockLinkQ)
+			if testcase.expectedErr != nil {
+				assert.EqualError(t, err, testcase.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, testcase.expectedNet, subnet)
+				assert.Equal(t, testcase.expectedInt, iface)
+			}
 		})
 	}
 }


### PR DESCRIPTION
@jnummelin @rbrtbnfgl @mrueg 

This prepares the way for broader refactors in the way that we handle nodes by:

* Separating frequently used node logic from the controller creation steps
* Keeping reused code DRY-er
* Adding interface abstractions for key groups of node data and starting to rely on those more rather than concrete types
* Separating node data from the rest of the controller data structure so  that it smaller definitions of data can be passed around to functions  that need it rather than always passing the entire controller which  contains more data / surface area than most functions need.

Eventually the changes here should better support the work that will need to happen to fix #1738 #676 