### PR TITLE
More injectRoute() Preparation Refactors

### DIFF
--- a/pkg/bgp/id.go
+++ b/pkg/bgp/id.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net"
-	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	gobgp "github.com/osrg/gobgp/v3/pkg/packet/bgp"
@@ -49,11 +49,10 @@ func ValidateCommunity(arg string) error {
 		return nil
 	}
 
-	_regexpCommunity := regexp.MustCompile(`(\d+):(\d+)`)
-	elems := _regexpCommunity.FindStringSubmatch(arg)
-	if len(elems) == 3 {
-		if _, err := strconv.ParseUint(elems[1], 10, CommunityMaxPartSize); err == nil {
-			if _, err = strconv.ParseUint(elems[2], 10, CommunityMaxPartSize); err == nil {
+	elem1, elem2, found := strings.Cut(arg, ":")
+	if found {
+		if _, err := strconv.ParseUint(elem1, 10, CommunityMaxPartSize); err == nil {
+			if _, err = strconv.ParseUint(elem2, 10, CommunityMaxPartSize); err == nil {
 				return nil
 			}
 		}

--- a/pkg/bgp/id.go
+++ b/pkg/bgp/id.go
@@ -1,0 +1,67 @@
+package bgp
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"net"
+	"regexp"
+	"strconv"
+
+	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
+	gobgp "github.com/osrg/gobgp/v3/pkg/packet/bgp"
+)
+
+const (
+	CommunityMaxSize     = 32
+	CommunityMaxPartSize = 16
+)
+
+// GenerateRouterID will generate a router ID based upon the user's configuration (or lack there of) and the node's
+// primary IP address if the user has not specified. If the user has configured the router ID as "generate" then we
+// will generate a router ID based upon fnv hashing the node's primary IP address.
+func GenerateRouterID(nodeIPAware utils.NodeIPAware, configRouterID string) (string, error) {
+	switch {
+	case configRouterID == "generate":
+		h := fnv.New32a()
+		h.Write(nodeIPAware.GetPrimaryNodeIP())
+		hs := h.Sum32()
+		gip := make(net.IP, 4)
+		binary.BigEndian.PutUint32(gip, hs)
+		return gip.String(), nil
+	case configRouterID != "":
+		return configRouterID, nil
+	}
+
+	if nodeIPAware.GetPrimaryNodeIP().To4() == nil {
+		return "", errors.New("router-id must be specified when primary node IP is an IPv6 address")
+	}
+	return configRouterID, nil
+}
+
+// ValidateCommunity takes in a string and attempts to parse a BGP community out of it in a way that is similar to
+// gobgp (internal/pkg/table/policy.go:ParseCommunity()). If it is not able to parse the community information it
+// returns an error.
+func ValidateCommunity(arg string) error {
+	_, err := strconv.ParseUint(arg, 10, CommunityMaxSize)
+	if err == nil {
+		return nil
+	}
+
+	_regexpCommunity := regexp.MustCompile(`(\d+):(\d+)`)
+	elems := _regexpCommunity.FindStringSubmatch(arg)
+	if len(elems) == 3 {
+		if _, err := strconv.ParseUint(elems[1], 10, CommunityMaxPartSize); err == nil {
+			if _, err = strconv.ParseUint(elems[2], 10, CommunityMaxPartSize); err == nil {
+				return nil
+			}
+		}
+	}
+	for _, v := range gobgp.WellKnownCommunityNameMap {
+		if arg == v {
+			return nil
+		}
+	}
+	return fmt.Errorf("failed to parse %s as community", arg)
+}

--- a/pkg/bgp/id_test.go
+++ b/pkg/bgp/id_test.go
@@ -1,0 +1,39 @@
+package bgp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ValidateCommunity(t *testing.T) {
+	t.Run("BGP community specified as a 32-bit integer should pass validation", func(t *testing.T) {
+		assert.Nil(t, ValidateCommunity("4294967041"))
+		assert.Nil(t, ValidateCommunity("4294967295"))
+	})
+	t.Run("BGP community specified as 2 16-bit integers should pass validation", func(t *testing.T) {
+		assert.Nil(t, ValidateCommunity("65535:65281"))
+		assert.Nil(t, ValidateCommunity("65535:65535"))
+	})
+	t.Run("Well known BGP communities passed as a string should pass validation", func(t *testing.T) {
+		assert.Nil(t, ValidateCommunity("no-export"))
+		assert.Nil(t, ValidateCommunity("internet"))
+		assert.Nil(t, ValidateCommunity("planned-shut"))
+		assert.Nil(t, ValidateCommunity("accept-own"))
+		assert.Nil(t, ValidateCommunity("blackhole"))
+		assert.Nil(t, ValidateCommunity("no-advertise"))
+		assert.Nil(t, ValidateCommunity("no-peer"))
+	})
+	t.Run("BGP community that is greater than 32-bit integer should fail validation", func(t *testing.T) {
+		assert.Error(t, ValidateCommunity("4294967296"))
+	})
+	t.Run("BGP community that is greater than 2 16-bit integers should fail validation", func(t *testing.T) {
+		assert.Error(t, ValidateCommunity("65536:65535"))
+		assert.Error(t, ValidateCommunity("65535:65536"))
+		assert.Error(t, ValidateCommunity("65536:65536"))
+	})
+	t.Run("BGP community that is not a number should fail validation", func(t *testing.T) {
+		assert.Error(t, ValidateCommunity("0xFFFFFFFF"))
+		assert.Error(t, ValidateCommunity("community"))
+	})
+}

--- a/pkg/bgp/parse.go
+++ b/pkg/bgp/parse.go
@@ -1,0 +1,63 @@
+package bgp
+
+import (
+	"fmt"
+	"net"
+
+	gobgpapi "github.com/osrg/gobgp/v3/api"
+	"github.com/vishvananda/netlink"
+)
+
+// ParseNextHop takes in a GoBGP Path and parses out the destination's next hop from its attributes. If it
+// can't parse a next hop IP from the GoBGP Path, it returns an error.
+func ParseNextHop(path *gobgpapi.Path) (net.IP, error) {
+	for _, pAttr := range path.GetPattrs() {
+		unmarshalNew, err := pAttr.UnmarshalNew()
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal path attribute: %s", err)
+		}
+		switch t := unmarshalNew.(type) {
+		case *gobgpapi.NextHopAttribute:
+			// This is the primary way that we receive NextHops and happens when both the client and the server exchange
+			// next hops on the same IP family that they negotiated BGP on
+			nextHopIP := net.ParseIP(t.NextHop)
+			if nextHopIP != nil && (nextHopIP.To4() != nil || nextHopIP.To16() != nil) {
+				return nextHopIP, nil
+			}
+			return nil, fmt.Errorf("invalid nextHop address: %s", t.NextHop)
+		case *gobgpapi.MpReachNLRIAttribute:
+			// in the case where the server and the client are exchanging next-hops that don't relate to their primary
+			// IP family, we get MpReachNLRIAttribute instead of NextHopAttributes
+			// TODO: here we only take the first next hop, at some point in the future it would probably be best to
+			// consider multiple next hops
+			nextHopIP := net.ParseIP(t.NextHops[0])
+			if nextHopIP != nil && (nextHopIP.To4() != nil || nextHopIP.To16() != nil) {
+				return nextHopIP, nil
+			}
+			return nil, fmt.Errorf("invalid nextHop address: %s", t.NextHops[0])
+		}
+	}
+	return nil, fmt.Errorf("could not parse next hop received from GoBGP for path: %s", path)
+}
+
+// ParsePath takes in a GoBGP Path and parses out the destination subnet and the next hop from its attributes.
+// If successful, it will return the destination of the BGP path as a subnet form and the next hop. If it
+// can't parse the destination or the next hop IP, it returns an error.
+func ParsePath(path *gobgpapi.Path) (*net.IPNet, net.IP, error) {
+	nextHop, err := ParseNextHop(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nlri := path.GetNlri()
+	var prefix gobgpapi.IPAddressPrefix
+	err = nlri.UnmarshalTo(&prefix)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid nlri in advertised path")
+	}
+	dstSubnet, err := netlink.ParseIPNet(prefix.Prefix + "/" + fmt.Sprint(prefix.PrefixLen))
+	if err != nil {
+		return nil, nil, fmt.Errorf("couldn't parse IP subnet from nlri advertised path")
+	}
+	return dstSubnet, nextHop, nil
+}

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
-	"github.com/stretchr/testify/assert"
 	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
@@ -2821,39 +2820,6 @@ func Test_OnNodeUpdate(t *testing.T) {
 	}
 }
 */
-
-func Test_generateTunnelName(t *testing.T) {
-	testcases := []struct {
-		name       string
-		nodeIP     string
-		tunnelName string
-	}{
-		{
-			"IP less than 12 characters after removing '.'",
-			"10.0.0.1",
-			"tun-e443169117a",
-		},
-		{
-			"IP has 12 characters after removing '.'",
-			"100.200.300.400",
-			"tun-9033d7906c7",
-		},
-		{
-			"IPv6 tunnel names are properly handled and consistent",
-			"2001:db8:42:2::/64",
-			"tun-ba56986ef05",
-		},
-	}
-
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			tunnelName := generateTunnelName(testcase.nodeIP)
-			assert.Lessf(t, len(tunnelName), 16, "the maximum length of the tunnel name should never exceed"+
-				"15 characters as 16 characters is the maximum length of a Unix interface name")
-			assert.Equal(t, testcase.tunnelName, tunnelName, "did not get expected tunnel interface name")
-		})
-	}
-}
 
 func createServices(clientset kubernetes.Interface, svcs []*v1core.Service) error {
 	for _, svc := range svcs {

--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -1,15 +1,12 @@
 package routing
 
 import (
-	"bufio"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"hash/fnv"
 	"net"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -140,23 +137,6 @@ func generateRouterID(nodeIPAware utils.NodeIPAware, configRouterID string) (str
 		return "", errors.New("router-id must be specified when primary node IP is an IPv6 address")
 	}
 	return configRouterID, nil
-}
-
-// generateTunnelName will generate a name for a tunnel interface given a node IP
-// Since linux restricts interface names to 15 characters, we take the sha-256 of the node IP after removing
-// non-entropic characters like '.' and ':', and then use the first 12 bytes of it. This allows us to cater to both
-// long IPv4 addresses and much longer IPv6 addresses.
-func generateTunnelName(nodeIP string) string {
-	// remove dots from an IPv4 address
-	strippedIP := strings.ReplaceAll(nodeIP, ".", "")
-	// remove colons from an IPv6 address
-	strippedIP = strings.ReplaceAll(strippedIP, ":", "")
-
-	h := sha256.New()
-	h.Write([]byte(strippedIP))
-	sum := h.Sum(nil)
-
-	return "tun-" + fmt.Sprintf("%x", sum)[0:11]
 }
 
 // validateCommunity takes in a string and attempts to parse a BGP community out of it in a way that is similar to
@@ -312,82 +292,4 @@ func (nrc *NetworkRoutingController) getBGPRouteInfoForVIP(vip string) (subnet u
 	}
 	err = fmt.Errorf("could not convert IP to IPv4 or IPv6, unable to find subnet for: %s", vip)
 	return
-}
-
-// fouPortAndProtoExist checks to see if the given FoU port is already configured on the system via iproute2
-// tooling for the given protocol
-//
-// fou show, shows both IPv4 and IPv6 ports in the same show command, they look like:
-// port 5556 gue
-// port 5556 gue -6
-// where the only thing that distinguishes them is the -6 or not on the end
-// WARNING we're parsing a CLI tool here not an API, this may break at some point in the future
-func fouPortAndProtoExist(port uint16, isIPv6 bool) bool {
-	const ipRoute2IPv6Prefix = "-6"
-	strPort := strconv.FormatInt(int64(port), 10)
-	fouArgs := make([]string, 0)
-	klog.V(2).Infof("Checking FOU Port and Proto... %s - %t", strPort, isIPv6)
-
-	if isIPv6 {
-		fouArgs = append(fouArgs, ipRoute2IPv6Prefix)
-	}
-	fouArgs = append(fouArgs, "fou", "show")
-
-	out, err := exec.Command("ip", fouArgs...).CombinedOutput()
-	// iproute2 returns an error if no fou configuration exists
-	if err != nil {
-		return false
-	}
-
-	strOut := string(out)
-	klog.V(2).Infof("Combined output of ip fou show: %s", strOut)
-	scanner := bufio.NewScanner(strings.NewReader(strOut))
-
-	// loop over all lines of output
-	for scanner.Scan() {
-		scannedLine := scanner.Text()
-		// if the output doesn't contain our port at all, then continue
-		if !strings.Contains(scannedLine, strPort) {
-			continue
-		}
-
-		// if this is IPv6 port and it has the correct IPv6 suffix (see example above) then return true
-		if isIPv6 && strings.HasSuffix(scannedLine, ipRoute2IPv6Prefix) {
-			return true
-		}
-
-		// if this is not IPv6 and it does not have an IPv6 suffix (see example above) then return true
-		if !isIPv6 && !strings.HasSuffix(scannedLine, ipRoute2IPv6Prefix) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// linkFOUEnabled checks to see whether the given link has FoU (Foo over Ethernet) enabled on it, specifically since
-// kube-router only works with GUE (Generic UDP Encapsulation) we look for that and not just FoU in general. If the
-// linkName is enabled with FoU GUE then we return true, otherwise false
-//
-// Output for a FoU Enabled GUE tunnel looks like:
-// ipip ipip remote <ip> local <ip> dev <dev> ttl 225 pmtudisc encap gue encap-sport auto encap-dport 5555 ...
-// Output for a normal IPIP tunnel looks like:
-// ipip ipip remote <ip> local <ip> dev <dev> ttl inherit ...
-func linkFOUEnabled(linkName string) bool {
-	const fouEncapEnabled = "encap gue"
-	cmdArgs := []string{"-details", "link", "show", linkName}
-
-	out, err := exec.Command("ip", cmdArgs...).CombinedOutput()
-
-	if err != nil {
-		klog.Warningf("recevied an error while trying to look at the link details of %s, this shouldn't have happened",
-			linkName)
-		return false
-	}
-
-	if strings.Contains(string(out), fouEncapEnabled) {
-		return true
-	}
-
-	return false
 }

--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -2,22 +2,15 @@ package routing
 
 import (
 	"encoding/base64"
-	"encoding/binary"
-	"errors"
 	"fmt"
-	"hash/fnv"
 	"net"
-	"regexp"
 	"strconv"
 	"strings"
 
-	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	gobgpapi "github.com/osrg/gobgp/v3/api"
-	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
+
 	v1core "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
-
-	"github.com/vishvananda/netlink"
 )
 
 // Used for processing Annotations that may contain multiple items
@@ -115,108 +108,6 @@ func statementsEqualByName(a, b []*gobgpapi.Statement) bool {
 
 	// If we've made it through both loops then we know that the statements arrays are equal
 	return true
-}
-
-// generateRouterID will generate a router ID based upon the user's configuration (or lack there of) and the node's
-// primary IP address if the user has not specified. If the user has configured the router ID as "generate" then we
-// will generate a router ID based upon fnv hashing the node's primary IP address.
-func generateRouterID(nodeIPAware utils.NodeIPAware, configRouterID string) (string, error) {
-	switch {
-	case configRouterID == "generate":
-		h := fnv.New32a()
-		h.Write(nodeIPAware.GetPrimaryNodeIP())
-		hs := h.Sum32()
-		gip := make(net.IP, 4)
-		binary.BigEndian.PutUint32(gip, hs)
-		return gip.String(), nil
-	case configRouterID != "":
-		return configRouterID, nil
-	}
-
-	if nodeIPAware.GetPrimaryNodeIP().To4() == nil {
-		return "", errors.New("router-id must be specified when primary node IP is an IPv6 address")
-	}
-	return configRouterID, nil
-}
-
-// validateCommunity takes in a string and attempts to parse a BGP community out of it in a way that is similar to
-// gobgp (internal/pkg/table/policy.go:ParseCommunity()). If it is not able to parse the community information it
-// returns an error.
-func validateCommunity(arg string) error {
-	_, err := strconv.ParseUint(arg, 10, bgpCommunityMaxSize)
-	if err == nil {
-		return nil
-	}
-
-	_regexpCommunity := regexp.MustCompile(`(\d+):(\d+)`)
-	elems := _regexpCommunity.FindStringSubmatch(arg)
-	if len(elems) == 3 {
-		if _, err := strconv.ParseUint(elems[1], 10, bgpCommunityMaxPartSize); err == nil {
-			if _, err = strconv.ParseUint(elems[2], 10, bgpCommunityMaxPartSize); err == nil {
-				return nil
-			}
-		}
-	}
-	for _, v := range bgp.WellKnownCommunityNameMap {
-		if arg == v {
-			return nil
-		}
-	}
-	return fmt.Errorf("failed to parse %s as community", arg)
-}
-
-// parseBGPNextHop takes in a GoBGP Path and parses out the destination's next hop from its attributes. If it
-// can't parse a next hop IP from the GoBGP Path, it returns an error.
-func parseBGPNextHop(path *gobgpapi.Path) (net.IP, error) {
-	for _, pAttr := range path.GetPattrs() {
-		unmarshalNew, err := pAttr.UnmarshalNew()
-		if err != nil {
-			return nil, fmt.Errorf("failed to unmarshal path attribute: %s", err)
-		}
-		switch t := unmarshalNew.(type) {
-		case *gobgpapi.NextHopAttribute:
-			// This is the primary way that we receive NextHops and happens when both the client and the server exchange
-			// next hops on the same IP family that they negotiated BGP on
-			nextHopIP := net.ParseIP(t.NextHop)
-			if nextHopIP != nil && (nextHopIP.To4() != nil || nextHopIP.To16() != nil) {
-				return nextHopIP, nil
-			}
-			return nil, fmt.Errorf("invalid nextHop address: %s", t.NextHop)
-		case *gobgpapi.MpReachNLRIAttribute:
-			// in the case where the server and the client are exchanging next-hops that don't relate to their primary
-			// IP family, we get MpReachNLRIAttribute instead of NextHopAttributes
-			// TODO: here we only take the first next hop, at some point in the future it would probably be best to
-			// consider multiple next hops
-			nextHopIP := net.ParseIP(t.NextHops[0])
-			if nextHopIP != nil && (nextHopIP.To4() != nil || nextHopIP.To16() != nil) {
-				return nextHopIP, nil
-			}
-			return nil, fmt.Errorf("invalid nextHop address: %s", t.NextHops[0])
-		}
-	}
-	return nil, fmt.Errorf("could not parse next hop received from GoBGP for path: %s", path)
-}
-
-// parseBGPPath takes in a GoBGP Path and parses out the destination subnet and the next hop from its attributes.
-// If successful, it will return the destination of the BGP path as a subnet form and the next hop. If it
-// can't parse the destination or the next hop IP, it returns an error.
-func parseBGPPath(path *gobgpapi.Path) (*net.IPNet, net.IP, error) {
-	nextHop, err := parseBGPNextHop(path)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	nlri := path.GetNlri()
-	var prefix gobgpapi.IPAddressPrefix
-	err = nlri.UnmarshalTo(&prefix)
-	if err != nil {
-		return nil, nil, fmt.Errorf("invalid nlri in advertised path")
-	}
-	dstSubnet, err := netlink.ParseIPNet(prefix.Prefix + "/" + fmt.Sprint(prefix.PrefixLen))
-	if err != nil {
-		return nil, nil, fmt.Errorf("couldn't parse IP subnet from nlri advertised path")
-	}
-	return dstSubnet, nextHop, nil
 }
 
 // getPodCIDRsFromAllNodeSources gets the pod CIDRs for all available sources on a given node in a specific order. The

--- a/pkg/controllers/routing/utils_test.go
+++ b/pkg/controllers/routing/utils_test.go
@@ -50,35 +50,3 @@ func Test_stringSliceToIPNets(t *testing.T) {
 		assert.Nil(t, ips)
 	})
 }
-
-func Test_validateCommunity(t *testing.T) {
-	t.Run("BGP community specified as a 32-bit integer should pass validation", func(t *testing.T) {
-		assert.Nil(t, validateCommunity("4294967041"))
-		assert.Nil(t, validateCommunity("4294967295"))
-	})
-	t.Run("BGP community specified as 2 16-bit integers should pass validation", func(t *testing.T) {
-		assert.Nil(t, validateCommunity("65535:65281"))
-		assert.Nil(t, validateCommunity("65535:65535"))
-	})
-	t.Run("Well known BGP communities passed as a string should pass validation", func(t *testing.T) {
-		assert.Nil(t, validateCommunity("no-export"))
-		assert.Nil(t, validateCommunity("internet"))
-		assert.Nil(t, validateCommunity("planned-shut"))
-		assert.Nil(t, validateCommunity("accept-own"))
-		assert.Nil(t, validateCommunity("blackhole"))
-		assert.Nil(t, validateCommunity("no-advertise"))
-		assert.Nil(t, validateCommunity("no-peer"))
-	})
-	t.Run("BGP community that is greater than 32-bit integer should fail validation", func(t *testing.T) {
-		assert.Error(t, validateCommunity("4294967296"))
-	})
-	t.Run("BGP community that is greater than 2 16-bit integers should fail validation", func(t *testing.T) {
-		assert.Error(t, validateCommunity("65536:65535"))
-		assert.Error(t, validateCommunity("65535:65536"))
-		assert.Error(t, validateCommunity("65536:65536"))
-	})
-	t.Run("BGP community that is not a number should fail validation", func(t *testing.T) {
-		assert.Error(t, validateCommunity("0xFFFFFFFF"))
-		assert.Error(t, validateCommunity("community"))
-	})
-}

--- a/pkg/routes/linux_routes.go
+++ b/pkg/routes/linux_routes.go
@@ -1,0 +1,32 @@
+package routes
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// Taken from: https://github.com/torvalds/linux/blob/master/include/uapi/linux/rtnetlink.h#L284
+	ZebraOriginator = 0x11
+)
+
+// DeleteByDestination attempts to safely find all routes based upon its destination subnet and delete them
+func DeleteByDestination(destinationSubnet *net.IPNet) error {
+	routes, err := netlink.RouteListFiltered(nl.FAMILY_ALL, &netlink.Route{
+		Dst: destinationSubnet, Protocol: ZebraOriginator,
+	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_PROTOCOL)
+	if err != nil {
+		return fmt.Errorf("failed to get routes from netlink: %v", err)
+	}
+	for i, r := range routes {
+		klog.V(2).Infof("Found route to remove: %s", r.String())
+		if err = netlink.RouteDel(&routes[i]); err != nil {
+			return fmt.Errorf("failed to remove route due to %v", err)
+		}
+	}
+	return nil
+}

--- a/pkg/routes/pbr.go
+++ b/pkg/routes/pbr.go
@@ -15,20 +15,16 @@ const (
 	CustomTableName = "kube-router"
 )
 
-type PBR struct {
+// PolicyBasedRules is a struct that holds all of the information needed for manipulating policy based routing rules
+type PolicyBasedRules struct {
 	nfa          utils.NodeFamilyAware
 	podIPv4CIDRs []string
 	podIPv6CIDRs []string
 }
 
-type PBRer interface {
-	EnablePolicyBasedRouting() error
-	DisablePolicyBasedRouting() error
-}
-
-// NewPBR creates a new PBR object which will be used to manipulate policy based routing rules
-func NewPBR(nfa utils.NodeFamilyAware, podIPv4CIDRs, podIPv6CIDRs []string) *PBR {
-	return &PBR{
+// NewPolicyBasedRules creates a new PBR object which will be used to manipulate policy based routing rules
+func NewPolicyBasedRules(nfa utils.NodeFamilyAware, podIPv4CIDRs, podIPv6CIDRs []string) *PolicyBasedRules {
+	return &PolicyBasedRules{
 		nfa:          nfa,
 		podIPv4CIDRs: podIPv4CIDRs,
 		podIPv6CIDRs: podIPv6CIDRs,
@@ -60,9 +56,9 @@ func ipRuleAbstraction(ipProtocol, ipOp, cidr string) error {
 	return nil
 }
 
-// setup a custom routing table that will be used for policy based routing to ensure traffic originating
-// on tunnel interface only leaves through tunnel interface irrespective rp_filter enabled/disabled
-func (pbr *PBR) EnablePolicyBasedRouting() error {
+// Enable setup a custom routing table that will be used for policy based routing to ensure traffic
+// originating on tunnel interface only leaves through tunnel interface irrespective rp_filter enabled/disabled
+func (pbr *PolicyBasedRules) Enable() error {
 	err := utils.RouteTableAdd(CustomTableID, CustomTableName)
 	if err != nil {
 		return fmt.Errorf("failed to update rt_tables file: %s", err)
@@ -86,7 +82,8 @@ func (pbr *PBR) EnablePolicyBasedRouting() error {
 	return nil
 }
 
-func (pbr *PBR) DisablePolicyBasedRouting() error {
+// Disable removes the custom routing table that was used for policy based routing
+func (pbr *PolicyBasedRules) Disable() error {
 	err := utils.RouteTableAdd(CustomTableID, CustomTableName)
 	if err != nil {
 		return fmt.Errorf("failed to update rt_tables file: %s", err)

--- a/pkg/routes/route_sync.go
+++ b/pkg/routes/route_sync.go
@@ -9,14 +9,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// RouteSyncer is an interface that defines the methods needed to sync routes to the kernel's routing table
-type RouteSyncer interface {
-	AddInjectedRoute(dst *net.IPNet, route *netlink.Route)
-	DelInjectedRoute(dst *net.IPNet)
-	Run(stopCh <-chan struct{}, wg *sync.WaitGroup)
-	SyncLocalRouteTable()
-}
-
 // RouteSync is a struct that holds all of the information needed for syncing routes to the kernel's routing table
 type RouteSync struct {
 	routeTableStateMap       map[string]*netlink.Route

--- a/pkg/routes/route_sync.go
+++ b/pkg/routes/route_sync.go
@@ -1,4 +1,4 @@
-package routing
+package routes
 
 import (
 	"net"
@@ -9,7 +9,16 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type routeSyncer struct {
+// RouteSyncer is an interface that defines the methods needed to sync routes to the kernel's routing table
+type RouteSyncer interface {
+	AddInjectedRoute(dst *net.IPNet, route *netlink.Route)
+	DelInjectedRoute(dst *net.IPNet)
+	Run(stopCh <-chan struct{}, wg *sync.WaitGroup)
+	SyncLocalRouteTable()
+}
+
+// RouteSync is a struct that holds all of the information needed for syncing routes to the kernel's routing table
+type RouteSync struct {
 	routeTableStateMap       map[string]*netlink.Route
 	injectedRoutesSyncPeriod time.Duration
 	mutex                    sync.Mutex
@@ -17,7 +26,7 @@ type routeSyncer struct {
 }
 
 // addInjectedRoute adds a route to the route map that is regularly synced to the kernel's routing table
-func (rs *routeSyncer) addInjectedRoute(dst *net.IPNet, route *netlink.Route) {
+func (rs *RouteSync) AddInjectedRoute(dst *net.IPNet, route *netlink.Route) {
 	rs.mutex.Lock()
 	defer rs.mutex.Unlock()
 	klog.V(3).Infof("Adding route for destination: %s", dst)
@@ -25,7 +34,7 @@ func (rs *routeSyncer) addInjectedRoute(dst *net.IPNet, route *netlink.Route) {
 }
 
 // delInjectedRoute delete a route from the route map that is regularly synced to the kernel's routing table
-func (rs *routeSyncer) delInjectedRoute(dst *net.IPNet) {
+func (rs *RouteSync) DelInjectedRoute(dst *net.IPNet) {
 	rs.mutex.Lock()
 	defer rs.mutex.Unlock()
 	if _, ok := rs.routeTableStateMap[dst.String()]; ok {
@@ -35,7 +44,7 @@ func (rs *routeSyncer) delInjectedRoute(dst *net.IPNet) {
 }
 
 // syncLocalRouteTable iterates over the local route state map and syncs all routes to the kernel's routing table
-func (rs *routeSyncer) syncLocalRouteTable() {
+func (rs *RouteSync) SyncLocalRouteTable() {
 	rs.mutex.Lock()
 	defer rs.mutex.Unlock()
 	klog.V(2).Infof("Running local route table synchronization")
@@ -49,7 +58,7 @@ func (rs *routeSyncer) syncLocalRouteTable() {
 }
 
 // run starts a goroutine that calls syncLocalRouteTable on interval injectedRoutesSyncPeriod
-func (rs *routeSyncer) run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
+func (rs *RouteSync) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 	// Start route synchronization routine
 	wg.Add(1)
 	go func(stopCh <-chan struct{}, wg *sync.WaitGroup) {
@@ -59,7 +68,7 @@ func (rs *routeSyncer) run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 		for {
 			select {
 			case <-t.C:
-				rs.syncLocalRouteTable()
+				rs.SyncLocalRouteTable()
 			case <-stopCh:
 				klog.Infof("Shutting down local route synchronization")
 				return
@@ -68,10 +77,10 @@ func (rs *routeSyncer) run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 	}(stopCh, wg)
 }
 
-// newRouteSyncer creates a new routeSyncer that, when run, will sync routes kept in its local state table every
+// NewRouteSyncer creates a new routeSyncer that, when run, will sync routes kept in its local state table every
 // syncPeriod
-func newRouteSyncer(syncPeriod time.Duration) *routeSyncer {
-	rs := routeSyncer{}
+func NewRouteSyncer(syncPeriod time.Duration) *RouteSync {
+	rs := RouteSync{}
 	rs.routeTableStateMap = make(map[string]*netlink.Route)
 	rs.injectedRoutesSyncPeriod = syncPeriod
 	rs.mutex = sync.Mutex{}

--- a/pkg/tunnels/linux_tunnels.go
+++ b/pkg/tunnels/linux_tunnels.go
@@ -70,7 +70,7 @@ func ParseEncapType(encapType string) (EncapType, error) {
 type EncapPort uint16
 
 func (e EncapPort) checkWithinRange() error {
-	if uint16(e) > minPort && uint16(e) < maxPort {
+	if uint16(e) >= minPort {
 		return nil
 	}
 	return fmt.Errorf("specified encap port is out of range of valid ports: %d, valid range is from %d to %d",

--- a/pkg/tunnels/linux_tunnels.go
+++ b/pkg/tunnels/linux_tunnels.go
@@ -1,0 +1,368 @@
+package tunnels
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"fmt"
+	"net"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/cloudnativelabs/kube-router/v2/pkg/routes"
+	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
+	"github.com/vishvananda/netlink"
+	"k8s.io/klog/v2"
+)
+
+const (
+	EncapTypeFOU  = EncapType("fou")
+	EncapTypeIPIP = EncapType("ipip")
+
+	// FOU modes used for the iproute2 tooling
+	fouIPv4LinkMode = "ipip"
+	fouIPv6LinkMode = "ip6tnl"
+
+	// IPIP modes used for the iproute2 tooling
+	ipipIPv4Mode = "ipip"
+	ipipIPv6Mode = "ip6ip6"
+
+	// The maximum and minimum port numbers for encap ports
+	maxPort = uint16(65535)
+	minPort = uint16(1024)
+)
+
+var (
+	validEncapTypes = []EncapType{EncapTypeFOU, EncapTypeIPIP}
+)
+
+// EncapType represents the type of encapsulation used for an overlay tunnel in kube-router.
+type EncapType string
+
+// IsValid checks if the encapsulation type is valid by comparing it against a list of valid types.
+// It returns true if the encapsulation type is valid, otherwise it returns false.
+func (e EncapType) IsValid() bool {
+	for _, validType := range validEncapTypes {
+		if e == validType {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseEncapType parses the given string and returns an Encap type if valid.
+// It returns an error if the encapsulation type is invalid.
+//
+// Parameters:
+//   - s: A string representing the encapsulation type.
+//
+// Returns:
+//   - Encap: The parsed encapsulation type.
+//   - error: An error if the encapsulation type is invalid.
+func ParseEncapType(encapType string) (EncapType, error) {
+	encap := EncapType(encapType)
+	if !encap.IsValid() {
+		return "", fmt.Errorf("invalid encapsulation type: %s", encapType)
+	}
+	return encap, nil
+}
+
+type EncapPort uint16
+
+func (e EncapPort) checkWithinRange() error {
+	if uint16(e) > minPort && uint16(e) < maxPort {
+		return nil
+	}
+	return fmt.Errorf("specified encap port is out of range of valid ports: %d, valid range is from %d to %d",
+		e, minPort, maxPort)
+}
+
+func ParseEncapPort(encapPort uint16) (EncapPort, error) {
+	port := EncapPort(encapPort)
+	if err := port.checkWithinRange(); err != nil {
+		return 0, err
+	}
+	return port, nil
+}
+
+type Tunneler interface {
+	SetupOverlayTunnel(tunnelName string, nextHop net.IP, nextHopSubnet *net.IPNet) (netlink.Link, error)
+	EncapType() EncapType
+	EncapPort() EncapPort
+}
+
+type OverlayTunnel struct {
+	krNode           utils.NodeIPAndFamilyAware
+	overlayEncapPort EncapPort
+	overlayEncap     EncapType
+}
+
+func NewOverlayTunnel(krNode utils.NodeIPAndFamilyAware, overlayEncap EncapType,
+	overlayEncapPort EncapPort) *OverlayTunnel {
+	return &OverlayTunnel{
+		krNode:           krNode,
+		overlayEncapPort: overlayEncapPort,
+		overlayEncap:     overlayEncap,
+	}
+}
+
+func (o *OverlayTunnel) EncapType() EncapType {
+	return o.overlayEncap
+}
+
+func (o *OverlayTunnel) EncapPort() EncapPort {
+	return o.overlayEncapPort
+}
+
+// setupOverlayTunnel attempts to create a tunnel link and corresponding routes for IPIP based overlay networks
+func (o *OverlayTunnel) SetupOverlayTunnel(tunnelName string, nextHop net.IP,
+	nextHopSubnet *net.IPNet) (netlink.Link, error) {
+	var out []byte
+	link, err := netlink.LinkByName(tunnelName)
+
+	var bestIPForFamily net.IP
+	var ipipMode, fouLinkType string
+	isIPv6 := false
+	ipBase := make([]string, 0)
+	strFormattedEncapPort := strconv.FormatInt(int64(o.overlayEncapPort), 10)
+
+	if nextHop.To4() != nil {
+		bestIPForFamily = o.krNode.FindBestIPv4NodeAddress()
+		ipipMode = ipipIPv4Mode
+		fouLinkType = fouIPv4LinkMode
+	} else {
+		// Need to activate the ip command in IPv6 mode
+		ipBase = append(ipBase, "-6")
+		bestIPForFamily = o.krNode.FindBestIPv6NodeAddress()
+		ipipMode = ipipIPv6Mode
+		fouLinkType = fouIPv6LinkMode
+		isIPv6 = true
+	}
+	if nil == bestIPForFamily {
+		return nil, fmt.Errorf("not able to find an appropriate configured IP address on node for destination "+
+			"IP family: %s", nextHop.String())
+	}
+
+	// This indicated that the tunnel already exists, so it's possible that there might be nothing more needed. However,
+	// it is also possible that the user changed the encap type, so we need to make sure that the encap type matches
+	// and if it doesn't, create it
+	recreate := false
+	if err == nil {
+		klog.V(1).Infof("Tunnel interface: %s with encap type %s for the node %s already exists.",
+			tunnelName, link.Attrs().EncapType, nextHop.String())
+
+		switch o.overlayEncap {
+		case EncapTypeIPIP:
+			if linkFOUEnabled(tunnelName) {
+				klog.Infof("Was configured to use ipip tunnels, but found existing fou tunnels in place, cleaning up")
+				recreate = true
+
+				// Even though we are setup for IPIP tunels we have existing tunnels that are FoU tunnels, remove them
+				// so that we can recreate them as IPIP
+				CleanupTunnel(nextHopSubnet, tunnelName)
+
+				// If we are transitioning from FoU to IPIP we also need to clean up the old FoU port if it exists
+				if fouPortAndProtoExist(o.overlayEncapPort, isIPv6) {
+					fouArgs := ipBase
+					fouArgs = append(fouArgs, "fou", "del", "port", strFormattedEncapPort)
+					out, err := exec.Command("ip", fouArgs...).CombinedOutput()
+					if err != nil {
+						klog.Warningf("failed to clean up previous FoU tunnel port (this is only a warning because it "+
+							"won't stop kube-router from working for now, but still shouldn't have happened) - error: "+
+							"%v, output %s", err, out)
+					}
+				}
+			}
+		case EncapTypeFOU:
+			if !linkFOUEnabled(tunnelName) {
+				klog.Infof("Was configured to use fou tunnels, but found existing ipip tunnels in place, cleaning up")
+				recreate = true
+				// Even though we are setup for FoU tunels we have existing tunnels that are IPIP tunnels, remove them
+				// so that we can recreate them as IPIP
+				CleanupTunnel(nextHopSubnet, tunnelName)
+			}
+		}
+	}
+
+	// an error here indicates that the tunnel didn't exist, so we need to create it, if it already exists there's
+	// nothing to do here
+	if err != nil || recreate {
+		klog.Infof("Creating tunnel %s of type %s with encap %s for destination %s",
+			tunnelName, fouLinkType, o.overlayEncap, nextHop.String())
+		cmdArgs := ipBase
+		switch o.overlayEncap {
+		case EncapTypeIPIP:
+			// Plain IPIP tunnel without any encapsulation
+			cmdArgs = append(cmdArgs, "tunnel", "add", tunnelName, "mode", ipipMode, "local", bestIPForFamily.String(),
+				"remote", nextHop.String())
+
+		case EncapTypeFOU:
+			// Ensure that the FOU tunnel port is set correctly
+			if !fouPortAndProtoExist(o.overlayEncapPort, isIPv6) {
+				fouArgs := ipBase
+				fouArgs = append(fouArgs, "fou", "add", "port", strFormattedEncapPort, "gue")
+				out, err := exec.Command("ip", fouArgs...).CombinedOutput()
+				if err != nil {
+					//nolint:goconst // don't need to make error messages a constant
+					return nil, fmt.Errorf("route not injected for the route advertised by the node %s "+
+						"Failed to set FoU tunnel port - error: %s, output: %s", tunnelName, err, string(out))
+				}
+			}
+
+			// Prep IPIP tunnel for FOU encapsulation
+			cmdArgs = append(cmdArgs, "link", "add", "name", tunnelName, "type", fouLinkType, "remote", nextHop.String(),
+				"local", bestIPForFamily.String(), "ttl", "225", "encap", "gue", "encap-sport", "auto", "encap-dport",
+				strFormattedEncapPort, "mode", ipipMode)
+
+		default:
+			return nil, fmt.Errorf("unknown tunnel encapsulation was passed: %s, unable to continue with overlay "+
+				"setup", o.overlayEncap)
+		}
+
+		klog.V(2).Infof("Executing the following command to create tunnel: ip %s", cmdArgs)
+		out, err := exec.Command("ip", cmdArgs...).CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("route not injected for the route advertised by the node %s "+
+				"Failed to create tunnel interface %s. error: %s, output: %s",
+				nextHop, tunnelName, err, string(out))
+		}
+
+		link, err = netlink.LinkByName(tunnelName)
+		if err != nil {
+			return nil, fmt.Errorf("route not injected for the route advertised by the node %s "+
+				"Failed to get tunnel interface by name error: %s", tunnelName, err)
+		}
+		if err = netlink.LinkSetUp(link); err != nil {
+			return nil, fmt.Errorf("failed to bring tunnel interface %s up due to: %v", tunnelName, err)
+		}
+	}
+
+	// Now that the tunnel link exists, we need to add a route to it, so the node knows where to send traffic bound for
+	// this interface
+	//nolint:gocritic // we understand that we are appending to a new slice
+	cmdArgs := append(ipBase, "route", "list", "table", routes.CustomTableID)
+	out, err = exec.Command("ip", cmdArgs...).CombinedOutput()
+	// This used to be "dev "+tunnelName+" scope" but this isn't consistent with IPv6's output, so we changed it to just
+	// "dev "+tunnelName, but at this point I'm unsure if there was a good reason for adding scope on before, so that's
+	// why this comment is here.
+	if err != nil || !strings.Contains(string(out), "dev "+tunnelName) {
+		//nolint:gocritic // we understand that we are appending to a new slice
+		cmdArgs = append(ipBase, "route", "add", nextHop.String(), "dev", tunnelName, "table", routes.CustomTableID)
+		if out, err = exec.Command("ip", cmdArgs...).CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("failed to add route in custom route table, err: %s, output: %s", err, string(out))
+		}
+	}
+
+	return link, nil
+}
+
+// cleanupTunnel removes any traces of tunnels / routes that were setup by nrc.setupOverlayTunnel() and are no longer
+// needed. All errors are logged only, as we want to attempt to perform all cleanup actions regardless of their success
+func CleanupTunnel(destinationSubnet *net.IPNet, tunnelName string) {
+	klog.V(1).Infof("Cleaning up old routes for %s if there are any", destinationSubnet.String())
+	if err := routes.DeleteByDestination(destinationSubnet); err != nil {
+		klog.Errorf("Failed to cleanup routes: %v", err)
+	}
+
+	klog.V(1).Infof("Cleaning up any lingering tunnel interfaces named: %s", tunnelName)
+	if link, err := netlink.LinkByName(tunnelName); err == nil {
+		if err = netlink.LinkDel(link); err != nil {
+			klog.Errorf("Failed to delete tunnel link for the node due to " + err.Error())
+		}
+	}
+}
+
+// GenerateTunnelName will generate a name for a tunnel interface given a node IP
+// Since linux restricts interface names to 15 characters, we take the sha-256 of the node IP after removing
+// non-entropic characters like '.' and ':', and then use the first 12 bytes of it. This allows us to cater to both
+// long IPv4 addresses and much longer IPv6 addresses.
+func GenerateTunnelName(nodeIP string) string {
+	// remove dots from an IPv4 address
+	strippedIP := strings.ReplaceAll(nodeIP, ".", "")
+	// remove colons from an IPv6 address
+	strippedIP = strings.ReplaceAll(strippedIP, ":", "")
+
+	h := sha256.New()
+	h.Write([]byte(strippedIP))
+	sum := h.Sum(nil)
+
+	return "tun-" + fmt.Sprintf("%x", sum)[0:11]
+}
+
+// fouPortAndProtoExist checks to see if the given FoU port is already configured on the system via iproute2
+// tooling for the given protocol
+//
+// fou show, shows both IPv4 and IPv6 ports in the same show command, they look like:
+// port 5556 gue
+// port 5556 gue -6
+// where the only thing that distinguishes them is the -6 or not on the end
+// WARNING we're parsing a CLI tool here not an API, this may break at some point in the future
+func fouPortAndProtoExist(port EncapPort, isIPv6 bool) bool {
+	const ipRoute2IPv6Prefix = "-6"
+	strPort := strconv.FormatInt(int64(port), 10)
+	fouArgs := make([]string, 0)
+	klog.V(2).Infof("Checking FOU Port and Proto... %s - %t", strPort, isIPv6)
+
+	if isIPv6 {
+		fouArgs = append(fouArgs, ipRoute2IPv6Prefix)
+	}
+	fouArgs = append(fouArgs, "fou", "show")
+
+	out, err := exec.Command("ip", fouArgs...).CombinedOutput()
+	// iproute2 returns an error if no fou configuration exists
+	if err != nil {
+		return false
+	}
+
+	strOut := string(out)
+	klog.V(2).Infof("Combined output of ip fou show: %s", strOut)
+	scanner := bufio.NewScanner(strings.NewReader(strOut))
+
+	// loop over all lines of output
+	for scanner.Scan() {
+		scannedLine := scanner.Text()
+		// if the output doesn't contain our port at all, then continue
+		if !strings.Contains(scannedLine, strPort) {
+			continue
+		}
+
+		// if this is IPv6 port and it has the correct IPv6 suffix (see example above) then return true
+		if isIPv6 && strings.HasSuffix(scannedLine, ipRoute2IPv6Prefix) {
+			return true
+		}
+
+		// if this is not IPv6 and it does not have an IPv6 suffix (see example above) then return true
+		if !isIPv6 && !strings.HasSuffix(scannedLine, ipRoute2IPv6Prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// linkFOUEnabled checks to see whether the given link has FoU (Foo over Ethernet) enabled on it, specifically since
+// kube-router only works with GUE (Generic UDP Encapsulation) we look for that and not just FoU in general. If the
+// linkName is enabled with FoU GUE then we return true, otherwise false
+//
+// Output for a FoU Enabled GUE tunnel looks like:
+// ipip ipip remote <ip> local <ip> dev <dev> ttl 225 pmtudisc encap gue encap-sport auto encap-dport 5555 ...
+// Output for a normal IPIP tunnel looks like:
+// ipip ipip remote <ip> local <ip> dev <dev> ttl inherit ...
+func linkFOUEnabled(linkName string) bool {
+	const fouEncapEnabled = "encap gue"
+	cmdArgs := []string{"-details", "link", "show", linkName}
+
+	out, err := exec.Command("ip", cmdArgs...).CombinedOutput()
+
+	if err != nil {
+		klog.Warningf("recevied an error while trying to look at the link details of %s, this shouldn't have happened",
+			linkName)
+		return false
+	}
+
+	if strings.Contains(string(out), fouEncapEnabled) {
+		return true
+	}
+
+	return false
+}

--- a/pkg/tunnels/linux_tunnels_test.go
+++ b/pkg/tunnels/linux_tunnels_test.go
@@ -1,0 +1,40 @@
+package tunnels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GenerateTunnelName(t *testing.T) {
+	testcases := []struct {
+		name       string
+		nodeIP     string
+		tunnelName string
+	}{
+		{
+			"IP less than 12 characters after removing '.'",
+			"10.0.0.1",
+			"tun-e443169117a",
+		},
+		{
+			"IP has 12 characters after removing '.'",
+			"100.200.300.400",
+			"tun-9033d7906c7",
+		},
+		{
+			"IPv6 tunnel names are properly handled and consistent",
+			"2001:db8:42:2::/64",
+			"tun-ba56986ef05",
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			tunnelName := GenerateTunnelName(testcase.nodeIP)
+			assert.Lessf(t, len(tunnelName), 16, "the maximum length of the tunnel name should never exceed"+
+				"15 characters as 16 characters is the maximum length of a Unix interface name")
+			assert.Equal(t, testcase.tunnelName, tunnelName, "did not get expected tunnel interface name")
+		})
+	}
+}


### PR DESCRIPTION
@mrueg @jnummelin @twz123 @rbrtbnfgl

Another refactor PR that is attempting to pull functionality out of NetworkRoutesController in prep for some work that I want to do with `injectRoute()`.

This time instead of tossing the functionality into the `utils` package like I did with `node.go`, I'm attempting to be a bit more Go idiomatic and naming the packages appropriately. This also helps the function names to be a bit shorter as context can be derived from the package name.

Note that with the `routes` package I'm just barely scratching the surface of what I want to do there long term. Trying to keep these refactors at least a bit controlled so that they don't get too big. Ideally there would probably be a lot more functionality that would get put into that package. And also #1697 would probably get consolidated with that effort.

Any and all feedback is appreciated.