### PR TITLE
fix(dsr): change grpc resolver to passthrough

### DIFF
--- a/pkg/cri/remote_runtime.go
+++ b/pkg/cri/remote_runtime.go
@@ -41,7 +41,11 @@ func NewRemoteRuntimeService(endpoint string, connectionTimeout time.Duration) (
 
 	klog.V(4).Infof("[RuntimeService] got endpoint %s (proto=%s, path=%s)", endpoint, proto, addr)
 
-	if proto != "unix" {
+	if proto == "unix" {
+		// Every since grpc.DialContext was deprecated, we no longer get the passthrough resolver for free, so we need
+		// to add it manually. See: https://github.com/grpc/grpc-go/issues/1846 for more context
+		addr = "passthrough:///" + addr
+	} else {
 		return nil, errors.New("[RuntimeService] only unix socket is currently supported")
 	}
 


### PR DESCRIPTION
@mrueg 

When we used DialContext() before it was deprecated, it manually set the default resolver to passthrough. NewClient() appears to not do this, and then several versions of grpc ago, they defaulted to the DNS resolver which broke our DSR implementation with CRI compatible container engines.

I'm not 100% sure that there isn't a better way to specify this, but I spent 20 - 30 minutes poking around the gRPC code base and I don't think that I can see an easy way to do this outside of specifying it this way.

Furthermore, the project itself seems to advocate for this approach in comments like those on: https://github.com/grpc/grpc-go/issues/1846

Fixes: #1754