### PR TITLE
fix: avoid to use http.DefaultServeMux which includes defaults routes inited by go like /debug/pprof

### DIFF
--- a/pkg/healthcheck/health_controller.go
+++ b/pkg/healthcheck/health_controller.go
@@ -220,11 +220,17 @@ func (hc *HealthController) CheckHealth() bool {
 // RunServer starts the HealthController's server
 func (hc *HealthController) RunServer(stopCh <-chan struct{}, wg *sync.WaitGroup) {
 	defer wg.Done()
+
+	mux := http.NewServeMux()
+
 	srv := &http.Server{
 		Addr:              ":" + strconv.Itoa(int(hc.HealthPort)),
-		Handler:           http.DefaultServeMux,
-		ReadHeaderTimeout: 5 * time.Second}
-	http.HandleFunc("/healthz", hc.Handler)
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	mux.HandleFunc("/healthz", hc.Handler)
+
 	if hc.Config.HealthPort > 0 {
 		hc.HTTPEnabled = true
 		go func() {

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -260,13 +260,15 @@ func (mc *Controller) Run(healthChan chan<- *healthcheck.ControllerHeartbeat, st
 	DefaultRegisterer.MustRegister(BuildInfo)
 	DefaultRegisterer.MustRegister(ControllerIpvsMetricsExportTime)
 
+	mux := http.NewServeMux()
+
 	srv := &http.Server{
 		Addr:              mc.MetricsAddr + ":" + strconv.Itoa(int(mc.MetricsPort)),
-		Handler:           http.DefaultServeMux,
+		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second}
 
 	// add prometheus handler on metrics path
-	http.Handle(mc.MetricsPath, Handler())
+	mux.Handle(mc.MetricsPath, Handler())
 
 	go func() {
 		if err := srv.ListenAndServe(); err != nil {


### PR DESCRIPTION
https://cs.opensource.google/go/go/+/refs/tags/go1.23.3:src/net/http/pprof/pprof.go;l=100

metrics may just metrics

if enable pprof in metrics server, the flags `--enable-pprof` may be confused.