### PR TITLE
Added `ipset.Save()` at the start of `syncNetworkPolicyChains`

### DIFF
--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -98,6 +98,13 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 		}
 	}()
 
+	for _, ipset := range npc.ipSetHandlers {
+		err := ipset.Save()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	// run through all network policies
 	for _, policy := range networkPoliciesInfo {
 		currentPodIPs := make(map[api.IPFamily][]string)


### PR DESCRIPTION
This PR should fixes #1732 to refresh the rules before syncing the policy.