### PR TITLE
feat(options): add flag for GoBGP grpc port

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -86,7 +86,7 @@ Usage of kube-router:
       --enable-pod-egress                             SNAT traffic from Pods to destinations outside the cluster. (default true)
       --enable-pprof                                  Enables pprof for debugging performance and memory leak issues.
       --excluded-cidrs strings                        Excluded CIDRs are used to exclude IPVS rules from deletion.
-      --gobgp-admin-port uint16                       Port to connect to GoBGP for administrative purposes. (default 50051)
+      --gobgp-admin-port uint16                       Port to connect to GoBGP for administrative purposes. Setting this to 0 will disable the GoBGP gRPC server. (default 50051)
       --hairpin-mode                                  Add iptables rules for every Service Endpoint to support hairpin traffic.
       --health-port uint16                            Health check port, 0 = Disabled (default 20244)
   -h, --help                                          Print usage information.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -86,6 +86,7 @@ Usage of kube-router:
       --enable-pod-egress                             SNAT traffic from Pods to destinations outside the cluster. (default true)
       --enable-pprof                                  Enables pprof for debugging performance and memory leak issues.
       --excluded-cidrs strings                        Excluded CIDRs are used to exclude IPVS rules from deletion.
+      --gobgp-admin-port uint16                       Port to connect to GoBGP for administrative purposes. (default 50051)
       --hairpin-mode                                  Add iptables rules for every Service Endpoint to support hairpin traffic.
       --health-port uint16                            Health check port, 0 = Disabled (default 20244)
   -h, --help                                          Print usage information.

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -122,6 +122,7 @@ type NetworkRoutingController struct {
 	bgpServerStarted               bool
 	bgpHoldtime                    float64
 	bgpPort                        uint32
+	goBGPAdminPort                 uint16
 	bgpRRClient                    bool
 	bgpRRServer                    bool
 	bgpClusterID                   string
@@ -1017,7 +1018,8 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 	if grpcServer {
 		nrc.bgpServer = gobgp.NewBgpServer(
 			gobgp.GrpcListenAddress(net.JoinHostPort(nrc.krNode.GetPrimaryNodeIP().String(),
-				"50051") + "," + "127.0.0.1:50051"))
+				strconv.FormatUint(uint64(nrc.goBGPAdminPort), 10)) + "," +
+				fmt.Sprintf("127.0.0.1:%d", nrc.goBGPAdminPort)))
 	} else {
 		nrc.bgpServer = gobgp.NewBgpServer()
 	}
@@ -1404,6 +1406,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	nrc.CNIFirewallSetup = sync.NewCond(&sync.Mutex{})
 
 	nrc.bgpPort = kubeRouterConfig.BGPPort
+	nrc.goBGPAdminPort = kubeRouterConfig.GoBGPAdminPort
 
 	// Convert ints to uint32s
 	peerASNs := make([]uint32, 0)

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -1015,7 +1015,7 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 		}
 	}
 
-	if grpcServer {
+	if grpcServer && nrc.goBGPAdminPort != 0 {
 		nrc.bgpServer = gobgp.NewBgpServer(
 			gobgp.GrpcListenAddress(net.JoinHostPort(nrc.krNode.GetPrimaryNodeIP().String(),
 				strconv.FormatUint(uint64(nrc.goBGPAdminPort), 10)) + "," +

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -167,7 +167,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.GlobalHairpinMode, "hairpin-mode", false,
 		"Add iptables rules for every Service Endpoint to support hairpin traffic.")
 	fs.Uint16Var(&s.GoBGPAdminPort, "gobgp-admin-port", defaultGoBGPAdminPort,
-		"Port to connect to GoBGP for administrative purposes.")
+		"Port to connect to GoBGP for administrative purposes. Setting this to 0 will disable the GoBGP gRPC server.")
 	fs.Uint16Var(&s.HealthPort, "health-port", defaultHealthCheckPort, "Health check port, 0 = Disabled")
 	fs.BoolVarP(&s.HelpRequested, "help", "h", false,
 		"Print usage information.")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -13,6 +13,7 @@ const (
 	DefaultBgpHoldTime                   = 90 * time.Second
 	defaultHealthCheckPort               = 20244
 	defaultOverlayTunnelEncapPort uint16 = 5555
+	defaultGoBGPAdminPort         uint16 = 50051
 )
 
 type KubeRouterConfig struct {
@@ -42,6 +43,7 @@ type KubeRouterConfig struct {
 	ExternalIPCIDRs                []string
 	FullMeshMode                   bool
 	GlobalHairpinMode              bool
+	GoBGPAdminPort                 uint16
 	HealthPort                     uint16
 	HelpRequested                  bool
 	HostnameOverride               string
@@ -164,6 +166,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Excluded CIDRs are used to exclude IPVS rules from deletion.")
 	fs.BoolVar(&s.GlobalHairpinMode, "hairpin-mode", false,
 		"Add iptables rules for every Service Endpoint to support hairpin traffic.")
+	fs.Uint16Var(&s.GoBGPAdminPort, "gobgp-admin-port", defaultGoBGPAdminPort,
+		"Port to connect to GoBGP for administrative purposes.")
 	fs.Uint16Var(&s.HealthPort, "health-port", defaultHealthCheckPort, "Health check port, 0 = Disabled")
 	fs.BoolVarP(&s.HelpRequested, "help", "h", false,
 		"Print usage information.")


### PR DESCRIPTION
Introduces the option `--gobgp-admin-port` which allows for setting the port that will be used for exposing GoBGP's grpc port.

Fixes: #1816 