### PR TITLE
Support --master without --kubeconfig

### DIFF
--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -42,6 +42,7 @@ func NewKubeRouterDefault(config *options.KubeRouterConfig) (*KubeRouter, error)
 	version.PrintVersion(true)
 	version.PrintVersionMessages(true)
 	// Use out of cluster config if the kubeconfig has been specified. Otherwise use incluster config.
+	//nolint:gocritic // An if-elseif-else is more readable than a switch in this case.
 	if len(config.Kubeconfig) != 0 {
 		clientconfig, err = clientcmd.BuildConfigFromFlags(config.Master, config.Kubeconfig)
 		if err != nil {


### PR DESCRIPTION
If --master is specified, but --kubeconfig is not, use in-cluster config and override the API server host.

This would fix #1614.