### PR TITLE
fix(ipset): ignore non-kube-router ipsets

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -741,6 +741,10 @@ func (ips *fakeIPSet) Restore() error {
 	return nil
 }
 
+func (ips *fakeIPSet) RestoreSets(_ []string) error {
+	return nil
+}
+
 func (ips *fakeIPSet) Flush() error {
 	return nil
 }

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -152,9 +152,11 @@ func (npc *NetworkPolicyController) syncNetworkPolicyChains(networkPoliciesInfo 
 		}
 	}
 
+	knownIPSets := utils.ConvertMapKeysToSlice[string](activePolicyIPSets)
+
 	for ipFamily, ipset := range npc.ipSetHandlers {
 		restoreStart := time.Now()
-		err := ipset.Restore()
+		err := ipset.RestoreSets(knownIPSets)
 		restoreEndTime := time.Since(restoreStart)
 
 		if npc.MetricsEnabled {

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -710,7 +710,7 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 
 		setHandler.RefreshSet(serviceIPPortsSetName, serviceIPPortsIPSets[family], utils.TypeHashIPPort)
 
-		err := setHandler.Restore()
+		err := setHandler.RestoreSets([]string{serviceIPsIPSetName, serviceIPPortsSetName})
 		if err != nil {
 			return fmt.Errorf("could not save ipset for service firewall: %v", err)
 		}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -864,7 +864,7 @@ func (nrc *NetworkRoutingController) syncNodeIPSets() error {
 
 		ipSetHandler.RefreshSet(nodeAddrsIPSetName, currentNodeIPs[family], utils.TypeHashIP)
 
-		err = ipSetHandler.Restore()
+		err = ipSetHandler.RestoreSets([]string{podSubnetsIPSetName, nodeAddrsIPSetName})
 		if err != nil {
 			return fmt.Errorf("failed to sync pod subnets / node addresses ipsets: %v", err)
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -75,3 +75,14 @@ func TCPAddressBindable(addr string, port uint16) error {
 	}
 	return ln.Close()
 }
+
+// ConvertMapKeysToSlice takes a map with a set of keys and then extracts the keys into a slice of the same length
+func ConvertMapKeysToSlice[K comparable, V any](mapContainingKeys map[K]V) []K {
+	keys := make([]K, 0, len(mapContainingKeys))
+
+	for k := range mapContainingKeys {
+		keys = append(keys, k)
+	}
+
+	return keys
+}


### PR DESCRIPTION
Attempt to filter out sets that we are not authoritative for to avoid race conditions with other operators (like Istio) that might be attempting to modify ipsets at the same time.

This still needs some refinement and probably a refactor or two, but wanted to get it out early so that you could test it and see if it actually resolves what you were seeing in #1918. I tried it in my cluster, and after proving that I could see kube-router modifying other ipsets, then applied this change, and saw that it no longer contained references in its output.

FYI @mjnagel @ilrudie

Attempts to fix #1918 