### PR TITLE
fix(ipset): store kube-router-local-ips ipset

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -710,7 +710,7 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 
 		setHandler.RefreshSet(serviceIPPortsSetName, serviceIPPortsIPSets[family], utils.TypeHashIPPort)
 
-		err := setHandler.RestoreSets([]string{serviceIPsIPSetName, serviceIPPortsSetName})
+		err := setHandler.RestoreSets([]string{localIPsIPSetName, serviceIPsIPSetName, serviceIPPortsSetName})
 		if err != nil {
 			return fmt.Errorf("could not save ipset for service firewall: %v", err)
 		}


### PR DESCRIPTION
Fixed storing local IP addresses to kube-router-local-ips ipset

fix https://github.com/cloudnativelabs/kube-router/issues/1924