### PR TITLE
feat(test): use safecast.RequireConvert in tests

### DIFF
--- a/pkg/controllers/proxy/ipset_fixture_test.go
+++ b/pkg/controllers/proxy/ipset_fixture_test.go
@@ -149,10 +149,7 @@ func buildIPVSServicesFromFixtures(t *testing.T, services *v1.ServiceList) []*ip
 			require.GreaterOrEqualf(t, port.Port, int32(0), "service %s/%s has negative port %d", svc.Namespace, svc.Name, port.Port)
 			const maxServicePort = 1<<16 - 1
 			require.LessOrEqualf(t, port.Port, int32(maxServicePort), "service %s/%s port %d exceeds %d", svc.Namespace, svc.Name, port.Port, maxServicePort)
-			targetPort, err := safecast.Convert[uint16](port.Port)
-			if err != nil {
-				t.Fatalf("failed to convert port %d to uint16: %v", port.Port, err)
-			}
+			targetPort := safecast.RequireConvert[uint16](t, port.Port)
 
 			appendService := func(ipStr string) {
 				ip := net.ParseIP(ipStr)


### PR DESCRIPTION
I'm the owner and maintainer of [ccoVeille/go-safecast](https://github.com/ccoVeille/go-safecast)

This is somehow a follow-up of #1941

I have noticed you were checking the err returned in a safecast conversion in a test.

my lib supports RequireConvert that try to convert and fails the provided test.

This PR can be merged separately of #1942, either before or after.

[v1](https://pkg.go.dev/github.com/ccoveille/go-safecast#RequireConvert) and [v2](https://pkg.go.dev/github.com/ccoveille/go-safecast/v2#RequireConvert) supports RequireConvert

So it's safe.

Here my PR is just a suggestion.



