### PR TITLE
fix: embed root cause errors in returned errors

### DIFF
--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -183,12 +183,12 @@ func (n *KRNode) FindBestIPv4NodeAddress() net.IP {
 func (n *LocalKRNode) GetNodeMTU() (int, error) {
 	links, err := n.linkQ.LinkList()
 	if err != nil {
-		return 0, errors.New("failed to get list of links")
+		return 0, fmt.Errorf("failed to get list of links: %w", err)
 	}
 	for _, link := range links {
 		addresses, err := n.linkQ.AddrList(link, netlink.FAMILY_ALL)
 		if err != nil {
-			return 0, errors.New("failed to get list of addr")
+			return 0, fmt.Errorf("failed to get list of addr: %w", err)
 		}
 		for _, addr := range addresses {
 			if addr.IP.Equal(n.PrimaryIP) {
@@ -289,7 +289,7 @@ func GetNodeObject(clientset kubernetes.Interface, hostnameOverride string) (*ap
 	if hostnameOverride != "" {
 		node, err := clientset.CoreV1().Nodes().Get(context.Background(), hostnameOverride, metav1.GetOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("unable to get node %s, due to: %v", hostnameOverride, err)
+			return nil, fmt.Errorf("unable to get node %s, due to: %w", hostnameOverride, err)
 		}
 		return node, nil
 	}
@@ -299,7 +299,7 @@ func GetNodeObject(clientset kubernetes.Interface, hostnameOverride string) (*ap
 	if nodeName != "" {
 		node, err := clientset.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("unable to get node %s, due to: %v", nodeName, err)
+			return nil, fmt.Errorf("unable to get node %s, due to: %w", nodeName, err)
 		}
 		return node, nil
 	}
@@ -308,7 +308,7 @@ func GetNodeObject(clientset kubernetes.Interface, hostnameOverride string) (*ap
 	hostName, _ := os.Hostname()
 	node, err := clientset.CoreV1().Nodes().Get(context.Background(), hostName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to identify the node by NODE_NAME, %s or --hostname-override: %v", hostName, err)
+		return nil, fmt.Errorf("failed to identify the node by NODE_NAME, %s or --hostname-override: %w", hostName, err)
 	}
 
 	return node, nil
@@ -375,13 +375,13 @@ func GetNodeSubnet(nodeIP net.IP, linkQ LocalLinkQuerier) (net.IPNet, string, er
 
 	links, err := linkQ.LinkList()
 	if err != nil {
-		return net.IPNet{}, "", errors.New("failed to get list of links")
+		return net.IPNet{}, "", fmt.Errorf("failed to get list of links: %w", err)
 	}
 
 	for _, link := range links {
 		addresses, err := linkQ.AddrList(link, netlink.FAMILY_ALL)
 		if err != nil {
-			return net.IPNet{}, "", errors.New("failed to get list of addrs")
+			return net.IPNet{}, "", fmt.Errorf("failed to get list of addrs: %w", err)
 		}
 		for _, addr := range addresses {
 			if addr.IP.Equal(nodeIP) {

--- a/pkg/utils/node_test.go
+++ b/pkg/utils/node_test.go
@@ -842,11 +842,11 @@ func Test_GetNodeSubnet(t *testing.T) {
 			"error getting list of links",
 			net.ParseIP("10.0.0.1"),
 			func(myMock *MockLocalLinkQuerier) {
-				myMock.On("LinkList").Return([]netlink.Link{}, errors.New("failed to get list of links"))
+				myMock.On("LinkList").Return([]netlink.Link{}, errors.New("embedded LinkList error"))
 			},
 			net.IPNet{},
 			"",
-			errors.New("failed to get list of links"),
+			errors.New("failed to get list of links: embedded LinkList error"),
 		},
 		{
 			"error getting addrs",
@@ -855,11 +855,11 @@ func Test_GetNodeSubnet(t *testing.T) {
 				myMock.On("LinkList").Return(
 					[]netlink.Link{&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "eth0"}}}, nil)
 				myMock.On("AddrList", mock.Anything, mock.Anything).Return(
-					[]netlink.Addr{}, errors.New("failed to get list of addrs"))
+					[]netlink.Addr{}, errors.New("embedded LinkList error"))
 			},
 			net.IPNet{},
 			"",
-			errors.New("failed to get list of addrs"),
+			errors.New("failed to get list of addrs: embedded LinkList error"),
 		},
 	}
 


### PR DESCRIPTION
Always embed the root cause error on returned errors so that the root cause can be determined.

Fixes #1962 

FYI @zerkms

As an aside, I'm pretty sure that there are other places in the code besides node.go that drop the root cause errors, but I want to wait until we merge @catherinetcai's PR #1914 to get merged before I go through and clean up error handling across the entire code base as it will just cause a bunch or refactoring work if I do it now.