### PR TITLE
chore: Use context instead of deprecated golang.org/x/net/context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vishvananda/netns v0.0.5
-	golang.org/x/net v0.46.0
 	golang.org/x/sys v0.39.0
 	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.11
@@ -119,6 +118,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/net v0.46.0 // indirect
 	golang.org/x/oauth2 v0.31.0 // indirect
 	golang.org/x/term v0.36.0 // indirect
 	golang.org/x/text v0.30.0 // indirect

--- a/pkg/healthcheck/health_controller.go
+++ b/pkg/healthcheck/health_controller.go
@@ -6,8 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"context"
+
 	"github.com/cloudnativelabs/kube-router/v2/pkg/options"
-	"golang.org/x/net/context"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -7,12 +7,13 @@ import (
 	"sync"
 	"time"
 
+	"context"
+
 	"github.com/cloudnativelabs/kube-router/v2/pkg/healthcheck"
 	"github.com/cloudnativelabs/kube-router/v2/pkg/options"
 	"github.com/cloudnativelabs/kube-router/v2/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"golang.org/x/net/context"
 	"k8s.io/klog/v2"
 )
 


### PR DESCRIPTION
Just noticed that linting was failing on https://github.com/cloudnativelabs/kube-router/pull/1980 and https://github.com/cloudnativelabs/kube-router/pull/1979 on this