### PR TITLE
feat(gobgp): add kube_router_bgp_peer_info metric

### DIFF
--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -88,9 +88,6 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 	// get the current list of the nodes from API server
 	nodes := nrc.nodeLister.List()
 
-	if nrc.MetricsEnabled {
-		metrics.ControllerBPGpeers.Set(float64(len(nodes)))
-	}
 	// establish peer and add Pod CIDRs with current set of nodes
 	currentNodes := make([]string, 0)
 	for _, obj := range nodes {

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -436,6 +436,10 @@ func (nrc *NetworkRoutingController) Run(
 			nrc.syncInternalPeers()
 		}
 
+		if nrc.MetricsEnabled {
+			nrc.updateBGPPeerMetrics()
+		}
+
 		if err == nil {
 			healthcheck.SendHeartBeat(healthChan, healthcheck.NetworkRoutesController)
 		} else {
@@ -727,6 +731,23 @@ func (nrc *NetworkRoutingController) injectRoute(path *apiutil.Path) error {
 	nrc.routeSyncer.AddInjectedRoute(dst, route)
 	// Immediately sync the local route table regardless of timer
 	return nrc.routeSyncer.SyncLocalRouteTable()
+}
+
+func (nrc *NetworkRoutingController) updateBGPPeerMetrics() {
+	metrics.ControllerBGPPeerInfo.Reset()
+	err := nrc.bgpServer.ListPeer(context.Background(), &gobgpapi.ListPeerRequest{}, func(peer *gobgpapi.Peer) {
+		if peer.Conf == nil || peer.State == nil {
+			return
+		}
+		peerAddress := peer.Conf.NeighborAddress
+		peerType := strings.ToLower(strings.TrimPrefix(peer.State.GetType().String(), "PEER_TYPE_"))
+		peerASN := strconv.FormatUint(uint64(peer.Conf.PeerAsn), 10)
+		peerState := strings.ToLower(strings.TrimPrefix(peer.State.SessionState.String(), "SESSION_STATE_"))
+		metrics.ControllerBGPPeerInfo.WithLabelValues(peerAddress, peerType, peerASN, peerState).Set(1)
+	})
+	if err != nil {
+		klog.Errorf("error updating BGP peer metrics: %v", err)
+	}
 }
 
 func (nrc *NetworkRoutingController) isPeerEstablished(peerIP string) (bool, error) {
@@ -1227,7 +1248,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		metrics.DefaultRegisterer.MustRegister(metrics.ControllerBGPadvertisementsReceived)
 		metrics.DefaultRegisterer.MustRegister(metrics.ControllerBGPadvertisementsSent)
 		metrics.DefaultRegisterer.MustRegister(metrics.ControllerBGPInternalPeersSyncTime)
-		metrics.DefaultRegisterer.MustRegister(metrics.ControllerBPGpeers)
+		metrics.DefaultRegisterer.MustRegister(metrics.ControllerBGPPeerInfo)
 		metrics.DefaultRegisterer.MustRegister(metrics.ControllerRoutesSyncTime)
 		nrc.MetricsEnabled = true
 	}

--- a/pkg/metrics/metrics_controller.go
+++ b/pkg/metrics/metrics_controller.go
@@ -158,12 +158,12 @@ var (
 		Name:      "controller_routes_sync_time",
 		Help:      "Time it took for controller to sync routes",
 	})
-	// ControllerBPGpeers BGP peers in the runtime configuration
-	ControllerBPGpeers = prometheus.NewGauge(prometheus.GaugeOpts{
+	// ControllerBGPPeerInfo BGP peer information
+	ControllerBGPPeerInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespace,
-		Name:      "controller_bgp_peers",
-		Help:      "BGP peers in the runtime configuration",
-	})
+		Name:      "bgp_peer_info",
+		Help:      "BGP peer information",
+	}, []string{"address", "type", "asn", "state"})
 	// ControllerBGPInternalPeersSyncTime Time it took to sync internal bgp peers
 	ControllerBGPInternalPeersSyncTime = prometheus.NewHistogram(prometheus.HistogramOpts{
 		Namespace: namespace,


### PR DESCRIPTION
Replace the misleading kube_router_controller_bgp_peers gauge
  which only counts 'cluster nodes'. with a new per peer metric
  kube_router_bgp_peer_info with 'GaugeVec' that exposes actual
  BGP session state from gobgp. labels include peer address, asn,
  and session state. metric value is 1 if established and 0 otherwise.

Closes: https://github.com/cloudnativelabs/kube-router/issues/848