### PR TITLE
fix(NPC,LBC): harden network policy and load balancer controllers

### DIFF
--- a/pkg/controllers/lballoc/lballoc.go
+++ b/pkg/controllers/lballoc/lballoc.go
@@ -392,16 +392,25 @@ func (lbc *LoadBalancerController) allocateService(svc *v1core.Service) error {
 	if want6 && !have6 {
 		ipv6, err6 = lbc.ipv6Ranges.getNextFreeIP(allocated6)
 	}
-	err := err6
+
+	// If no allocation was needed, the service already has all requested IPs
+	if ipv4 == nil && ipv6 == nil && err4 == nil && err6 == nil {
+		return nil
+	}
+
+	var errs []error
 	if err4 != nil {
-		err = err4
+		errs = append(errs, fmt.Errorf("IPv4: %w", err4))
+	}
+	if err6 != nil {
+		errs = append(errs, fmt.Errorf("IPv6: %w", err6))
 	}
 
 	if ipv4 == nil && ipv6 == nil {
-		return fmt.Errorf("unable to allocate address: %w", err)
+		return fmt.Errorf("unable to allocate address: %w", errors.Join(errs...))
 	}
 	if (ipv4 == nil || ipv6 == nil) && requireDual {
-		return fmt.Errorf("unable to allocate dual-stack addresses: %w", err)
+		return fmt.Errorf("unable to allocate dual-stack addresses: %w", errors.Join(errs...))
 	}
 
 	// This is only non-nil during certain unit tests that need to understand when this goroutine is finished to remove

--- a/pkg/controllers/lballoc/lballoc_test.go
+++ b/pkg/controllers/lballoc/lballoc_test.go
@@ -596,7 +596,7 @@ func TestAllocateService(t *testing.T) {
 	fp := v1core.IPFamilyPolicyRequireDualStack
 	svc.Spec.IPFamilyPolicy = &fp
 	err = mlbc.allocateService(&svc)
-	errExp := "unable to allocate dual-stack addresses: no IPs left to allocate"
+	errExp := "unable to allocate dual-stack addresses: IPv4: no IPs left to allocate"
 	if errExp != err.Error() {
 		t.Fatalf("expected %s, got %s", errExp, err)
 	}
@@ -604,6 +604,7 @@ func TestAllocateService(t *testing.T) {
 	mlbc.ipv4Ranges = ir4
 	mlbc.ipv6Ranges = newipRanges(nil)
 	err = mlbc.allocateService(&svc)
+	errExp = "unable to allocate dual-stack addresses: IPv6: no IPs left to allocate"
 	if errExp != err.Error() {
 		t.Fatalf("expected %s, got %s", errExp, err)
 	}
@@ -612,11 +613,38 @@ func TestAllocateService(t *testing.T) {
 	fp = v1core.IPFamilyPolicyPreferDualStack
 	svc.Spec.IPFamilyPolicy = &fp
 	err = mlbc.allocateService(&svc)
-	errExp = "unable to allocate address: no IPs left to allocate"
+	errExp = "unable to allocate address: IPv4: no IPs left to allocate\nIPv6: no IPs left to allocate"
 	if errExp != err.Error() {
 		t.Fatalf("expected %s, got %s", errExp, err)
 	}
 
+}
+
+// TestAllocateServiceAlreadyAllocated covers the case where a service already has all
+// requested ingress IPs and no allocation is needed. Before the early-return guard in
+// allocateService, this path would fall through to the error check with nil IPs and nil
+// errors, producing a spurious error (or panic).
+func TestAllocateServiceAlreadyAllocated(t *testing.T) {
+	mlbc := &LoadBalancerController{
+		clientset:  fake.NewSimpleClientset(),
+		unitTestWG: &sync.WaitGroup{},
+	}
+	ir4, ir6 := makeIPRanges("127.127.127.127/30", "ffff::/80")
+	mlbc.ipv4Ranges = ir4
+	mlbc.ipv6Ranges = ir6
+	mi := newMockIndexer()
+	mlbc.svcLister = mi
+
+	svc := makeTestService()
+	// Give the service existing ingress IPs for both families so that
+	// allocateService has nothing to allocate.
+	appendIngressIP(&svc, net.ParseIP("127.127.127.127"))
+	appendIngressIP(&svc, net.ParseIP("ffff::1"))
+
+	err := mlbc.allocateService(&svc)
+	if err != nil {
+		t.Fatalf("expected nil error when service already has all IPs, got: %s", err)
+	}
 }
 
 type mockInformer struct {

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -4,11 +4,26 @@ import (
 	"crypto/sha256"
 	"encoding/base32"
 	"strings"
+	"unicode"
 
 	api "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
+
+// sanitizeForComment removes control characters (newlines, tabs, etc.) from a
+// string before it is embedded into an iptables-restore comment. This is a
+// defense-in-depth measure: Kubernetes API server validates pod/namespace names
+// to DNS label format, but we should not rely solely on external validation when
+// constructing input for iptables-restore.
+func sanitizeForComment(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
 
 func (npc *NetworkPolicyController) newPodEventHandler() cache.ResourceEventHandler {
 	return cache.ResourceEventHandlerFuncs{
@@ -88,7 +103,7 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 			}
 
 			// add rule to log the packets that will be dropped due to network policy enforcement
-			comment := "\"rule to log dropped traffic POD name:" + pod.name + " namespace: " + pod.namespace + "\""
+			comment := "\"rule to log dropped traffic POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) + "\""
 			args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
 				"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "NFLOG",
 				"--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10", "\n"}
@@ -100,8 +115,8 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 			filterTableRules.WriteString(strings.Join(args, " "))
 
 			// add rule to DROP if no applicable network policy permits the traffic
-			comment = "\"rule to REJECT traffic destined for POD name:" + pod.name + " namespace: " +
-				pod.namespace + "\""
+			comment = "\"rule to REJECT traffic destined for POD name:" + sanitizeForComment(pod.name) + " namespace: " +
+				sanitizeForComment(pod.namespace) + "\""
 			args = []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
 				"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "REJECT", "\n"}
 			filterTableRules.WriteString(strings.Join(args, " "))
@@ -188,7 +203,7 @@ func (npc *NetworkPolicyController) setupPodNetpolRules(pod podInfo, podFwChainN
 			if _, ok := policy.targetPods[pod.ip]; !ok {
 				continue
 			}
-			comment := "\"run through nw policy " + policy.name + "\""
+			comment := "\"run through nw policy " + sanitizeForComment(policy.name) + "\""
 			policyChainName := networkPolicyChainName(policy.namespace, policy.name, version, ipFamily)
 			var args []string
 			switch policy.policyType {
@@ -255,7 +270,7 @@ func (npc *NetworkPolicyController) interceptPodInboundTraffic(pod podInfo, podF
 
 		// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
 		// this rule applies to the traffic getting routed (coming for other node pods)
-		comment := "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
+		comment := "\"rule to jump traffic destined to POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) +
 			" to chain " + podFwChainName + "\""
 		args := []string{"-A", kubeForwardChainName, "-m", "comment", "--comment", comment, "-d", ip,
 			"-j", podFwChainName + "\n"}
@@ -269,7 +284,7 @@ func (npc *NetworkPolicyController) interceptPodInboundTraffic(pod podInfo, podF
 
 		// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
 		// this rule applies to the traffic getting switched (coming for same node pods)
-		comment = "\"rule to jump traffic destined to POD name:" + pod.name + " namespace: " + pod.namespace +
+		comment = "\"rule to jump traffic destined to POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) +
 			" to chain " + podFwChainName + "\""
 		args = []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
 			"-m", "comment", "--comment", comment,
@@ -294,7 +309,7 @@ func (npc *NetworkPolicyController) interceptPodOutboundTraffic(pod podInfo, pod
 			// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
 			// this rule applies to the traffic getting forwarded/routed (traffic from the pod destined
 			// to pod on a different node)
-			comment := "\"rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
+			comment := "\"rule to jump traffic from POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) +
 				" to chain " + podFwChainName + "\""
 			args := []string{"-A", chain, "-m", "comment", "--comment", comment, "-s", ip, "-j", podFwChainName, "\n"}
 			filterTableRules.WriteString(strings.Join(args, " "))
@@ -302,7 +317,7 @@ func (npc *NetworkPolicyController) interceptPodOutboundTraffic(pod podInfo, pod
 
 		// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
 		// this rule applies to the traffic getting switched (coming for same node pods)
-		comment := "\"rule to jump traffic from POD name:" + pod.name + " namespace: " + pod.namespace +
+		comment := "\"rule to jump traffic from POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) +
 			" to chain " + podFwChainName + "\""
 		args := []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
 			"-m", "comment", "--comment", comment,

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -103,7 +103,9 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 			}
 
 			// add rule to log the packets that will be dropped due to network policy enforcement
-			comment := "\"rule to log dropped traffic POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) + "\""
+			comment := "\"rule to log dropped traffic POD name:" +
+				sanitizeForComment(pod.name) + " namespace: " +
+				sanitizeForComment(pod.namespace) + "\""
 			args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
 				"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "NFLOG",
 				"--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10", "\n"}
@@ -270,7 +272,9 @@ func (npc *NetworkPolicyController) interceptPodInboundTraffic(pod podInfo, podF
 
 		// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
 		// this rule applies to the traffic getting routed (coming for other node pods)
-		comment := "\"rule to jump traffic destined to POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) +
+		comment := "\"rule to jump traffic destined to POD name:" +
+			sanitizeForComment(pod.name) + " namespace: " +
+			sanitizeForComment(pod.namespace) +
 			" to chain " + podFwChainName + "\""
 		args := []string{"-A", kubeForwardChainName, "-m", "comment", "--comment", comment, "-d", ip,
 			"-j", podFwChainName + "\n"}
@@ -284,7 +288,9 @@ func (npc *NetworkPolicyController) interceptPodInboundTraffic(pod podInfo, podF
 
 		// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
 		// this rule applies to the traffic getting switched (coming for same node pods)
-		comment = "\"rule to jump traffic destined to POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) +
+		comment = "\"rule to jump traffic destined to POD name:" +
+			sanitizeForComment(pod.name) + " namespace: " +
+			sanitizeForComment(pod.namespace) +
 			" to chain " + podFwChainName + "\""
 		args = []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
 			"-m", "comment", "--comment", comment,
@@ -309,7 +315,9 @@ func (npc *NetworkPolicyController) interceptPodOutboundTraffic(pod podInfo, pod
 			// ensure there is rule in filter table and FORWARD chain to jump to pod specific firewall chain
 			// this rule applies to the traffic getting forwarded/routed (traffic from the pod destined
 			// to pod on a different node)
-			comment := "\"rule to jump traffic from POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) +
+			comment := "\"rule to jump traffic from POD name:" +
+				sanitizeForComment(pod.name) + " namespace: " +
+				sanitizeForComment(pod.namespace) +
 				" to chain " + podFwChainName + "\""
 			args := []string{"-A", chain, "-m", "comment", "--comment", comment, "-s", ip, "-j", podFwChainName, "\n"}
 			filterTableRules.WriteString(strings.Join(args, " "))
@@ -317,7 +325,9 @@ func (npc *NetworkPolicyController) interceptPodOutboundTraffic(pod podInfo, pod
 
 		// ensure there is rule in filter table and forward chain to jump to pod specific firewall chain
 		// this rule applies to the traffic getting switched (coming for same node pods)
-		comment := "\"rule to jump traffic from POD name:" + sanitizeForComment(pod.name) + " namespace: " + sanitizeForComment(pod.namespace) +
+		comment := "\"rule to jump traffic from POD name:" +
+			sanitizeForComment(pod.name) + " namespace: " +
+			sanitizeForComment(pod.namespace) +
 			" to chain " + podFwChainName + "\""
 		args := []string{"-A", kubeForwardChainName, "-m", "physdev", "--physdev-is-bridged",
 			"-m", "comment", "--comment", comment,

--- a/pkg/controllers/netpol/pod_test.go
+++ b/pkg/controllers/netpol/pod_test.go
@@ -1,0 +1,58 @@
+package netpol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizeForComment(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "clean string passes through",
+			input: "my-pod-name",
+			want:  "my-pod-name",
+		},
+		{
+			name:  "newlines stripped",
+			input: "my-pod\n-A INJECT -j DROP\n",
+			want:  "my-pod-A INJECT -j DROP",
+		},
+		{
+			name:  "tabs stripped",
+			input: "my-pod\tinjected",
+			want:  "my-podinjected",
+		},
+		{
+			name:  "carriage return stripped",
+			input: "my-pod\rinjected",
+			want:  "my-podinjected",
+		},
+		{
+			name:  "null bytes stripped",
+			input: "my-pod\x00injected",
+			want:  "my-podinjected",
+		},
+		{
+			name:  "normal characters preserved",
+			input: "nginx-deployment-7c79f4c9b8-abc12",
+			want:  "nginx-deployment-7c79f4c9b8-abc12",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeForComment(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
bug

#### What this PR does / why we need it:
Two defensive fixes (per @aauren's consolidation request on #2020):

1. **LBC allocateService() nil panic**: When a service already has all requested IPs, `err.Error()` was called on a nil error. Added early return and safe per-family error collection.
2. **NPC iptables comment sanitization**: Pod/namespace/policy names embedded directly in iptables-restore comments without control character filtering. Added `sanitizeForComment()` as defense-in-depth.

Supersedes: #2022, #2039

#### Was AI used during the creation of this PR?
* What tool was used: Claude Code
* To what extent was the tool used? Code review identified the bugs, human reviewed and confirmed each fix
* If drafted, how detailed of a plan did you create for the AI? Detailed — each bug traced line-by-line
* Help us understand if a human was in the loop or not for this PR? Yes

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
Unit tests pass for both lballoc and netpol packages. No integration testing.

#### Does this PR introduce a breaking change?
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?
The LBC fix changes error message format from `"unable to allocate address: no IPs left"` to `"unable to allocate address: IPv4: no IPs left"` — log/error string change only, no API change.