### PR TITLE
feat(healthcheck): make healtcheck bind address configurable

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -20,6 +20,9 @@
   - [Docker](#docker)
   - [containerd](#containerd)
 - [trying kube-router as alternative to kube-proxy](#trying-kube-router-as-alternative-to-kube-proxy)
+- [Binding health check endpoint to a specific host IP](#binding-health-check-endpoint-to-a-specific-host-ip)
+  - [Using the primary host address via Downward API](#using-the-primary-host-address-via-downward-api)
+  - [Using a specific IP address](#using-a-specific-ip-address)
 - [Advertising IPs](#advertising-ips)
 - [External IP and LoadBalancer IP Validation](#external-ip-and-loadbalancer-ip-validation)
   - [How It Works](#how-it-works)
@@ -130,6 +133,7 @@ Usage of kube-router:
       --gobgp-admin-address string                    Address for GoBGP server. Used in combination with gobgp-admin-port to expose GoBGP for administrative purposes. Setting this to empty string will default the address to 127.0.0.1. (default "127.0.0.1")
       --gobgp-admin-port uint16                       Port to connect to GoBGP for administrative purposes. Setting this to 0 will disable the GoBGP gRPC server. (default 50051)
       --hairpin-mode                                  Add iptables rules for every Service Endpoint to support hairpin traffic.
+      --health-addr string                            Health check address to listen on (Default: all interfaces; ensure to configure the 'livenessProbe' to use the same IP address)
       --health-port uint16                            Health check port, 0 = Disabled (default 20244)
   -h, --help                                          Print usage information.
       --hostname-override string                      Overrides the NodeName of the node. Set this if kube-router is unable to determine your NodeName automatically.
@@ -289,6 +293,62 @@ and if you want to move back to kube-proxy then clean up config done by kube-rou
 ```
 
 and run kube-proxy with the configuration you have.
+
+## Binding health check endpoint to a specific host IP
+
+Using `--health-addr` you can bind health check to specific host IP.
+When using this option, you have to ensure, that the `livenessProbe` is configured to use the same IP address.
+
+### Using the primary host address via Downward API
+
+You can use the Kubernetes [Downward API](https://kubernetes.io/docs/concepts/workloads/pods/downward-api/) to determine
+the primary IP address of the node to which the Pod is assigned and use it for the health check.
+
+```yaml
+env:
+  - name: HOST_IP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
+args:
+  - --health-addr=$(HOST_IP)
+```
+
+Ensure to configure the `livenessProbe` to use the `HOST_IP` as the `host` value.
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 20244
+    host: $(HOST_IP)
+    scheme: HTTP
+  initialDelaySeconds: 10
+  periodSeconds: 10
+```
+
+### Using a specific IP address
+
+You can also use a specific IP address for the health check. For example 127.0.0.1 to bind locally, or any other
+available IP address.
+
+```yaml
+args:
+  - --health-addr=127.0.0.1
+```
+
+You still need to configure the `livenessProbe` to use the chosen IP address for the `host` value.
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 20244
+    host: 127.0.0.1
+    scheme: HTTP
+  initialDelaySeconds: 10
+  periodSeconds: 10
+```
 
 ## Advertising IPs
 

--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -107,6 +107,14 @@ func (kr *KubeRouter) Run() error {
 	defer close(healthChan)
 	stopCh := make(chan struct{})
 
+	// Verify the health address/port combo provided is listenable
+	if err := utils.TCPAddressBindable(kr.Config.HealthAddr, kr.Config.HealthPort); err != nil {
+		return fmt.Errorf("failed to listen on %s:%d for heath controller: %w",
+			kr.Config.HealthAddr,
+			int(kr.Config.HealthPort),
+			err)
+	}
+
 	hc, err := healthcheck.NewHealthController(kr.Config)
 	if err != nil {
 		return fmt.Errorf("failed to create health controller: %w", err)

--- a/pkg/healthcheck/health_controller.go
+++ b/pkg/healthcheck/health_controller.go
@@ -48,6 +48,7 @@ type ControllerHeartbeat struct {
 
 // HealthController reports the health of the controller loops as a http endpoint
 type HealthController struct {
+	HealthAddr  string
 	HealthPort  uint16
 	HTTPEnabled bool
 	Status      HealthStats
@@ -225,7 +226,7 @@ func (hc *HealthController) RunServer(stopCh <-chan struct{}, wg *sync.WaitGroup
 	mux := http.NewServeMux()
 
 	srv := &http.Server{
-		Addr:              ":" + strconv.Itoa(int(hc.HealthPort)),
+		Addr:              hc.HealthAddr + ":" + strconv.Itoa(int(hc.HealthPort)),
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
@@ -290,6 +291,7 @@ func (hc *HealthController) SetAlive() {
 func NewHealthController(config *options.KubeRouterConfig) (*HealthController, error) {
 	hc := HealthController{
 		Config:     config,
+		HealthAddr: config.HealthAddr,
 		HealthPort: config.HealthPort,
 		Status: HealthStats{
 			Healthy: true,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -46,6 +46,7 @@ type KubeRouterConfig struct {
 	GlobalHairpinMode              bool
 	GoBGPAdminAddress              string
 	GoBGPAdminPort                 uint16
+	HealthAddr                     string
 	HealthPort                     uint16
 	HelpRequested                  bool
 	HostnameOverride               string
@@ -174,6 +175,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 			"Setting this to empty string will default the address to 127.0.0.1.")
 	fs.Uint16Var(&s.GoBGPAdminPort, "gobgp-admin-port", defaultGoBGPAdminPort,
 		"Port to connect to GoBGP for administrative purposes. Setting this to 0 will disable the GoBGP gRPC server.")
+	fs.StringVar(&s.HealthAddr, "health-addr", "", "Health check address to listen on (Default: all interfaces; "+
+		"ensure to configure the 'livenessProbe' to use the same IP address)")
 	fs.Uint16Var(&s.HealthPort, "health-port", defaultHealthCheckPort, "Health check port, 0 = Disabled")
 	fs.BoolVarP(&s.HelpRequested, "help", "h", false,
 		"Print usage information.")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?

<!--
Please choose one of the following kinds:
-->
feature

#### What this PR does / why we need it:

This PR makes the bind address used for the healthcheck endpoint configurable.
Similar to and pretty much based on: https://github.com/cloudnativelabs/kube-router/pull/1570 that makes metrics bind address configurable.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->
Fixes https://github.com/cloudnativelabs/kube-router/issues/2043

#### Was AI used during the creation of this PR?
<!--
We are not against AI, but in the current era of tech AI is being used more and more to help upstream projects and it is
useful for the maintainers of this project to understand if AI was used and to what extent it was used. Please see our
AI policy: https://github.com/cloudnativelabs/kube-router/blob/master/AI_POLICY.md

If no AI was used during the generation of this PR, please remove the following content and simply put "No" for this
section.
-->
No

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->
None


#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?
This PR is pretty much a copy/paste and adapting of changes from https://github.com/cloudnativelabs/kube-router/pull/1570.

The development and contribution guides ask/require to execute certain commands. Unfortunately, some of them fail for me.

- `make kube-router` and `make gofmt` are successful.
- `make gofmt-fix` fails as it misses `goimports`. I tried to run `go install golang.org/x/tools/cmd/goimports@latest` but the fixing still failed with the same error. As I did not change imports, I assume this can be "ignored".
- `make test-pretty` fails with `DONE 592 tests, 1 failure in 0.062s`, where the failing test is 
   > kube-router_test.go:53: docs/user-guide.md 'command line options' section does not match `kube-router --help`.
- plain `make` fails with
  > docker run --rm -v /home/dodge/projects/kube-router:/work -w /work alpine:3.23 sh -c \
        'wget -qO- https://github.com/crate-ci/typos/releases/download/v1.33.1/typos-v1.33.1-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin && typos'
28FBA63FD4730000:error:0A000126:SSL routines::unexpected eof while reading:ssl/record/rec_layer_s3.c:698:
ssl_client: SSL_connect
wget: error getting response: Connection reset by peer
tar: invalid magic
tar: short read
make: *** [Makefile:139: spellcheck] Error 1

