### PR TITLE
chore: modernize Go primitives to use 1.13+ stdlib features

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,7 @@ linters:
     - nakedret
     - noctx
     - nolintlint
+    - perfsprint
     - staticcheck
     - unconvert
     - unparam

--- a/build/dependency-updater/registry/docker.go
+++ b/build/dependency-updater/registry/docker.go
@@ -250,12 +250,12 @@ func filterStableTags(tags []string, image, constraint string) []string {
 // Returns ("", false) if the tag does not match the expected format.
 func GoVersionFromImageTag(imageRef string) (string, bool) {
 	// Strip digest if present.
-	if idx := strings.Index(imageRef, "@"); idx != -1 {
-		imageRef = imageRef[:idx]
+	if before, _, found := strings.Cut(imageRef, "@"); found {
+		imageRef = before
 	}
 	// Strip image name prefix (e.g. "golang:").
-	if idx := strings.Index(imageRef, ":"); idx != -1 {
-		imageRef = imageRef[idx+1:]
+	if _, after, found := strings.Cut(imageRef, ":"); found {
+		imageRef = after
 	}
 	// imageRef is now the tag, e.g. "1.25.8-alpine3.23".
 	m := alpineVariantRe.FindStringSubmatch(imageRef)

--- a/build/dependency-updater/updater/classify.go
+++ b/build/dependency-updater/updater/classify.go
@@ -116,9 +116,9 @@ func looksLikeImage(value string) bool {
 // Returns name, tag, digest (digest may be empty).
 func ParseImageRef(ref string) (name, tag, digest string) {
 	// Strip digest if present.
-	if idx := strings.Index(ref, "@sha256:"); idx != -1 {
-		digest = ref[idx+1:] // "sha256:abc123..."
-		ref = ref[:idx]
+	if before, after, found := strings.Cut(ref, "@sha256:"); found {
+		digest = "sha256:" + after
+		ref = before
 	}
 
 	// Split on last colon for tag (but avoid splitting registry:port).

--- a/cmd/kube-router/kube-router.go
+++ b/cmd/kube-router/kube-router.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
@@ -58,7 +59,7 @@ func Main() error {
 	}
 
 	if os.Geteuid() != 0 {
-		return fmt.Errorf("kube-router needs to be run with privileges to execute iptables, ipset and configure ipvs")
+		return errors.New("kube-router needs to be run with privileges to execute iptables, ipset and configure ipvs")
 	}
 
 	if config.CleanupConfig {

--- a/cmd/kube-router/kube-router.go
+++ b/cmd/kube-router/kube-router.go
@@ -36,15 +36,15 @@ func Main() error {
 	// https://github.com/kubernetes/kubernetes/issues/17162
 	err := flag.CommandLine.Parse([]string{})
 	if err != nil {
-		return fmt.Errorf("failed to parse flags: %s", err)
+		return fmt.Errorf("failed to parse flags: %w", err)
 	}
 	err = flag.Set("logtostderr", "true")
 	if err != nil {
-		return fmt.Errorf("failed to set flag: %s", err)
+		return fmt.Errorf("failed to set flag: %w", err)
 	}
 	err = flag.Set("v", config.VLevel)
 	if err != nil {
-		return fmt.Errorf("failed to set flag: %s", err)
+		return fmt.Errorf("failed to set flag: %w", err)
 	}
 
 	if config.HelpRequested {
@@ -68,7 +68,7 @@ func Main() error {
 
 	kubeRouter, err := cmd.NewKubeRouterDefault(config)
 	if err != nil {
-		return fmt.Errorf("failed to parse kube-router config: %v", err)
+		return fmt.Errorf("failed to parse kube-router config: %w", err)
 	}
 
 	if config.EnablePprof {
@@ -84,7 +84,7 @@ func Main() error {
 
 	err = kubeRouter.Run()
 	if err != nil {
-		return fmt.Errorf("failed to run kube-router: %v", err)
+		return fmt.Errorf("failed to run kube-router: %w", err)
 	}
 
 	return nil

--- a/pkg/bgp/peer_config.go
+++ b/pkg/bgp/peer_config.go
@@ -64,7 +64,7 @@ func (p PeerConfig) Port() *uint32 {
 func (p PeerConfig) String() string {
 	var fields []string
 	if p.localIP != "" {
-		fields = append(fields, fmt.Sprintf("LocalIP: %s", p.localIP))
+		fields = append(fields, "LocalIP: "+p.localIP)
 	}
 	if p.port != nil {
 		fields = append(fields, fmt.Sprintf("Port: %d", *p.port))

--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -49,7 +49,7 @@ func NewKubeRouterDefault(config *options.KubeRouterConfig) (*KubeRouter, error)
 	if len(config.Kubeconfig) != 0 {
 		clientconfig, err = clientcmd.BuildConfigFromFlags(config.Master, config.Kubeconfig)
 		if err != nil {
-			return nil, fmt.Errorf("failed to build configuration from CLI: %v", err)
+			return nil, fmt.Errorf("failed to build configuration from CLI: %w", err)
 		}
 	} else if len(config.Master) != 0 {
 		// InClusterConfig() fails with ErrNotInCluster if these are unset.
@@ -58,7 +58,7 @@ func NewKubeRouterDefault(config *options.KubeRouterConfig) (*KubeRouter, error)
 
 		clientconfig, err = rest.InClusterConfig()
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize inclusterconfig: %v", err)
+			return nil, fmt.Errorf("unable to initialize inclusterconfig: %w", err)
 		}
 
 		os.Setenv("KUBERNETES_SERVICE_HOST", "")
@@ -68,13 +68,13 @@ func NewKubeRouterDefault(config *options.KubeRouterConfig) (*KubeRouter, error)
 	} else {
 		clientconfig, err = rest.InClusterConfig()
 		if err != nil {
-			return nil, fmt.Errorf("unable to initialize inclusterconfig: %v", err)
+			return nil, fmt.Errorf("unable to initialize inclusterconfig: %w", err)
 		}
 	}
 
 	clientset, err := kubernetes.NewForConfig(clientconfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create Kubernetes client: %v", err)
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
 	}
 
 	return &KubeRouter{Client: clientset, Config: config}, nil
@@ -109,7 +109,7 @@ func (kr *KubeRouter) Run() error {
 
 	hc, err := healthcheck.NewHealthController(kr.Config)
 	if err != nil {
-		return fmt.Errorf("failed to create health controller: %v", err)
+		return fmt.Errorf("failed to create health controller: %w", err)
 	}
 	wg.Add(1)
 	go hc.RunServer(stopCh, &wg)
@@ -128,14 +128,14 @@ func (kr *KubeRouter) Run() error {
 		indexers.ServiceNameIndex: indexers.ServiceNameIndexFunc,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to add indexers to endpoint slice informer: %v", err)
+		return fmt.Errorf("failed to add indexers to endpoint slice informer: %w", err)
 	}
 
 	informerFactory.Start(stopCh)
 
 	err = kr.CacheSyncOrTimeout(informerFactory, stopCh)
 	if err != nil {
-		return fmt.Errorf("failed to synchronize cache: %v", err)
+		return fmt.Errorf("failed to synchronize cache: %w", err)
 	}
 
 	hc.SetAlive()
@@ -155,7 +155,7 @@ func (kr *KubeRouter) Run() error {
 		kr.Config.MetricsEnabled = true
 		mc, err := metrics.NewMetricsController(kr.Config)
 		if err != nil {
-			return fmt.Errorf("failed to create metrics controller: %v", err)
+			return fmt.Errorf("failed to create metrics controller: %w", err)
 		}
 		wg.Add(1)
 		go mc.Run(healthChan, stopCh, &wg)
@@ -192,7 +192,7 @@ func (kr *KubeRouter) Run() error {
 		EnableIPv6:        kr.Config.EnableIPv6,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to create service IP validator: %v", err)
+		return fmt.Errorf("failed to create service IP validator: %w", err)
 	}
 	ipValidator.LogStatus()
 
@@ -200,20 +200,20 @@ func (kr *KubeRouter) Run() error {
 		nrc, err := routing.NewNetworkRoutingController(kr.Client, kr.Config,
 			nodeInformer, svcInformer, epSliceInformer, &ipsetMutex, ipValidator)
 		if err != nil {
-			return fmt.Errorf("failed to create network routing controller: %v", err)
+			return fmt.Errorf("failed to create network routing controller: %w", err)
 		}
 
 		_, err = nodeInformer.AddEventHandler(nrc.NodeEventHandler)
 		if err != nil {
-			return fmt.Errorf("failed to add NodeEventHandler: %v", err)
+			return fmt.Errorf("failed to add NodeEventHandler: %w", err)
 		}
 		_, err = svcInformer.AddEventHandler(nrc.ServiceEventHandler)
 		if err != nil {
-			return fmt.Errorf("failed to add ServiceEventHandler: %v", err)
+			return fmt.Errorf("failed to add ServiceEventHandler: %w", err)
 		}
 		_, err = epSliceInformer.AddEventHandler(nrc.EndpointSliceEventHandler)
 		if err != nil {
-			return fmt.Errorf("failed to add EndpointsEventHandler: %v", err)
+			return fmt.Errorf("failed to add EndpointsEventHandler: %w", err)
 		}
 
 		wg.Add(1)
@@ -231,16 +231,16 @@ func (kr *KubeRouter) Run() error {
 		nsc, err := proxy.NewNetworkServicesController(kr.Client, kr.Config,
 			svcInformer, epSliceInformer, podInformer, &ipsetMutex, ipValidator)
 		if err != nil {
-			return fmt.Errorf("failed to create network services controller: %v", err)
+			return fmt.Errorf("failed to create network services controller: %w", err)
 		}
 
 		_, err = svcInformer.AddEventHandler(nsc.ServiceEventHandler)
 		if err != nil {
-			return fmt.Errorf("failed to add ServiceEventHandler: %v", err)
+			return fmt.Errorf("failed to add ServiceEventHandler: %w", err)
 		}
 		_, err = epSliceInformer.AddEventHandler(nsc.EndpointSliceEventHandler)
 		if err != nil {
-			return fmt.Errorf("failed to add EndpointsEventHandler: %v", err)
+			return fmt.Errorf("failed to add EndpointsEventHandler: %w", err)
 		}
 
 		wg.Add(1)
@@ -257,26 +257,26 @@ func (kr *KubeRouter) Run() error {
 	if kr.Config.RunFirewall {
 		iptablesCmdHandlers, ipSetHandlers, err := netpol.NewIPTablesHandlers(kr.Config)
 		if err != nil {
-			return fmt.Errorf("failed to create iptables handlers: %v", err)
+			return fmt.Errorf("failed to create iptables handlers: %w", err)
 		}
 		npc, err := netpol.NewNetworkPolicyController(kr.Client,
 			kr.Config, podInformer, npInformer, nsInformer, &ipsetMutex, nil, iptablesCmdHandlers, ipSetHandlers,
 			ipValidator)
 		if err != nil {
-			return fmt.Errorf("failed to create network policy controller: %v", err)
+			return fmt.Errorf("failed to create network policy controller: %w", err)
 		}
 
 		_, err = podInformer.AddEventHandler(npc.PodEventHandler)
 		if err != nil {
-			return fmt.Errorf("failed to add PodEventHandler: %v", err)
+			return fmt.Errorf("failed to add PodEventHandler: %w", err)
 		}
 		_, err = nsInformer.AddEventHandler(npc.NamespaceEventHandler)
 		if err != nil {
-			return fmt.Errorf("failed to add NamespaceEventHandler: %v", err)
+			return fmt.Errorf("failed to add NamespaceEventHandler: %w", err)
 		}
 		_, err = npInformer.AddEventHandler(npc.NetworkPolicyEventHandler)
 		if err != nil {
-			return fmt.Errorf("failed to add NetworkPolicyEventHandler: %v", err)
+			return fmt.Errorf("failed to add NetworkPolicyEventHandler: %w", err)
 		}
 
 		wg.Add(1)
@@ -287,12 +287,12 @@ func (kr *KubeRouter) Run() error {
 		klog.V(0).Info("running load balancer allocator controller")
 		lbc, err := lballoc.NewLoadBalancerController(kr.Client, kr.Config, svcInformer, ipValidator)
 		if err != nil {
-			return fmt.Errorf("failed to create load balancer allocator: %v", err)
+			return fmt.Errorf("failed to create load balancer allocator: %w", err)
 		}
 
 		_, err = svcInformer.AddEventHandler(lbc)
 		if err != nil {
-			return fmt.Errorf("failed to add ServiceEventHandler: %v", err)
+			return fmt.Errorf("failed to add ServiceEventHandler: %w", err)
 		}
 
 		wg.Add(1)

--- a/pkg/controllers/lballoc/lballoc.go
+++ b/pkg/controllers/lballoc/lballoc.go
@@ -1,9 +1,9 @@
 package lballoc
 
 import (
-	"fmt"
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"sync"

--- a/pkg/controllers/lballoc/lballoc.go
+++ b/pkg/controllers/lballoc/lballoc.go
@@ -1,6 +1,7 @@
 package lballoc
 
 import (
+	"fmt"
 	"context"
 	"errors"
 	"net"
@@ -397,10 +398,10 @@ func (lbc *LoadBalancerController) allocateService(svc *v1core.Service) error {
 	}
 
 	if ipv4 == nil && ipv6 == nil {
-		return errors.New("unable to allocate address: " + err.Error())
+		return fmt.Errorf("unable to allocate address: %w", err)
 	}
 	if (ipv4 == nil || ipv6 == nil) && requireDual {
-		return errors.New("unable to allocate dual-stack addresses: " + err.Error())
+		return fmt.Errorf("unable to allocate dual-stack addresses: %w", err)
 	}
 
 	// This is only non-nil during certain unit tests that need to understand when this goroutine is finished to remove

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/base32"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -350,7 +351,7 @@ func (npc *NetworkPolicyController) iptablesCmdHandlerForCIDR(cidr *net.IPNet) (
 		return npc.iptablesCmdHandlers[v1core.IPv6Protocol], nil
 	}
 
-	return nil, fmt.Errorf("invalid CIDR")
+	return nil, errors.New("invalid CIDR")
 }
 
 func (npc *NetworkPolicyController) allowTrafficToClusterIPRange(
@@ -897,21 +898,21 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	clusterIPv4 := ipRanges.ClusterIPRanges(v1core.IPv4Protocol)
 	clusterIPv6 := ipRanges.ClusterIPRanges(v1core.IPv6Protocol)
 	if config.EnableIPv4 && !config.EnableIPv6 && len(clusterIPv4) == 0 {
-		return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: " +
+		return nil, errors.New("failed to get parse --service-cluster-ip-range parameter: " +
 			"IPv4 is enabled but only IPv6 address is provided")
 	}
 	if !config.EnableIPv4 && config.EnableIPv6 && len(clusterIPv6) == 0 {
-		return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: " +
+		return nil, errors.New("failed to get parse --service-cluster-ip-range parameter: " +
 			"IPv6 is enabled but only IPv4 address is provided")
 	}
 	if config.EnableIPv4 && config.EnableIPv6 && len(config.ClusterIPCIDRs) > 1 {
 		if len(clusterIPv4) == 0 || len(clusterIPv6) == 0 {
-			return nil, fmt.Errorf("failed to get parse --service-cluster-ip-range parameter: " +
+			return nil, errors.New("failed to get parse --service-cluster-ip-range parameter: " +
 				"dual-stack is enabled, both IPv4 and IPv6 addresses should be provided")
 		}
 	}
 	if !config.EnableIPv4 && !config.EnableIPv6 && len(config.ClusterIPCIDRs) > 1 {
-		return nil, fmt.Errorf("too many CIDRs provided in --service-cluster-ip-range parameter: " +
+		return nil, errors.New("too many CIDRs provided in --service-cluster-ip-range parameter: " +
 			"dual-stack must be enabled to provide two addresses")
 	}
 
@@ -956,7 +957,7 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 
 	if config.EnableIPv4 {
 		if !npc.krNode.IsIPv4Capable() {
-			return nil, fmt.Errorf("IPv4 was enabled but no IPv4 address was found on node")
+			return nil, errors.New("IPv4 was enabled but no IPv4 address was found on node")
 		}
 		klog.V(2).Infof("IPv4 is enabled")
 		npc.iptablesSaveRestore[v1core.IPv4Protocol] = utils.NewIPTablesSaveRestore(v1core.IPv4Protocol)
@@ -965,7 +966,7 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	}
 	if config.EnableIPv6 {
 		if !npc.krNode.IsIPv6Capable() {
-			return nil, fmt.Errorf("IPv6 was enabled but no IPv6 address was found on node")
+			return nil, errors.New("IPv6 was enabled but no IPv6 address was found on node")
 		}
 		klog.V(2).Infof("IPv6 is enabled")
 		npc.iptablesSaveRestore[v1core.IPv6Protocol] = utils.NewIPTablesSaveRestore(v1core.IPv6Protocol)

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -3,7 +3,6 @@ package netpol
 import (
 	"crypto/sha256"
 	"encoding/base32"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -724,7 +723,7 @@ func (npc *NetworkPolicyController) evalPodPeer(policy *networking.NetworkPolicy
 		namespaceSelector, _ := v1.LabelSelectorAsSelector(peer.NamespaceSelector)
 		namespaces, err := npc.ListNamespaceByLabels(namespaceSelector)
 		if err != nil {
-			return nil, errors.New("Failed to build network policies info due to " + err.Error())
+			return nil, fmt.Errorf("Failed to build network policies info due to: %w", err)
 		}
 
 		podSelector := labels.Everything()
@@ -734,7 +733,7 @@ func (npc *NetworkPolicyController) evalPodPeer(policy *networking.NetworkPolicy
 		for _, namespace := range namespaces {
 			namespacePods, err := npc.ListPodsByNamespaceAndLabels(namespace.Name, podSelector)
 			if err != nil {
-				return nil, errors.New("Failed to build network policies info due to " + err.Error())
+				return nil, fmt.Errorf("Failed to build network policies info due to: %w", err)
 			}
 			matchingPods = append(matchingPods, namespacePods...)
 		}

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -3,6 +3,7 @@ package netpol
 import (
 	"crypto/sha256"
 	"encoding/base32"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -515,7 +516,7 @@ func (npc *NetworkPolicyController) buildNetworkPoliciesInfo() ([]networkPolicyI
 		policy, ok := policyObj.(*networking.NetworkPolicy)
 		podSelector, _ := v1.LabelSelectorAsSelector(&policy.Spec.PodSelector)
 		if !ok {
-			return nil, fmt.Errorf("failed to convert")
+			return nil, errors.New("failed to convert")
 		}
 		newPolicy := networkPolicyInfo{
 			name:        policy.Name,
@@ -723,7 +724,7 @@ func (npc *NetworkPolicyController) evalPodPeer(policy *networking.NetworkPolicy
 		namespaceSelector, _ := v1.LabelSelectorAsSelector(peer.NamespaceSelector)
 		namespaces, err := npc.ListNamespaceByLabels(namespaceSelector)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to build network policies info due to: %w", err)
+			return nil, fmt.Errorf("failed to build network policies info due to: %w", err)
 		}
 
 		podSelector := labels.Everything()
@@ -733,7 +734,7 @@ func (npc *NetworkPolicyController) evalPodPeer(policy *networking.NetworkPolicy
 		for _, namespace := range namespaces {
 			namespacePods, err := npc.ListPodsByNamespaceAndLabels(namespace.Name, podSelector)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to build network policies info due to: %w", err)
+				return nil, fmt.Errorf("failed to build network policies info due to: %w", err)
 			}
 			matchingPods = append(matchingPods, namespacePods...)
 		}

--- a/pkg/controllers/proxy/hairpin_controller.go
+++ b/pkg/controllers/proxy/hairpin_controller.go
@@ -72,7 +72,7 @@ func (hpc *hairpinController) ensureHairpinEnabledForPodInterface(endpointIP str
 
 	hostNetworkNSHandle, err := netns.Get()
 	if err != nil {
-		return fmt.Errorf("failed to get namespace due to %v", err)
+		return fmt.Errorf("failed to get namespace due to %w", err)
 	}
 	defer utils.CloseCloserDisregardError(&hostNetworkNSHandle)
 
@@ -81,14 +81,14 @@ func (hpc *hairpinController) ensureHairpinEnabledForPodInterface(endpointIP str
 		// WARN: This method is deprecated and will be removed once docker-shim is removed from kubelet.
 		pid, err = hpc.nsc.ln.getContainerPidWithDocker(containerID)
 		if err != nil {
-			return fmt.Errorf("failed to get pod's (%s) pid for hairpinning due to %v", endpointIP, err)
+			return fmt.Errorf("failed to get pod's (%s) pid for hairpinning due to %w", endpointIP, err)
 		}
 	} else {
 		// We expect CRI compliant runtimes here
 		// ugly workaround, refactoring of pkg/Proxy is required
 		pid, err = hpc.nsc.ln.getContainerPidWithCRI(hpc.nsc.dsr.runtimeEndpoint, containerID)
 		if err != nil {
-			return fmt.Errorf("failed to get pod's (%s) pid for hairpinning due to %v", endpointIP, err)
+			return fmt.Errorf("failed to get pod's (%s) pid for hairpinning due to %w", endpointIP, err)
 		}
 	}
 	klog.V(2).Infof("Found PID %d for endpoint IP %s", pid, endpointIP)

--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -594,7 +594,7 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 			defaultPrefixCIDR = utils.GetDefaultIPv6Route()
 		}
 		if defaultPrefixCIDR == nil {
-			return fmt.Errorf("failed to parse default route (this is statically defined, so if you see this " +
+			return errors.New("failed to parse default route (this is statically defined, so if you see this " +
 				"error please report because something has gone very wrong)")
 		}
 
@@ -746,7 +746,7 @@ func (ln *linuxNetworking) getContainerPidWithDocker(containerID string) (int, e
 // among other things, for us to enter the network namespace of the pod
 func (ln *linuxNetworking) getContainerPidWithCRI(runtimeEndpoint string, containerID string) (int, error) {
 	if runtimeEndpoint == "" {
-		return 0, fmt.Errorf("runtimeEndpoint is not specified")
+		return 0, errors.New("runtimeEndpoint is not specified")
 	}
 
 	rs, err := cri.NewRemoteRuntimeService(runtimeEndpoint, cri.DefaultConnectionTimeout)

--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -89,7 +90,7 @@ func (ln *linuxNetworking) ipAddrDel(iface netlink.Link, ip string, nodeIP strin
 	addrList, err := nlretry.AddrList(context.Background(), iface, nFamily)
 	nIfaceHasAddr := false
 	if err != nil {
-		return fmt.Errorf("failed to list addresses for interface %s due to: %v", iface.Attrs().Name, err)
+		return fmt.Errorf("failed to list addresses for interface %s due to: %w", iface.Attrs().Name, err)
 	}
 	for _, addr := range addrList {
 		if addr.IP.Equal(parsedIP) {
@@ -125,7 +126,7 @@ func (ln *linuxNetworking) ipAddrDel(iface netlink.Link, ip string, nodeIP strin
 	routes, err := nlretry.RouteListFiltered(context.Background(), netlink.FAMILY_ALL, nRoute,
 		netlink.RT_FILTER_TYPE|netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_SRC)
 	if err != nil {
-		return fmt.Errorf("failed to list filtered routes for route %s: %v", nRoute, err)
+		return fmt.Errorf("failed to list filtered routes for route %s: %w", nRoute, err)
 	}
 
 	// Let the user know if we found more than 1 route that matched a single route filter
@@ -143,8 +144,8 @@ func (ln *linuxNetworking) ipAddrDel(iface netlink.Link, ip string, nodeIP strin
 		klog.V(1).Infof("Found %d routes for interface %s, deleting them...", len(routes), iface.Attrs().Name)
 		err = netlink.RouteDel(nRoute)
 		if err != nil {
-			if !strings.Contains(err.Error(), "no such process") {
-				return fmt.Errorf("failed to delete route %s: %v", nRoute, err)
+			if !errors.Is(err, syscall.ESRCH) {
+				return fmt.Errorf("failed to delete route %s: %w", nRoute, err)
 			}
 			klog.Warningf("got a No such process error while trying to remove route %s: %v (this is not normally bad "+
 				"enough to stop processing)", nRoute, err)
@@ -180,8 +181,8 @@ func (ln *linuxNetworking) ipAddrAdd(iface netlink.Link, ip string, nodeIP strin
 	ipPrefix := utils.GetSingleIPNet(parsedIP)
 	naddr := &netlink.Addr{IPNet: ipPrefix, Scope: syscall.RT_SCOPE_LINK}
 	err := netlink.AddrAdd(iface, naddr)
-	if err != nil && err.Error() != IfaceHasAddr {
-		klog.Errorf("failed to assign cluster ip %s to dummy interface: %s", naddr.IP.String(), err.Error())
+	if err != nil && !errors.Is(err, syscall.EEXIST) {
+		klog.Errorf("failed to assign cluster ip %s to dummy interface: %v", naddr.IP.String(), err)
 		return err
 	}
 
@@ -300,7 +301,7 @@ func (ln *linuxNetworking) ipvsAddService(svcs []*ipvs.Service, vip net.IP, prot
 			klog.V(2).Info("Service matched VIP")
 			ptim, err := safecast.Convert[uint32](persistentTimeout)
 			if err != nil {
-				return svcs, nil, fmt.Errorf("failed to convert persistent timeout to uint32: %v", err)
+				return svcs, nil, fmt.Errorf("failed to convert persistent timeout to uint32: %w", err)
 			}
 			if (persistent && (svc.Flags&ipvsPersistentFlagHex) == 0) ||
 				(!persistent && (svc.Flags&ipvsPersistentFlagHex) != 0) ||
@@ -375,7 +376,7 @@ func (ln *linuxNetworking) ipvsAddService(svcs []*ipvs.Service, vip net.IP, prot
 		ipvsServiceString(&svc))
 	err = ln.ipvsNewService(&svc)
 	if err != nil {
-		return svcs, nil, fmt.Errorf("failed to create new service %s due to: %v", ipvsServiceString(&svc), err)
+		return svcs, nil, fmt.Errorf("failed to create new service %s due to: %w", ipvsServiceString(&svc), err)
 	}
 
 	// We add the just created service to the list of existing IPVS services because the calling logic here is a little
@@ -470,7 +471,7 @@ func (ln *linuxNetworking) ipvsAddFWMarkService(svcs []*ipvs.Service, fwMark uin
 
 	err := ipvsSetPersistence(&svc, persistent, persistentTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("failed to set persistence for service %s due to: %v", ipvsServiceString(&svc), err)
+		return nil, fmt.Errorf("failed to set persistence for service %s due to: %w", ipvsServiceString(&svc), err)
 	}
 	ipvsSetSchedFlags(&svc, flags)
 
@@ -490,17 +491,17 @@ func (ln *linuxNetworking) ipvsAddServer(service *ipvs.Service, dest *ipvs.Desti
 		return nil
 	}
 
-	if strings.Contains(err.Error(), IpvsServerExists) {
+	if errors.Is(err, syscall.EEXIST) {
 		err = ln.ipvsUpdateDestination(service, dest)
 		if err != nil {
-			return fmt.Errorf("failed to update ipvs destination %s to the ipvs service %s due to : %s",
-				ipvsDestinationString(dest), ipvsServiceString(service), err.Error())
+			return fmt.Errorf("failed to update ipvs destination %s to the ipvs service %s due to : %w",
+				ipvsDestinationString(dest), ipvsServiceString(service), err)
 		}
 		klog.V(2).Infof("ipvs destination %s already exists in the ipvs service %s so not adding destination",
 			ipvsDestinationString(dest), ipvsServiceString(service))
 	} else {
-		return fmt.Errorf("failed to add ipvs destination %s to the ipvs service %s due to : %s",
-			ipvsDestinationString(dest), ipvsServiceString(service), err.Error())
+		return fmt.Errorf("failed to add ipvs destination %s to the ipvs service %s due to : %w",
+			ipvsDestinationString(dest), ipvsServiceString(service), err)
 	}
 	return nil
 }
@@ -511,12 +512,12 @@ func (ln *linuxNetworking) ipvsAddServer(service *ipvs.Service, dest *ipvs.Desti
 func (ln *linuxNetworking) setupPolicyRoutingForDSR(setupIPv4, setupIPv6 bool) error {
 	err := utils.RouteTableAdd(customDSRRouteTableID, customDSRRouteTableName)
 	if err != nil {
-		return fmt.Errorf("failed to setup policy routing required for DSR due to %v", err)
+		return fmt.Errorf("failed to setup policy routing required for DSR due to %w", err)
 	}
 
 	loNetLink, err := nlretry.LinkByName(context.Background(), "lo")
 	if err != nil {
-		return fmt.Errorf("failed to get loopback interface due to %v", err)
+		return fmt.Errorf("failed to get loopback interface due to %w", err)
 	}
 
 	if setupIPv4 {
@@ -539,7 +540,7 @@ func (ln *linuxNetworking) setupPolicyRoutingForDSR(setupIPv4, setupIPv6 bool) e
 		if err != nil || len(routes) < 1 {
 			err = netlink.RouteAdd(nRoute)
 			if err != nil {
-				return fmt.Errorf("failed to add route to custom route table for DSR due to: %v", err)
+				return fmt.Errorf("failed to add route to custom route table for DSR due to: %w", err)
 			}
 		}
 	}
@@ -564,7 +565,7 @@ func (ln *linuxNetworking) setupPolicyRoutingForDSR(setupIPv4, setupIPv6 bool) e
 		if err != nil || len(routes) < 1 {
 			err = netlink.RouteAdd(nRoute)
 			if err != nil {
-				return fmt.Errorf("failed to add route to custom route table for DSR due to: %v", err)
+				return fmt.Errorf("failed to add route to custom route table for DSR due to: %w", err)
 			}
 		}
 	}
@@ -580,7 +581,7 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 	setupIPv4, setupIPv6 bool) error {
 	err := utils.RouteTableAdd(externalIPRouteTableID, externalIPRouteTableName)
 	if err != nil {
-		return fmt.Errorf("failed to setup policy routing required for DSR due to %v", err)
+		return fmt.Errorf("failed to setup policy routing required for DSR due to %w", err)
 	}
 
 	setupIPRulesAndRoutes := func(isIPv6 bool) error {
@@ -639,7 +640,7 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 		// service from the local node to an non-local traffic policy service.
 		/* kubeBridgeLink, err := nlretry.LinkByName(context.Background(), KubeBridgeIf)
 		if err != nil {
-			return fmt.Errorf("failed to get kube-bridge interface due to %v", err)
+			return fmt.Errorf("failed to get kube-bridge interface due to %w", err)
 		}
 
 		activeExternalIPs := make(map[string]bool)
@@ -668,7 +669,7 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 				routes, err := nlretry.RouteListFiltered(context.Background(), nFamily, nRoute,
 					netlink.RT_FILTER_DST|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_OIF)
 				if err != nil {
-					return fmt.Errorf("failed to list route for external IP's due to: %s", err)
+					return fmt.Errorf("failed to list route for external IP's due to: %w", err)
 				}
 				if len(routes) < 1 {
 					err = netlink.RouteAdd(nRoute)
@@ -692,7 +693,7 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 		}
 		routes, err := nlretry.RouteListFiltered(context.Background(), nFamily, nRoute, netlink.RT_FILTER_TABLE)
 		if err != nil {
-			return fmt.Errorf("failed to list route for external IP's due to: %s", err)
+			return fmt.Errorf("failed to list route for external IP's due to: %w", err)
 		}
 		for idx, route := range routes {
 			ip := route.Dst.IP.String()
@@ -729,13 +730,13 @@ func (ln *linuxNetworking) setupRoutesForExternalIPForDSR(serviceInfoMap service
 func (ln *linuxNetworking) getContainerPidWithDocker(containerID string) (int, error) {
 	dockerClient, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get docker client due to %v", err)
+		return 0, fmt.Errorf("failed to get docker client due to %w", err)
 	}
 	defer utils.CloseCloserDisregardError(dockerClient)
 
 	containerSpec, err := dockerClient.ContainerInspect(context.Background(), containerID)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get docker container spec due to %v", err)
+		return 0, fmt.Errorf("failed to get docker container spec due to %w", err)
 	}
 
 	return containerSpec.State.Pid, nil
@@ -851,7 +852,7 @@ func (ln *linuxNetworking) configureContainerForDSR(
 	// This is just for logging, and that is why we close it immediately after getting it
 	activeNetworkNamespaceHandle, err := netns.Get()
 	if err != nil {
-		return fmt.Errorf("failed to get activeNetworkNamespace due to %v", err)
+		return fmt.Errorf("failed to get activeNetworkNamespace due to %w", err)
 	}
 	klog.V(2).Infof("Current network namespace after netns. Set to container network namespace: %s",
 		activeNetworkNamespaceHandle.String())
@@ -872,7 +873,7 @@ func (ln *linuxNetworking) configureContainerForDSR(
 		err = netlink.LinkAdd(ipTunLink)
 		if err != nil {
 			attemptNamespaceResetAfterError(hostNetworkNamespaceHandle)
-			return fmt.Errorf("failed to add ipip tunnel interface in endpoint namespace due to %v", err)
+			return fmt.Errorf("failed to add ipip tunnel interface in endpoint namespace due to %w", err)
 		}
 
 		// this is ugly, but ran into issue multiple times where interface did not come up quickly.
@@ -893,7 +894,7 @@ func (ln *linuxNetworking) configureContainerForDSR(
 
 		if err != nil {
 			attemptNamespaceResetAfterError(hostNetworkNamespaceHandle)
-			return fmt.Errorf("failed to get %s tunnel interface handle due to %v", ipTunLink.Attrs().Name, err)
+			return fmt.Errorf("failed to get %s tunnel interface handle due to %w", ipTunLink.Attrs().Name, err)
 		}
 
 		klog.V(2).Infof("Successfully created tunnel interface %s in endpoint %s.",
@@ -904,12 +905,12 @@ func (ln *linuxNetworking) configureContainerForDSR(
 	err = netlink.LinkSetUp(tunIf)
 	if err != nil {
 		attemptNamespaceResetAfterError(hostNetworkNamespaceHandle)
-		return fmt.Errorf("failed to bring up ipip tunnel interface in endpoint namespace due to %v", err)
+		return fmt.Errorf("failed to bring up ipip tunnel interface in endpoint namespace due to %w", err)
 	}
 
 	// assign VIP to the KUBE_TUNNEL_IF interface
 	err = ln.ipAddrAdd(tunIf, vip, "", false)
-	if err != nil && err.Error() != IfaceHasAddr {
+	if err != nil && !errors.Is(err, syscall.EEXIST) {
 		attemptNamespaceResetAfterError(hostNetworkNamespaceHandle)
 		return fmt.Errorf("failed to assign vip %s to kube-tunnel-if interface", vip)
 	}
@@ -939,11 +940,11 @@ func (ln *linuxNetworking) configureContainerForDSR(
 
 	err = netns.Set(hostNetworkNamespaceHandle)
 	if err != nil {
-		return fmt.Errorf("failed to set hostNetworkNamespace handle due to %v", err)
+		return fmt.Errorf("failed to set hostNetworkNamespace handle due to %w", err)
 	}
 	activeNetworkNamespaceHandle, err = netns.Get()
 	if err != nil {
-		return fmt.Errorf("failed to get activeNetworkNamespace handle due to %v", err)
+		return fmt.Errorf("failed to get activeNetworkNamespace handle due to %w", err)
 	}
 	klog.Infof("Current network namespace after revert namespace to host network namespace: %s",
 		activeNetworkNamespaceHandle.String())
@@ -960,15 +961,15 @@ func (ln *linuxNetworking) getKubeDummyInterface() (netlink.Link, error) {
 			KubeDummyIf)
 		err = netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: KubeDummyIf}})
 		if err != nil {
-			return nil, fmt.Errorf("failed to add dummy interface: %v", err)
+			return nil, fmt.Errorf("failed to add dummy interface: %w", err)
 		}
 		dummyVipInterface, err = nlretry.LinkByName(ctx, KubeDummyIf)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get dummy interface: %v", err)
+			return nil, fmt.Errorf("failed to get dummy interface: %w", err)
 		}
 		err = netlink.LinkSetUp(dummyVipInterface)
 		if err != nil {
-			return nil, fmt.Errorf("failed to bring dummy interface up: %v", err)
+			return nil, fmt.Errorf("failed to bring dummy interface up: %w", err)
 		}
 	}
 	return dummyVipInterface, nil
@@ -987,7 +988,7 @@ func newLinuxNetworking(tcpTimeout, tcpFinTimeout, udpTimeout time.Duration) (*l
 	}
 	err = ipvsHandle.SetConfig(ipvsConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to configure IPVS config with timeouts: %v", err)
+		return nil, fmt.Errorf("failed to configure IPVS config with timeouts: %w", err)
 	}
 	ln.ipvsHandle = ipvsHandle
 	return ln, nil

--- a/pkg/controllers/proxy/mock_netlink_state_test.go
+++ b/pkg/controllers/proxy/mock_netlink_state_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"net"
 
@@ -125,12 +126,12 @@ func (m *mockNetlinkState) addInterface(name string, attrs netlink.LinkAttrs) {
 // getInterface retrieves a mock interface by name
 func (m *mockNetlinkState) getInterface(name string) (netlink.Link, error) {
 	if m.errorMode.interfaceNotFound {
-		return nil, fmt.Errorf("Link not found")
+		return nil, errors.New("Link not found")
 	}
 
 	link, exists := m.interfaces[name]
 	if !exists {
-		return nil, fmt.Errorf("Link not found")
+		return nil, errors.New("Link not found")
 	}
 	return link, nil
 }
@@ -138,7 +139,7 @@ func (m *mockNetlinkState) getInterface(name string) (netlink.Link, error) {
 // addAddress adds an IP address to a mock interface
 func (m *mockNetlinkState) addAddress(ifaceName string, ip net.IP, ipNet *net.IPNet, family, scope int) error {
 	if m.errorMode.permissionDenied {
-		return fmt.Errorf("operation not permitted")
+		return errors.New("operation not permitted")
 	}
 
 	if _, exists := m.interfaces[ifaceName]; !exists {
@@ -149,7 +150,7 @@ func (m *mockNetlinkState) addAddress(ifaceName string, ip net.IP, ipNet *net.IP
 	for _, addr := range m.addresses[ifaceName] {
 		if addr.ip.Equal(ip) {
 			if m.errorMode.addressExists {
-				return fmt.Errorf("file exists")
+				return errors.New("file exists")
 			}
 			// Address already exists, this is idempotent
 			return nil
@@ -168,7 +169,7 @@ func (m *mockNetlinkState) addAddress(ifaceName string, ip net.IP, ipNet *net.IP
 // deleteAddress removes an IP address from a mock interface
 func (m *mockNetlinkState) deleteAddress(ifaceName string, ip net.IP) error {
 	if m.errorMode.permissionDenied {
-		return fmt.Errorf("operation not permitted")
+		return errors.New("operation not permitted")
 	}
 
 	if _, exists := m.interfaces[ifaceName]; !exists {
@@ -184,7 +185,7 @@ func (m *mockNetlinkState) deleteAddress(ifaceName string, ip net.IP) error {
 	}
 
 	// Address not found - return "cannot assign requested address"
-	return fmt.Errorf("cannot assign requested address")
+	return errors.New("cannot assign requested address")
 }
 
 // listAddresses returns all addresses for an interface with the specified family
@@ -193,7 +194,7 @@ func (m *mockNetlinkState) deleteAddress(ifaceName string, ip net.IP) error {
 //nolint:unused // Reserved for future test extensions and external package usage
 func (m *mockNetlinkState) listAddresses(ifaceName string, family int) ([]*mockAddress, error) {
 	if m.errorMode.permissionDenied {
-		return nil, fmt.Errorf("operation not permitted")
+		return nil, errors.New("operation not permitted")
 	}
 
 	if _, exists := m.interfaces[ifaceName]; !exists {
@@ -212,7 +213,7 @@ func (m *mockNetlinkState) listAddresses(ifaceName string, family int) ([]*mockA
 // addRoute adds a route to the specified routing table
 func (m *mockNetlinkState) addRoute(route *mockRoute) error {
 	if m.errorMode.permissionDenied {
-		return fmt.Errorf("operation not permitted")
+		return errors.New("operation not permitted")
 	}
 
 	if m.routes[route.table] == nil {
@@ -226,12 +227,12 @@ func (m *mockNetlinkState) addRoute(route *mockRoute) error {
 // deleteRoute removes a route from the routing table
 func (m *mockNetlinkState) deleteRoute(route *mockRoute) error {
 	if m.errorMode.permissionDenied {
-		return fmt.Errorf("operation not permitted")
+		return errors.New("operation not permitted")
 	}
 
 	routes, exists := m.routes[route.table]
 	if !exists {
-		return fmt.Errorf("no such process")
+		return errors.New("no such process")
 	}
 
 	for i, r := range routes {
@@ -241,7 +242,7 @@ func (m *mockNetlinkState) deleteRoute(route *mockRoute) error {
 		}
 	}
 
-	return fmt.Errorf("no such process")
+	return errors.New("no such process")
 }
 
 // listRoutes returns routes matching the filter
@@ -250,7 +251,7 @@ func (m *mockNetlinkState) deleteRoute(route *mockRoute) error {
 //nolint:unused // Reserved for future test extensions and external package usage
 func (m *mockNetlinkState) listRoutes(family, table int, dst *net.IPNet) ([]*mockRoute, error) {
 	if m.errorMode.permissionDenied {
-		return nil, fmt.Errorf("operation not permitted")
+		return nil, errors.New("operation not permitted")
 	}
 
 	var result []*mockRoute
@@ -286,7 +287,7 @@ func (m *mockNetlinkState) listRoutes(family, table int, dst *net.IPNet) ([]*moc
 // addRule adds a policy routing rule
 func (m *mockNetlinkState) addRule(rule *mockRule) error {
 	if m.errorMode.permissionDenied {
-		return fmt.Errorf("operation not permitted")
+		return errors.New("operation not permitted")
 	}
 
 	m.rules = append(m.rules, rule)
@@ -296,7 +297,7 @@ func (m *mockNetlinkState) addRule(rule *mockRule) error {
 // listRules returns policy routing rules matching the filter
 func (m *mockNetlinkState) listRules(family, table, priority int) ([]*mockRule, error) {
 	if m.errorMode.permissionDenied {
-		return nil, fmt.Errorf("operation not permitted")
+		return nil, errors.New("operation not permitted")
 	}
 
 	var result []*mockRule

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"context"
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -41,9 +40,7 @@ const (
 	KubeTunnelIfv6    = "kube-tunnel-v6"
 	KubeBridgeIf      = "kube-bridge"
 	IfaceNotFound     = "Link not found"
-	IfaceHasAddr      = "file exists"
 	IfaceHasNoAddr    = "cannot assign requested address"
-	IpvsServerExists  = "file exists"
 	IpvsMaglevHashing = "mh"
 	IpvsSvcFSched1    = "flag-1"
 	IpvsSvcFSched2    = "flag-2"
@@ -465,18 +462,18 @@ func (nsc *NetworkServicesController) setupIpvsFirewall() error {
 		// Create ipset for local addresses.
 		_, err = ipSetHandler.Create(localIPsIPSetName, utils.TypeHashIP, utils.OptionTimeout, "0")
 		if err != nil {
-			return fmt.Errorf("failed to create ipset: %s - %v", localIPsIPSetName, err)
+			return fmt.Errorf("failed to create ipset: %s - %w", localIPsIPSetName, err)
 		}
 
 		// Create 2 ipsets for services. One for 'ip' and one for 'ip,port'
 		_, err = ipSetHandler.Create(serviceIPsIPSetName, utils.TypeHashIP, utils.OptionTimeout, "0")
 		if err != nil {
-			return fmt.Errorf("failed to create ipset: %s - %v", serviceIPsIPSetName, err)
+			return fmt.Errorf("failed to create ipset: %s - %w", serviceIPsIPSetName, err)
 		}
 
 		_, err = ipSetHandler.Create(serviceIPPortsSetName, utils.TypeHashIPPort, utils.OptionTimeout, "0")
 		if err != nil {
-			return fmt.Errorf("failed to create ipset: %s - %v", serviceIPPortsSetName, err)
+			return fmt.Errorf("failed to create ipset: %s - %w", serviceIPPortsSetName, err)
 		}
 	}
 
@@ -485,7 +482,7 @@ func (nsc *NetworkServicesController) setupIpvsFirewall() error {
 		// ClearChain either clears an existing chain or creates a new one.
 		err = iptablesCmdHandler.ClearChain("filter", ipvsFirewallChainName)
 		if err != nil {
-			return fmt.Errorf("failed to run iptables command: %s", err.Error())
+			return fmt.Errorf("failed to run iptables command: %w", err)
 		}
 
 		// config.IpvsPermitAll: true then create INPUT/KUBE-ROUTER-SERVICE Chain creation else skip
@@ -512,7 +509,7 @@ func (nsc *NetworkServicesController) setupIpvsFirewall() error {
 				icmpRule.IPTablesType, icmpRule.ICMPType, "-j", "ACCEPT"}
 			err = iptablesCmdHandler.AppendUnique("filter", ipvsFirewallChainName, icmpArgs...)
 			if err != nil {
-				return fmt.Errorf("failed to run iptables command: %v", err)
+				return fmt.Errorf("failed to run iptables command: %w", err)
 			}
 		}
 
@@ -522,7 +519,7 @@ func (nsc *NetworkServicesController) setupIpvsFirewall() error {
 			"--match-set", getIPSetName(serviceIPPortsSetName, family), "dst,dst", "-j", "ACCEPT"}
 		err := iptablesCmdHandler.AppendUnique("filter", ipvsFirewallChainName, args...)
 		if err != nil {
-			return fmt.Errorf("failed to run iptables command: %s", err.Error())
+			return fmt.Errorf("failed to run iptables command: %w", err)
 		}
 
 		// We exclude the local addresses here as that would otherwise block all traffic to local addresses if any
@@ -533,19 +530,19 @@ func (nsc *NetworkServicesController) setupIpvsFirewall() error {
 			"-j", "REJECT", "--reject-with", icmpRejectType}
 		err = iptablesCmdHandler.AppendUnique("filter", ipvsFirewallChainName, args...)
 		if err != nil {
-			return fmt.Errorf("failed to run iptables command: %s", err.Error())
+			return fmt.Errorf("failed to run iptables command: %w", err)
 		}
 
 		// Pass incoming traffic into our custom chain.
 		ipvsFirewallInputChainRule := getIPVSFirewallInputChainRule(family)
 		exists, err = iptablesCmdHandler.Exists("filter", "INPUT", ipvsFirewallInputChainRule...)
 		if err != nil {
-			return fmt.Errorf("failed to run iptables command: %s", err.Error())
+			return fmt.Errorf("failed to run iptables command: %w", err)
 		}
 		if !exists {
 			err = iptablesCmdHandler.Insert("filter", "INPUT", 1, ipvsFirewallInputChainRule...)
 			if err != nil {
-				return fmt.Errorf("failed to run iptables command: %s", err.Error())
+				return fmt.Errorf("failed to run iptables command: %w", err)
 			}
 		}
 	}
@@ -635,7 +632,7 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 	// Populate local addresses ipset.
 	addrsMap, err := getAllLocalIPs()
 	if err != nil {
-		return fmt.Errorf("failed to get local IPs: %s", err)
+		return fmt.Errorf("failed to get local IPs: %w", err)
 	}
 
 	for family, addrs := range addrsMap {
@@ -660,7 +657,7 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 	// Populate service ipsets.
 	ipvsServices, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return errors.New("Failed to list IPVS services: " + err.Error())
+		return fmt.Errorf("Failed to list IPVS services: %w", err)
 	}
 
 	serviceIPsSets := make(map[v1.IPFamily][][]string)
@@ -734,7 +731,7 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 		)
 		err := setHandler.RestoreSets(multiFamilySetNames)
 		if err != nil {
-			return fmt.Errorf("could not save ipset for service firewall: %v", err)
+			return fmt.Errorf("could not save ipset for service firewall: %w", err)
 		}
 	}
 
@@ -1110,12 +1107,12 @@ func (nsc *NetworkServicesController) ensureMasqueradeIptablesRule() error {
 		if nsc.masqueradeAll {
 			err := iptablesCmdHandler.AppendUnique("nat", "POSTROUTING", args...)
 			if err != nil {
-				return fmt.Errorf("failed to create iptables rule to masquerade all outbound IPVS traffic: %v", err)
+				return fmt.Errorf("failed to create iptables rule to masquerade all outbound IPVS traffic: %w", err)
 			}
 		} else {
 			exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", args...)
 			if err != nil {
-				return fmt.Errorf("failed to lookup iptables rule to masquerade all outbound IPVS traffic: %v", err)
+				return fmt.Errorf("failed to lookup iptables rule to masquerade all outbound IPVS traffic: %w", err)
 			}
 			if exists {
 				err = iptablesCmdHandler.Delete("nat", "POSTROUTING", args...)
@@ -1138,7 +1135,7 @@ func (nsc *NetworkServicesController) ensureMasqueradeIptablesRule() error {
 
 			err := iptablesCmdHandler.AppendUnique("nat", "POSTROUTING", args...)
 			if err != nil {
-				return fmt.Errorf("failed to run iptables command: %v", err)
+				return fmt.Errorf("failed to run iptables command: %w", err)
 			}
 		}
 	}
@@ -1183,7 +1180,7 @@ func (nsc *NetworkServicesController) deleteBadMasqueradeIptablesRules() error {
 		for _, args := range argsBad {
 			exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", args...)
 			if err != nil {
-				return fmt.Errorf("failed to lookup iptables rule: %v", err)
+				return fmt.Errorf("failed to lookup iptables rule: %w", err)
 			}
 
 			if exists {
@@ -1299,14 +1296,14 @@ func (nsc *NetworkServicesController) syncHairpinIptablesRules() error {
 		klog.V(1).Info("No IPv4 hairpin-mode enabled services found -- no hairpin rules created")
 		err := nsc.deleteHairpinIptablesRules(v1.IPv4Protocol)
 		if err != nil {
-			return fmt.Errorf("error deleting hairpin rules: %v", err)
+			return fmt.Errorf("error deleting hairpin rules: %w", err)
 		}
 	}
 	if len(ipv6RulesNeeded) == 0 && nsc.krNode.IsIPv6Capable() {
 		klog.V(1).Info("No IPv6 hairpin-mode enabled services found -- no hairpin rules created")
 		err := nsc.deleteHairpinIptablesRules(v1.IPv6Protocol)
 		if err != nil {
-			return fmt.Errorf("error deleting hairpin rules: %v", err)
+			return fmt.Errorf("error deleting hairpin rules: %w", err)
 		}
 	}
 	// If both rulesets are blank, then return now as our work is done
@@ -1332,7 +1329,7 @@ func (nsc *NetworkServicesController) syncHairpinIptablesRules() error {
 
 		rulesFromNode, err := iptablesCmdHandler.List("nat", ipvsHairpinChainName)
 		if err != nil {
-			return fmt.Errorf("failed to get rules from iptables chain \"%s\": %v", ipvsHairpinChainName, err)
+			return fmt.Errorf("failed to get rules from iptables chain \"%s\": %w", ipvsHairpinChainName, err)
 		}
 
 		// Apply the rules we need
@@ -1347,7 +1344,7 @@ func (nsc *NetworkServicesController) syncHairpinIptablesRules() error {
 			if !ruleExists {
 				err = iptablesCmdHandler.AppendUnique("nat", ipvsHairpinChainName, ruleArgs...)
 				if err != nil {
-					return fmt.Errorf("failed to apply hairpin iptables rule: %v", err)
+					return fmt.Errorf("failed to apply hairpin iptables rule: %w", err)
 				}
 			}
 		}
@@ -1389,7 +1386,7 @@ func (nsc *NetworkServicesController) deleteHairpinIptablesRules(family v1.IPFam
 	// TODO: Factor out this code
 	chains, err := iptablesCmdHandler.ListChains("nat")
 	if err != nil {
-		return errors.New("Failed to list iptables chains: " + err.Error())
+		return fmt.Errorf("Failed to list iptables chains: %w", err)
 	}
 
 	// TODO: Factor these variables out
@@ -1412,7 +1409,7 @@ func (nsc *NetworkServicesController) deleteHairpinIptablesRules(family v1.IPFam
 	jumpArgs := []string{"-m", "ipvs", "--vdir", "ORIGINAL", "-j", ipvsHairpinChainName}
 	hasHairpinJumpRule, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", jumpArgs...)
 	if err != nil {
-		return fmt.Errorf("failed to search POSTROUTING iptables rules: %v", err)
+		return fmt.Errorf("failed to search POSTROUTING iptables rules: %w", err)
 	}
 
 	// Delete the jump rule to the hairpin chain
@@ -1428,11 +1425,11 @@ func (nsc *NetworkServicesController) deleteHairpinIptablesRules(family v1.IPFam
 	// Flush and delete the chain for hairpin rules
 	err = iptablesCmdHandler.ClearChain("nat", ipvsHairpinChainName)
 	if err != nil {
-		return fmt.Errorf("failed to flush iptables chain \"%s\": %v", ipvsHairpinChainName, err)
+		return fmt.Errorf("failed to flush iptables chain \"%s\": %w", ipvsHairpinChainName, err)
 	}
 	err = iptablesCmdHandler.DeleteChain("nat", ipvsHairpinChainName)
 	if err != nil {
-		return fmt.Errorf("failed to delete iptables chain \"%s\": %v", ipvsHairpinChainName, err)
+		return fmt.Errorf("failed to delete iptables chain \"%s\": %w", ipvsHairpinChainName, err)
 	}
 
 	return nil
@@ -1442,13 +1439,13 @@ func (nsc *NetworkServicesController) deleteMasqueradeIptablesRule() error {
 	for _, iptablesCmdHandler := range nsc.iptablesCmdHandlers {
 		postRoutingChainRules, err := iptablesCmdHandler.List("nat", "POSTROUTING")
 		if err != nil {
-			return errors.New("Failed to list iptables rules in POSTROUTING chain in nat table" + err.Error())
+			return fmt.Errorf("Failed to list iptables rules in POSTROUTING chain in nat table: %w", err)
 		}
 		for i, rule := range postRoutingChainRules {
 			if strings.Contains(rule, "ipvs") && strings.Contains(rule, "SNAT") {
 				err = iptablesCmdHandler.Delete("nat", "POSTROUTING", strconv.Itoa(i))
 				if err != nil {
-					return errors.New("Failed to run iptables command" + err.Error())
+					return fmt.Errorf("Failed to run iptables command: %w", err)
 				}
 				klog.V(2).Infof("Deleted iptables masquerade rule: %s", rule)
 				break
@@ -1512,7 +1509,7 @@ func ipvsSetPersistence(svc *ipvs.Service, p bool, timeout int32) error {
 	if p {
 		uTimeout, err := safecast.Convert[uint32](timeout)
 		if err != nil {
-			return fmt.Errorf("failed to convert timeout to uint32: %v", err)
+			return fmt.Errorf("failed to convert timeout to uint32: %w", err)
 		}
 
 		svc.Flags |= ipvsPersistentFlagHex
@@ -1582,11 +1579,11 @@ func (nsc *NetworkServicesController) setupMangleTableRule(ip string, protocol s
 	args := []string{"-d", ip, "-m", protocol, "-p", protocol, "--dport", port, "-j", "MARK", "--set-mark", fwmark}
 	err := iptablesCmdHandler.AppendUnique("mangle", "PREROUTING", args...)
 	if err != nil {
-		return fmt.Errorf("failed to run iptables command to set up FWMARK due to %v", err)
+		return fmt.Errorf("failed to run iptables command to set up FWMARK due to %w", err)
 	}
 	err = iptablesCmdHandler.AppendUnique("mangle", "OUTPUT", args...)
 	if err != nil {
-		return fmt.Errorf("failed to run iptables command to set up FWMARK due to %v", err)
+		return fmt.Errorf("failed to run iptables command to set up FWMARK due to %w", err)
 	}
 
 	// setup iptables rule TCPMSS for DSR mode to fix mtu problem
@@ -1596,7 +1593,7 @@ func (nsc *NetworkServicesController) setupMangleTableRule(ip string, protocol s
 			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(tcpMSS)}
 		err = iptablesCmdHandler.AppendUnique("mangle", "PREROUTING", mtuArgs...)
 		if err != nil {
-			return fmt.Errorf("failed to run iptables command to set up TCPMSS due to %v", err)
+			return fmt.Errorf("failed to run iptables command to set up TCPMSS due to %w", err)
 		}
 	}
 
@@ -1609,13 +1606,13 @@ func (nsc *NetworkServicesController) setupMangleTableRule(ip string, protocol s
 		klog.V(2).Infof("looking for mangle rule with: %s -t mangle %s", chain, prevMTUArgs)
 		exists, err := iptablesCmdHandler.Exists("mangle", chain, prevMTUArgs...)
 		if err != nil {
-			return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %v", err)
+			return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %w", err)
 		}
 		if exists {
 			klog.V(2).Infof("removing mangle rule with: iptables -D %s -t mangle %s", chain, prevMTUArgs)
 			err = iptablesCmdHandler.Delete("mangle", chain, prevMTUArgs...)
 			if err != nil {
-				return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %v", err)
+				return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %w", err)
 			}
 		}
 	}
@@ -1640,14 +1637,14 @@ func (nsc *NetworkServicesController) setupMangleTableRule(ip string, protocol s
 					"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(oldIncorrectIPv6MSS)}
 				exists, err := iptablesCmdHandler.Exists("mangle", chain, oldIncorrectArgs...)
 				if err != nil {
-					return fmt.Errorf("failed to check for old incorrect IPv6 TCPMSS rule in %s due to %v", chain, err)
+					return fmt.Errorf("failed to check for old incorrect IPv6 TCPMSS rule in %s due to %w", chain, err)
 				}
 				if exists {
 					klog.V(2).Infof("removing old incorrect IPv6 TCPMSS rule with MSS %d: ip6tables -D %s -t mangle %v",
 						oldIncorrectIPv6MSS, chain, oldIncorrectArgs)
 					err = iptablesCmdHandler.Delete("mangle", chain, oldIncorrectArgs...)
 					if err != nil {
-						return fmt.Errorf("failed to delete old incorrect IPv6 TCPMSS rule from %s due to %v", chain, err)
+						return fmt.Errorf("failed to delete old incorrect IPv6 TCPMSS rule from %s due to %w", chain, err)
 					}
 				}
 			}
@@ -1658,14 +1655,14 @@ func (nsc *NetworkServicesController) setupMangleTableRule(ip string, protocol s
 				"--set-mss", strconv.Itoa(oldIncorrectIPv6MSS)}
 			exists, err := iptablesCmdHandler.Exists("mangle", "PREROUTING", currentFormatOldMSS...)
 			if err != nil {
-				return fmt.Errorf("failed to check for old incorrect IPv6 TCPMSS rule (current format) due to %v", err)
+				return fmt.Errorf("failed to check for old incorrect IPv6 TCPMSS rule (current format) due to %w", err)
 			}
 			if exists {
 				klog.V(2).Infof("removing old incorrect IPv6 TCPMSS rule (current format) with MSS %d",
 					oldIncorrectIPv6MSS)
 				err = iptablesCmdHandler.Delete("mangle", "PREROUTING", currentFormatOldMSS...)
 				if err != nil {
-					return fmt.Errorf("failed to delete old incorrect IPv6 TCPMSS rule (current format) due to %v", err)
+					return fmt.Errorf("failed to delete old incorrect IPv6 TCPMSS rule (current format) due to %w", err)
 				}
 			}
 		}
@@ -1693,24 +1690,24 @@ func (nsc *NetworkServicesController) cleanupMangleTableRule(ip string, protocol
 	args := []string{"-d", ip, "-m", protocol, "-p", protocol, "--dport", port, "-j", "MARK", "--set-mark", fwmark}
 	exists, err := iptablesCmdHandler.Exists("mangle", "PREROUTING", args...)
 	if err != nil {
-		return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %v", err)
+		return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %w", err)
 	}
 	if exists {
 		klog.V(2).Infof("removing mangle rule with: iptables -D PREROUTING -t mangle %s", args)
 		err = iptablesCmdHandler.Delete("mangle", "PREROUTING", args...)
 		if err != nil {
-			return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %v", err)
+			return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %w", err)
 		}
 	}
 	exists, err = iptablesCmdHandler.Exists("mangle", "OUTPUT", args...)
 	if err != nil {
-		return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %v", err)
+		return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %w", err)
 	}
 	if exists {
 		klog.V(2).Infof("removing mangle rule with: iptables -D OUTPUT -t mangle %s", args)
 		err = iptablesCmdHandler.Delete("mangle", "OUTPUT", args...)
 		if err != nil {
-			return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %v", err)
+			return fmt.Errorf("failed to cleanup iptables command to set up FWMARK due to %w", err)
 		}
 	}
 
@@ -1721,13 +1718,13 @@ func (nsc *NetworkServicesController) cleanupMangleTableRule(ip string, protocol
 			"--tcp-flags", "SYN,RST", "SYN", "-j", "TCPMSS", "--set-mss", strconv.Itoa(tcpMSS)}
 		exists, err = iptablesCmdHandler.Exists("mangle", "PREROUTING", mtuArgs...)
 		if err != nil {
-			return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %v", err)
+			return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %w", err)
 		}
 		if exists {
 			klog.V(2).Infof("removing mangle rule with: iptables -D PREROUTING -t mangle %s", args)
 			err = iptablesCmdHandler.Delete("mangle", "PREROUTING", mtuArgs...)
 			if err != nil {
-				return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %v", err)
+				return fmt.Errorf("failed to cleanup iptables command to set up TCPMSS due to %w", err)
 			}
 		}
 	}
@@ -1754,7 +1751,7 @@ var routeVIPTrafficToDirector = func(fwmark uint32, family v1.IPFamily) error {
 	routes, err := nlretry.RuleListFiltered(context.Background(), nFamily, nRule,
 		netlink.RT_FILTER_MARK|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_PRIORITY)
 	if err != nil {
-		return fmt.Errorf("failed to verify if `ip rule` exists due to: %v", err)
+		return fmt.Errorf("failed to verify if `ip rule` exists due to: %w", err)
 	}
 
 	if len(routes) < 1 {
@@ -2068,18 +2065,18 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 	if config.RunRouter {
 		node, err := utils.GetNodeObject(nsc.client, config.HostnameOverride)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get node object due to: %v", err.Error())
+			return nil, fmt.Errorf("failed to get node object due to: %w", err)
 		}
 
 		cidr, err := utils.GetPodCidrFromNodeSpec(node)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get pod CIDR details from Node.spec: %v", err)
+			return nil, fmt.Errorf("failed to get pod CIDR details from Node.spec: %w", err)
 		}
 		nsc.podCidr = cidr
 
 		nsc.podIPv4CIDRs, nsc.podIPv6CIDRs, err = utils.GetPodCIDRsFromNodeSpecDualStack(node)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get pod CIDRs detail from Node.spec: %v", err)
+			return nil, fmt.Errorf("failed to get pod CIDRs detail from Node.spec: %w", err)
 		}
 	}
 
@@ -2087,7 +2084,7 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 	for i, excludedCidr := range config.ExcludedCidrs {
 		_, ipnet, err := net.ParseCIDR(excludedCidr)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get excluded CIDR details: %v", err)
+			return nil, fmt.Errorf("failed to get excluded CIDR details: %w", err)
 		}
 		nsc.excludedCidrs[i] = *ipnet
 	}

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -393,7 +394,7 @@ func (nsc *NetworkServicesController) Run(healthChan chan<- *healthcheck.Control
 				}
 				nsc.mu.Unlock()
 				if syncErrors {
-					err = fmt.Errorf("one or more errors during ipvs sync")
+					err = errors.New("one or more errors during ipvs sync")
 				}
 			}
 			if err == nil {
@@ -657,7 +658,7 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 	// Populate service ipsets.
 	ipvsServices, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return fmt.Errorf("Failed to list IPVS services: %w", err)
+		return fmt.Errorf("failed to list IPVS services: %w", err)
 	}
 
 	serviceIPsSets := make(map[v1.IPFamily][][]string)
@@ -1386,7 +1387,7 @@ func (nsc *NetworkServicesController) deleteHairpinIptablesRules(family v1.IPFam
 	// TODO: Factor out this code
 	chains, err := iptablesCmdHandler.ListChains("nat")
 	if err != nil {
-		return fmt.Errorf("Failed to list iptables chains: %w", err)
+		return fmt.Errorf("failed to list iptables chains: %w", err)
 	}
 
 	// TODO: Factor these variables out
@@ -1439,13 +1440,13 @@ func (nsc *NetworkServicesController) deleteMasqueradeIptablesRule() error {
 	for _, iptablesCmdHandler := range nsc.iptablesCmdHandlers {
 		postRoutingChainRules, err := iptablesCmdHandler.List("nat", "POSTROUTING")
 		if err != nil {
-			return fmt.Errorf("Failed to list iptables rules in POSTROUTING chain in nat table: %w", err)
+			return fmt.Errorf("failed to list iptables rules in POSTROUTING chain in nat table: %w", err)
 		}
 		for i, rule := range postRoutingChainRules {
 			if strings.Contains(rule, "ipvs") && strings.Contains(rule, "SNAT") {
 				err = iptablesCmdHandler.Delete("nat", "POSTROUTING", strconv.Itoa(i))
 				if err != nil {
-					return fmt.Errorf("Failed to run iptables command: %w", err)
+					return fmt.Errorf("failed to run iptables command: %w", err)
 				}
 				klog.V(2).Infof("Deleted iptables masquerade rule: %s", rule)
 				break

--- a/pkg/controllers/proxy/network_services_controller_test.go
+++ b/pkg/controllers/proxy/network_services_controller_test.go
@@ -1782,7 +1782,7 @@ func TestDSR_TwoDSRServicesSameIPDifferentPorts(t *testing.T) {
 	for i, svcName := range []string{"dsr-svc-1", "dsr-svc-2"} {
 		endpointSlice := &discoveryv1.EndpointSlice{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-slice", svcName),
+				Name:      svcName + "-slice",
 				Namespace: "default",
 				Labels:    map[string]string{discoveryv1.LabelServiceName: svcName},
 			},
@@ -1935,7 +1935,7 @@ func TestDSR_FWMarkCollisionCase_Issue1045(t *testing.T) {
 	// Create minimal endpoints
 	for i, svcName := range []string{"collision-svc-1", "collision-svc-2"} {
 		endpointSlice := &discoveryv1.EndpointSlice{
-			ObjectMeta:  metav1.ObjectMeta{Name: fmt.Sprintf("%s-slice", svcName), Namespace: "default", Labels: map[string]string{discoveryv1.LabelServiceName: svcName}},
+			ObjectMeta:  metav1.ObjectMeta{Name: svcName + "-slice", Namespace: "default", Labels: map[string]string{discoveryv1.LabelServiceName: svcName}},
 			AddressType: discoveryv1.AddressTypeIPv4,
 			Endpoints:   []discoveryv1.Endpoint{{Addresses: []string{fmt.Sprintf("172.20.1.%d", i+1)}, NodeName: testutils.ValToPtr("localnode-1"), Conditions: discoveryv1.EndpointConditions{Ready: testutils.ValToPtr(true)}}},
 			Ports:       []discoveryv1.EndpointPort{{Name: testutils.ValToPtr("port"), Port: testutils.ValToPtr(int32(80)), Protocol: testutils.ValToPtr(v1core.ProtocolTCP)}},

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -270,7 +270,7 @@ func (nsc *NetworkServicesController) setupNodePortServices(serviceInfoMap servi
 	endpointsInfoMap endpointSliceInfoMap, activeServiceEndpointMap map[string][]string) error {
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return fmt.Errorf("Failed get list of IPVS services due to: %w", err)
+		return fmt.Errorf("failed get list of IPVS services due to: %w", err)
 	}
 
 	// For each Service in our service map
@@ -538,17 +538,17 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svcIn *servic
 
 	dummyVipInterface, err := nsc.ln.getKubeDummyInterface()
 	if err != nil {
-		return fmt.Errorf("Failed getting dummy interface: %w", err)
+		return fmt.Errorf("failed getting dummy interface: %w", err)
 	}
 
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return fmt.Errorf("Failed get list of IPVS services due to: %w", err)
+		return fmt.Errorf("failed get list of IPVS services due to: %w", err)
 	}
 
 	fwMark, err := nsc.generateUniqueFWMark(externalIP.String(), svcIn.protocol, strconv.Itoa(svcIn.port))
 	if err != nil {
-		return fmt.Errorf("failed to generate FW mark")
+		return errors.New("failed to generate FW mark")
 	}
 
 	sInPort, err := safecast.Convert[uint16](svcIn.port)
@@ -563,12 +563,12 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svcIn *servic
 			fwMark, externalIP, err.Error())
 	}
 
-	externalIPServiceID := fmt.Sprint(fwMark)
+	externalIPServiceID := strconv.FormatUint(uint64(fwMark), 10)
 
 	// ensure there is iptables mangle table rule to FWMARK the packet
 	err = nsc.setupMangleTableRule(externalIP.String(), svcIn.protocol, strconv.Itoa(svcIn.port), externalIPServiceID)
 	if err != nil {
-		return fmt.Errorf("failed to setup mangle table rule to forward the traffic to external IP")
+		return errors.New("failed to setup mangle table rule to forward the traffic to external IP")
 	}
 
 	// ensure VIP less director. we dont assign VIP to any interface
@@ -655,7 +655,7 @@ func (nsc *NetworkServicesController) setupForDSR(serviceInfoMap serviceInfoMap)
 	klog.V(1).Infof("Setting up policy routing required for Direct Server Return functionality.")
 	err := nsc.ln.setupPolicyRoutingForDSR(nsc.krNode.IsIPv4Capable(), nsc.krNode.IsIPv6Capable())
 	if err != nil {
-		return fmt.Errorf("Failed setup PBR for DSR due to: %w", err)
+		return fmt.Errorf("failed setup PBR for DSR due to: %w", err)
 	}
 	klog.V(1).Infof("Custom routing table %s required for Direct Server Return is setup as expected.",
 		customDSRRouteTableName)
@@ -691,7 +691,7 @@ func (nsc *NetworkServicesController) cleanupStaleVIPs(activeServiceEndpointMap 
 	cleanupStaleVIPsForFamily := func(intfc netlink.Link, netlinkFamily int) error {
 		addrs, err := nlretry.AddrList(context.Background(), intfc, netlinkFamily)
 		if err != nil {
-			return fmt.Errorf("Failed to list dummy interface IPs: %w", err)
+			return fmt.Errorf("failed to list dummy interface IPs: %w", err)
 		}
 		for _, addr := range addrs {
 			isActive := addrActive[addr.IP.String()]
@@ -761,7 +761,7 @@ func (nsc *NetworkServicesController) cleanupStaleIPVSConfig(activeServiceEndpoi
 		case ipvsSvc.Address != nil:
 			key = generateIPPortID(ipvsSvc.Address.String(), protocol, strconv.Itoa(int(ipvsSvc.Port)))
 		case ipvsSvc.FWMark != 0:
-			key = fmt.Sprint(ipvsSvc.FWMark)
+			key = strconv.FormatUint(uint64(ipvsSvc.FWMark), 10)
 		default:
 			continue
 		}

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -114,7 +114,7 @@ func (nsc *NetworkServicesController) setupClusterIPServices(serviceInfoMap serv
 	endpointsInfoMap endpointSliceInfoMap, activeServiceEndpointMap map[string][]string) error {
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return fmt.Errorf("failed get list of IPVS services due to: %v", err)
+		return fmt.Errorf("failed get list of IPVS services due to: %w", err)
 	}
 
 	for k, svc := range serviceInfoMap {
@@ -133,11 +133,11 @@ func (nsc *NetworkServicesController) setupClusterIPServices(serviceInfoMap serv
 		ipv6NodeIP := nsc.krNode.FindBestIPv6NodeAddress()
 		dummyVipInterface, err := nsc.ln.getKubeDummyInterface()
 		if err != nil {
-			return fmt.Errorf("failed creating dummy interface: %v", err)
+			return fmt.Errorf("failed creating dummy interface: %w", err)
 		}
 		sPort, err := safecast.Convert[uint16](svc.port)
 		if err != nil {
-			return fmt.Errorf("failed to convert service port to uint16: %v", err)
+			return fmt.Errorf("failed to convert service port to uint16: %w", err)
 		}
 
 		for family, famClusIPs := range clusterIPs {
@@ -270,7 +270,7 @@ func (nsc *NetworkServicesController) setupNodePortServices(serviceInfoMap servi
 	endpointsInfoMap endpointSliceInfoMap, activeServiceEndpointMap map[string][]string) error {
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return errors.New("Failed get list of IPVS services due to: " + err.Error())
+		return fmt.Errorf("Failed get list of IPVS services due to: %w", err)
 	}
 
 	// For each Service in our service map
@@ -293,7 +293,7 @@ func (nsc *NetworkServicesController) setupNodePortServices(serviceInfoMap servi
 
 		nPort, err := safecast.Convert[uint16](svc.nodePort)
 		if err != nil {
-			return fmt.Errorf("failed to convert node port to uint16: %v", err)
+			return fmt.Errorf("failed to convert node port to uint16: %w", err)
 		}
 
 		var svcID string
@@ -385,7 +385,7 @@ func (nsc *NetworkServicesController) setupExternalIPServices(serviceInfoMap ser
 					// that was generated to add this external IP to the activeServiceEndpointMap
 					err := nsc.setupExternalIPForDSRService(svc, externalIP, endpoints, activeServiceEndpointMap)
 					if err != nil {
-						return fmt.Errorf("failed to setup DSR endpoint %s: %v", externalIP, err)
+						return fmt.Errorf("failed to setup DSR endpoint %s: %w", externalIP, err)
 					}
 					continue
 				}
@@ -394,7 +394,7 @@ func (nsc *NetworkServicesController) setupExternalIPServices(serviceInfoMap ser
 				// and port to add this external IP to the activeServiceEndpointMap
 				err := nsc.setupExternalIPForService(svc, externalIP, endpoints, activeServiceEndpointMap)
 				if err != nil {
-					return fmt.Errorf("failed to setup service endpoint %s: %v", externalIP, err)
+					return fmt.Errorf("failed to setup service endpoint %s: %w", externalIP, err)
 				}
 			}
 		}
@@ -445,22 +445,22 @@ func (nsc *NetworkServicesController) setupExternalIPForService(svc *serviceInfo
 
 	dummyVipInterface, err := nsc.ln.getKubeDummyInterface()
 	if err != nil {
-		return fmt.Errorf("failed creating dummy interface: %v", err)
+		return fmt.Errorf("failed creating dummy interface: %w", err)
 	}
 
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return fmt.Errorf("failed get list of IPVS services due to: %v", err)
+		return fmt.Errorf("failed get list of IPVS services due to: %w", err)
 	}
 
 	sPort, err := safecast.Convert[uint16](svc.port)
 	if err != nil {
-		return fmt.Errorf("failed to convert service port to uint16: %v", err)
+		return fmt.Errorf("failed to convert service port to uint16: %w", err)
 	}
 
 	// ensure director with vip assigned
 	err = nsc.ln.ipAddrAdd(dummyVipInterface, externalIP.String(), nodeIP.String(), true)
-	if err != nil && err.Error() != IfaceHasAddr {
+	if err != nil && !errors.Is(err, syscall.EEXIST) {
 		return fmt.Errorf("failed to assign external ip %s to dummy interface %s due to %v",
 			externalIP, KubeDummyIf, err)
 	}
@@ -480,7 +480,7 @@ func (nsc *NetworkServicesController) setupExternalIPForService(svc *serviceInfo
 		klog.V(2).Infof("the following service '%s:%s:%d' had fwMark associated with it: %d doing "+
 			"additional cleanup", externalIP, svc.protocol, svc.port, fwMark)
 		if err = nsc.cleanupDSRService(fwMark); err != nil {
-			return fmt.Errorf("failed to cleanup DSR service: %v", err)
+			return fmt.Errorf("failed to cleanup DSR service: %w", err)
 		}
 	}
 
@@ -538,12 +538,12 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svcIn *servic
 
 	dummyVipInterface, err := nsc.ln.getKubeDummyInterface()
 	if err != nil {
-		return errors.New("Failed getting dummy interface: " + err.Error())
+		return fmt.Errorf("Failed getting dummy interface: %w", err)
 	}
 
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return errors.New("Failed get list of IPVS services due to: " + err.Error())
+		return fmt.Errorf("Failed get list of IPVS services due to: %w", err)
 	}
 
 	fwMark, err := nsc.generateUniqueFWMark(externalIP.String(), svcIn.protocol, strconv.Itoa(svcIn.port))
@@ -553,7 +553,7 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svcIn *servic
 
 	sInPort, err := safecast.Convert[uint16](svcIn.port)
 	if err != nil {
-		return fmt.Errorf("failed to convert serviceIn port to uint16: %v", err)
+		return fmt.Errorf("failed to convert serviceIn port to uint16: %w", err)
 	}
 
 	ipvsExternalIPSvc, err := nsc.ln.ipvsAddFWMarkService(ipvsSvcs, fwMark, sysFamily, protocol, sInPort,
@@ -574,7 +574,7 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svcIn *servic
 	// ensure VIP less director. we dont assign VIP to any interface
 	err = nsc.ln.ipAddrDel(dummyVipInterface, externalIP.String(), nodeIP.String())
 	if err != nil && err.Error() != IfaceHasNoAddr {
-		return fmt.Errorf("failed to delete external ip address from dummyVipInterface due to %v", err)
+		return fmt.Errorf("failed to delete external ip address from dummyVipInterface due to %w", err)
 	}
 
 	// do policy routing to deliver the packet locally so that IPVS can pick the packet
@@ -617,7 +617,7 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svcIn *servic
 
 		ePort, err := safecast.Convert[uint16](endpoint.port)
 		if err != nil {
-			return fmt.Errorf("failed to convert endpoint port to uint16: %v", err)
+			return fmt.Errorf("failed to convert endpoint port to uint16: %w", err)
 		}
 
 		// create the basic IPVS destination record
@@ -640,7 +640,7 @@ func (nsc *NetworkServicesController) setupExternalIPForDSRService(svcIn *servic
 		if endpoint.isLocal {
 			// add the external IP to a virtual interface inside the pod so that the pod can receive it
 			if err = nsc.addDSRIPInsidePodNetNamespace(externalIP.String(), endpoint.ip); err != nil {
-				return fmt.Errorf("unable to setup DSR receiver inside pod: %v", err)
+				return fmt.Errorf("unable to setup DSR receiver inside pod: %w", err)
 			}
 		}
 
@@ -655,7 +655,7 @@ func (nsc *NetworkServicesController) setupForDSR(serviceInfoMap serviceInfoMap)
 	klog.V(1).Infof("Setting up policy routing required for Direct Server Return functionality.")
 	err := nsc.ln.setupPolicyRoutingForDSR(nsc.krNode.IsIPv4Capable(), nsc.krNode.IsIPv6Capable())
 	if err != nil {
-		return errors.New("Failed setup PBR for DSR due to: " + err.Error())
+		return fmt.Errorf("Failed setup PBR for DSR due to: %w", err)
 	}
 	klog.V(1).Infof("Custom routing table %s required for Direct Server Return is setup as expected.",
 		customDSRRouteTableName)
@@ -691,7 +691,7 @@ func (nsc *NetworkServicesController) cleanupStaleVIPs(activeServiceEndpointMap 
 	cleanupStaleVIPsForFamily := func(intfc netlink.Link, netlinkFamily int) error {
 		addrs, err := nlretry.AddrList(context.Background(), intfc, netlinkFamily)
 		if err != nil {
-			return errors.New("Failed to list dummy interface IPs: " + err.Error())
+			return fmt.Errorf("Failed to list dummy interface IPs: %w", err)
 		}
 		for _, addr := range addrs {
 			isActive := addrActive[addr.IP.String()]
@@ -718,15 +718,15 @@ func (nsc *NetworkServicesController) cleanupStaleVIPs(activeServiceEndpointMap 
 
 	dummyVipInterface, err := nsc.ln.getKubeDummyInterface()
 	if err != nil {
-		return fmt.Errorf("failed creating dummy interface: %v", err)
+		return fmt.Errorf("failed creating dummy interface: %w", err)
 	}
 	err = cleanupStaleVIPsForFamily(dummyVipInterface, netlink.FAMILY_V4)
 	if err != nil {
-		return fmt.Errorf("failed to remove stale IPv4 VIPs: %v", err)
+		return fmt.Errorf("failed to remove stale IPv4 VIPs: %w", err)
 	}
 	err = cleanupStaleVIPsForFamily(dummyVipInterface, netlink.FAMILY_V6)
 	if err != nil {
-		return fmt.Errorf("failed to remove stale IPv6 VIPs: %v", err)
+		return fmt.Errorf("failed to remove stale IPv6 VIPs: %w", err)
 	}
 
 	return nil
@@ -735,7 +735,7 @@ func (nsc *NetworkServicesController) cleanupStaleVIPs(activeServiceEndpointMap 
 func (nsc *NetworkServicesController) cleanupStaleIPVSConfig(activeServiceEndpointMap map[string][]string) error {
 	ipvsSvcs, err := nsc.ln.ipvsGetServices()
 	if err != nil {
-		return errors.New("failed get list of IPVS services due to: " + err.Error())
+		return fmt.Errorf("failed get list of IPVS services due to: %w", err)
 	}
 
 	// cleanup stale ipvs service and servers

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -117,7 +117,7 @@ func (nsc *NetworkServicesController) lookupServiceByFWMark(fwMark uint32) (stri
 	}
 	port, err := strconv.ParseInt(serviceKeySplit[2], 10, 32)
 	if err != nil {
-		return "", "", 0, fmt.Errorf("port number for service key for found FW mark was not a 32-bit int: %v", err)
+		return "", "", 0, fmt.Errorf("port number for service key for found FW mark was not a 32-bit int: %w", err)
 	}
 	return serviceKeySplit[0], serviceKeySplit[1], int(port), nil
 }
@@ -145,7 +145,7 @@ func (nsc *NetworkServicesController) isValidKubeRouterServiceArtifact(address n
 			if nsc.nodeportBindOnAllIP {
 				addrMap, err := getAllLocalIPs()
 				if err != nil {
-					return false, fmt.Errorf("failed to get all local IPs: %v", err)
+					return false, fmt.Errorf("failed to get all local IPs: %w", err)
 				}
 				var addresses []net.IP
 				if address.To4() != nil {
@@ -289,7 +289,7 @@ func (nsc *NetworkServicesController) addDSRIPInsidePodNetNamespace(externalIP, 
 
 	hostNetworkNamespaceHandle, err := netns.Get()
 	if err != nil {
-		return fmt.Errorf("failed to get namespace due to %v", err)
+		return fmt.Errorf("failed to get namespace due to %w", err)
 	}
 	defer utils.CloseCloserDisregardError(&hostNetworkNamespaceHandle)
 
@@ -306,7 +306,7 @@ func (nsc *NetworkServicesController) addDSRIPInsidePodNetNamespace(externalIP, 
 		// ugly workaround, refactoring of pkg/Proxy is required
 		pid, err = nsc.ln.getContainerPidWithCRI(nsc.dsr.runtimeEndpoint, containerID)
 		if err != nil {
-			return fmt.Errorf("failed to prepare endpoint %s to do DSR due to: %v", endpointIP, err)
+			return fmt.Errorf("failed to prepare endpoint %s to do DSR due to: %w", endpointIP, err)
 		}
 	}
 
@@ -521,7 +521,7 @@ func ensureHairpinChain(iptablesCmdHandler utils.IPTablesHandler) error {
 	hasHairpinChain := false
 	chains, err := iptablesCmdHandler.ListChains("nat")
 	if err != nil {
-		return fmt.Errorf("failed to list iptables chains: %v", err)
+		return fmt.Errorf("failed to list iptables chains: %w", err)
 	}
 	for _, chain := range chains {
 		if chain == ipvsHairpinChainName {
@@ -533,7 +533,7 @@ func ensureHairpinChain(iptablesCmdHandler utils.IPTablesHandler) error {
 	if !hasHairpinChain {
 		err = iptablesCmdHandler.NewChain("nat", ipvsHairpinChainName)
 		if err != nil {
-			return fmt.Errorf("failed to create iptables chain \"%s\": %v", ipvsHairpinChainName, err)
+			return fmt.Errorf("failed to create iptables chain \"%s\": %w", ipvsHairpinChainName, err)
 		}
 	}
 
@@ -541,7 +541,7 @@ func ensureHairpinChain(iptablesCmdHandler utils.IPTablesHandler) error {
 	jumpArgs := []string{"-m", "ipvs", "--vdir", "ORIGINAL", "-j", ipvsHairpinChainName}
 	err = iptablesCmdHandler.AppendUnique("nat", "POSTROUTING", jumpArgs...)
 	if err != nil {
-		return fmt.Errorf("failed to add hairpin iptables jump rule: %v", err)
+		return fmt.Errorf("failed to add hairpin iptables jump rule: %w", err)
 	}
 
 	return nil
@@ -555,7 +555,7 @@ func getAllLocalIPs() (map[v1.IPFamily][]net.IP, error) {
 	v6Map := make(map[string]bool)
 	links, err := nlretry.LinkList(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("could not load list of net interfaces: %v", err)
+		return nil, fmt.Errorf("could not load list of net interfaces: %w", err)
 	}
 
 	for _, link := range links {
@@ -569,7 +569,7 @@ func getAllLocalIPs() (map[v1.IPFamily][]net.IP, error) {
 
 		linkAddrs, err := nlretry.AddrList(context.Background(), link, netlink.FAMILY_ALL)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get IPs for interface: %v", err)
+			return nil, fmt.Errorf("failed to get IPs for interface: %w", err)
 		}
 
 		for _, addr := range linkAddrs {

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -62,7 +62,7 @@ func (nsc *NetworkServicesController) generateUniqueFWMark(ip, protocol, port st
 		if increment == 0 {
 			_, err = h.Write([]byte(ip + "-" + protocol + "-" + port))
 		} else {
-			_, err = h.Write([]byte(ip + "-" + protocol + "-" + port + "-" + fmt.Sprintf("%d", increment)))
+			_, err = h.Write([]byte(ip + "-" + protocol + "-" + port + "-" + strconv.Itoa(increment)))
 		}
 		if err != nil {
 			return 0, err
@@ -109,11 +109,11 @@ func (nsc *NetworkServicesController) lookupFWMarkByService(ip, protocol, port s
 func (nsc *NetworkServicesController) lookupServiceByFWMark(fwMark uint32) (string, string, int, error) {
 	serviceKey, ok := nsc.fwMarkMap[fwMark]
 	if !ok {
-		return "", "", 0, fmt.Errorf("could not find service matching the given FW mark")
+		return "", "", 0, errors.New("could not find service matching the given FW mark")
 	}
 	serviceKeySplit := strings.Split(serviceKey, "-")
 	if len(serviceKeySplit) != 3 {
-		return "", "", 0, fmt.Errorf("service key for found FW mark did not have 3 parts, this shouldn't be possible")
+		return "", "", 0, errors.New("service key for found FW mark did not have 3 parts, this shouldn't be possible")
 	}
 	port, err := strconv.ParseInt(serviceKeySplit[2], 10, 32)
 	if err != nil {
@@ -616,5 +616,5 @@ func getLabelFromMap(label string, labels map[string]string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("label doesn't exist in map")
+	return "", errors.New("label doesn't exist in map")
 }

--- a/pkg/controllers/proxy/utils_test.go
+++ b/pkg/controllers/proxy/utils_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -246,8 +247,8 @@ func TestIsValidKubeRouterServiceArtifact(t *testing.T) {
 		{net.ParseIP("172.16.0.2"), 0, true, nil},
 		{net.ParseIP("192.168.1.10"), 30000, true, nil},
 		{net.ParseIP("192.168.1.10"), 30001, true, nil},
-		{net.ParseIP("192.168.1.4"), 0, false, fmt.Errorf("service not found for address 192.168.1.4")},
-		{net.ParseIP("192.168.1.10"), 0, false, fmt.Errorf("service not found for address 192.168.1.10")},
+		{net.ParseIP("192.168.1.4"), 0, false, errors.New("service not found for address 192.168.1.4")},
+		{net.ParseIP("192.168.1.10"), 0, false, errors.New("service not found for address 192.168.1.10")},
 	}
 
 	for _, test := range tests {

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -179,7 +179,7 @@ func (nrc *NetworkRoutingController) syncInternalPeers() {
 				// add rr options with clusterId
 				n.RouteReflector = &gobgpapi.RouteReflector{
 					RouteReflectorClient:    true,
-					RouteReflectorClusterId: fmt.Sprint(nrc.bgpClusterID),
+					RouteReflectorClusterId: nrc.bgpClusterID,
 				}
 			}
 		}

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -604,7 +605,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 	if nrc.pathPrepend {
 		prependAsn, err := strconv.ParseUint(nrc.pathPrependAS, 10, asnMaxBitSize)
 		if err != nil {
-			return fmt.Errorf("Invalid value for kube-router.io/path-prepend.as: %w", err)
+			return fmt.Errorf("invalid value for kube-router.io/path-prepend.as: %w", err)
 		}
 		bgpActions = gobgpapi.Actions{
 			AsPrepend: &gobgpapi.AsPrependAction{
@@ -775,7 +776,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 	}
 	err := nrc.bgpServer.ListPolicy(context.Background(), &gobgpapi.ListPolicyRequest{}, checkExistingPolicy)
 	if err != nil {
-		return fmt.Errorf("Failed to verify if kube-router BGP export policy exists: %w", err)
+		return fmt.Errorf("failed to verify if kube-router BGP export policy exists: %w", err)
 	}
 
 	// If this is the first time this is run and there is no current policy in GoBGP initialize it before sending it off
@@ -933,7 +934,7 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 	}
 	err := nrc.bgpServer.ListPolicy(context.Background(), &gobgpapi.ListPolicyRequest{}, checkExistingPolicy)
 	if err != nil {
-		return fmt.Errorf("Failed to verify if kube-router BGP export policy exists: %w", err)
+		return fmt.Errorf("failed to verify if kube-router BGP export policy exists: %w", err)
 	}
 
 	// If this is the first time this is run and there is no current policy in GoBGP initialize it before sending it off
@@ -1051,7 +1052,7 @@ func (nrc *NetworkRoutingController) incrementAndCreatePolicy(curPolName string,
 	var err error
 	// sanity check
 	if curPolName == "" {
-		return fmt.Errorf("we require that curPolName be non-blank before calling this method")
+		return errors.New("we require that curPolName be non-blank before calling this method")
 	}
 
 	matches := rePolicyVersionExtractor.FindStringSubmatch(curPolName)
@@ -1074,7 +1075,7 @@ func (nrc *NetworkRoutingController) incrementAndCreatePolicy(curPolName string,
 		ReferExistingStatements: true,
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to add policy: %w", err)
+		return fmt.Errorf("failed to add policy: %w", err)
 	}
 
 	return nil
@@ -1096,7 +1097,7 @@ func (nrc *NetworkRoutingController) assignPolicyByName(newPolicy *gobgpapi.Poli
 		&gobgpapi.ListPolicyAssignmentRequest{Name: "global", Direction: polDir},
 		checkExistingPolicyAssignment)
 	if err != nil {
-		return fmt.Errorf("Failed to verify if kube-router BGP export policy assignment exists: %w", err)
+		return fmt.Errorf("failed to verify if kube-router BGP export policy assignment exists: %w", err)
 	}
 	if policyAssignmentExists {
 		return nil
@@ -1112,7 +1113,7 @@ func (nrc *NetworkRoutingController) assignPolicyByName(newPolicy *gobgpapi.Poli
 	err = nrc.bgpServer.AddPolicyAssignment(context.Background(),
 		&gobgpapi.AddPolicyAssignmentRequest{Assignment: &policyAssignment})
 	if err != nil {
-		return fmt.Errorf("Failed to add policy assignment: %w", err)
+		return fmt.Errorf("failed to add policy assignment: %w", err)
 	}
 
 	return nil

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -2,12 +2,10 @@ package routing
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
-	"reflect"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -124,7 +122,7 @@ func (nrc *NetworkRoutingController) addPodCidrDefinedSet() error {
 			for _, cidr := range cidrs {
 				_, ipNet, err := net.ParseCIDR(cidr)
 				if err != nil {
-					return fmt.Errorf("couldn't parse CIDR: %s - %v", cidr, err)
+					return fmt.Errorf("couldn't parse CIDR: %s - %w", cidr, err)
 				}
 				cidrLen, _ := ipNet.Mask.Size()
 				var cidrMax int
@@ -138,7 +136,7 @@ func (nrc *NetworkRoutingController) addPodCidrDefinedSet() error {
 				}
 				uCIDRLen, err := safecast.Convert[uint32](cidrLen)
 				if err != nil {
-					return fmt.Errorf("failed to convert CIDR length to uint32: %v", err)
+					return fmt.Errorf("failed to convert CIDR length to uint32: %w", err)
 				}
 				prefixes = append(prefixes, &gobgpapi.Prefix{
 					IpPrefix:      cidr,
@@ -217,13 +215,15 @@ func (nrc *NetworkRoutingController) addServiceVIPsDefinedSet() error {
 		}
 
 		currentPrefixes := currentDefinedSet.Prefixes
-		sort.SliceStable(advIPPrefixList, func(i, j int) bool {
-			return advIPPrefixList[i].IpPrefix < advIPPrefixList[j].IpPrefix
+		slices.SortStableFunc(advIPPrefixList, func(a, b *gobgpapi.Prefix) int {
+			return strings.Compare(a.IpPrefix, b.IpPrefix)
 		})
-		sort.SliceStable(currentPrefixes, func(i, j int) bool {
-			return currentPrefixes[i].IpPrefix < currentPrefixes[j].IpPrefix
+		slices.SortStableFunc(currentPrefixes, func(a, b *gobgpapi.Prefix) int {
+			return strings.Compare(a.IpPrefix, b.IpPrefix)
 		})
-		if reflect.DeepEqual(advIPPrefixList, currentPrefixes) {
+		if slices.EqualFunc(advIPPrefixList, currentPrefixes, func(a, b *gobgpapi.Prefix) bool {
+			return a.IpPrefix == b.IpPrefix && a.MaskLengthMin == b.MaskLengthMin && a.MaskLengthMax == b.MaskLengthMax
+		}) {
 			continue
 		}
 		toAdd := make([]*gobgpapi.Prefix, 0)
@@ -326,7 +326,7 @@ func (nrc *NetworkRoutingController) addCustomImportRejectDefinedSet() error {
 
 			uIntMask, err := safecast.Convert[uint32](mask)
 			if err != nil {
-				return fmt.Errorf("failed to convert mask to uint32: %v", err)
+				return fmt.Errorf("failed to convert mask to uint32: %w", err)
 			}
 
 			prefix.MaskLengthMin = uIntMask
@@ -392,9 +392,9 @@ func (nrc *NetworkRoutingController) addiBGPPeersDefinedSet() (map[v1core.IPFami
 		}
 
 		currentCIDRs := currentDefinedSet.List
-		sort.Strings(iBGPPeerCIDRs[family])
-		sort.Strings(currentCIDRs)
-		if reflect.DeepEqual(iBGPPeerCIDRs, currentCIDRs) {
+		slices.Sort(iBGPPeerCIDRs[family])
+		slices.Sort(currentCIDRs)
+		if slices.Equal(iBGPPeerCIDRs[family], currentCIDRs) {
 			continue
 		}
 		toAdd := make([]string, 0)
@@ -604,7 +604,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 	if nrc.pathPrepend {
 		prependAsn, err := strconv.ParseUint(nrc.pathPrependAS, 10, asnMaxBitSize)
 		if err != nil {
-			return errors.New("Invalid value for kube-router.io/path-prepend.as: " + err.Error())
+			return fmt.Errorf("Invalid value for kube-router.io/path-prepend.as: %w", err)
 		}
 		bgpActions = gobgpapi.Actions{
 			AsPrepend: &gobgpapi.AsPrependAction{
@@ -647,7 +647,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 				Name:    podSet + iBGPPeerSet,
 			}
 			if err = nrc.ensureStatementExists(&statement); err != nil {
-				return fmt.Errorf("could not check or create statement: %s - %v", statement.Name, err)
+				return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
 			}
 			statementNames = append(statementNames, statement.Name)
 		}
@@ -709,7 +709,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 					Name:    serviceVIPSet + peerSet,
 				}
 				if err = nrc.ensureStatementExists(&statement); err != nil {
-					return fmt.Errorf("could not check or create statement: %s - %v", statement.Name, err)
+					return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
 				}
 				statementNames = append(statementNames, statement.Name)
 			}
@@ -744,7 +744,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 						Name:    podSet + peerSet,
 					}
 					if err = nrc.ensureStatementExists(&statement); err != nil {
-						return fmt.Errorf("could not check or create statement: %s - %v", statement.Name, err)
+						return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
 					}
 					statementNames = append(statementNames, statement.Name)
 				}
@@ -775,7 +775,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 	}
 	err := nrc.bgpServer.ListPolicy(context.Background(), &gobgpapi.ListPolicyRequest{}, checkExistingPolicy)
 	if err != nil {
-		return errors.New("Failed to verify if kube-router BGP export policy exists: " + err.Error())
+		return fmt.Errorf("Failed to verify if kube-router BGP export policy exists: %w", err)
 	}
 
 	// If this is the first time this is run and there is no current policy in GoBGP initialize it before sending it off
@@ -794,14 +794,14 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 	klog.Infof("Current policy does not appear to match new policy: %s - creating new policy",
 		newPolicy.Name)
 	if err = nrc.incrementAndCreatePolicy(currentPolicyName, &newPolicy); err != nil {
-		return fmt.Errorf("could not increment and create new policy: %v", err)
+		return fmt.Errorf("could not increment and create new policy: %w", err)
 	}
 
 	klog.Infof("Ensuring that policy %s is assigned", newPolicy.Name)
 	err = nrc.assignPolicyByName(&newPolicy, gobgpapi.PolicyDirection_POLICY_DIRECTION_EXPORT,
 		gobgpapi.RouteAction_ROUTE_ACTION_REJECT)
 	if err != nil {
-		return fmt.Errorf("could not assign policy by name: %v", err)
+		return fmt.Errorf("could not assign policy by name: %w", err)
 	}
 
 	if currentPolicyFound {
@@ -809,7 +809,7 @@ func (nrc *NetworkRoutingController) addExportPolicies() error {
 			newPolicy.Name, currentPolicyName)
 		if err = nrc.unassignAndRemovePolicy(currentPolicyName, gobgpapi.PolicyDirection_POLICY_DIRECTION_EXPORT,
 			gobgpapi.RouteAction_ROUTE_ACTION_REJECT); err != nil {
-			return fmt.Errorf("could not clean up old policy: %v", err)
+			return fmt.Errorf("could not clean up old policy: %w", err)
 		}
 	}
 
@@ -864,7 +864,7 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 				Name:    vipSet + peerSet,
 			}
 			if err = nrc.ensureStatementExists(&statement); err != nil {
-				return fmt.Errorf("could not check or create statement: %s - %v", statement.Name, err)
+				return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
 			}
 			statementNames = append(statementNames, statement.Name)
 		}
@@ -884,7 +884,7 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 			Name:    defaultRouteSet + peerSet,
 		}
 		if err = nrc.ensureStatementExists(&statement); err != nil {
-			return fmt.Errorf("could not check or create statement: %s - %v", statement.Name, err)
+			return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
 		}
 		statementNames = append(statementNames, statement.Name)
 
@@ -904,7 +904,7 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 				Name:    customImportRejectSet + peerSet,
 			}
 			if err = nrc.ensureStatementExists(&statement); err != nil {
-				return fmt.Errorf("could not check or create statement: %s - %v", statement.Name, err)
+				return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
 			}
 			statementNames = append(statementNames, statement.Name)
 		}
@@ -933,7 +933,7 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 	}
 	err := nrc.bgpServer.ListPolicy(context.Background(), &gobgpapi.ListPolicyRequest{}, checkExistingPolicy)
 	if err != nil {
-		return errors.New("Failed to verify if kube-router BGP export policy exists: " + err.Error())
+		return fmt.Errorf("Failed to verify if kube-router BGP export policy exists: %w", err)
 	}
 
 	// If this is the first time this is run and there is no current policy in GoBGP initialize it before sending it off
@@ -952,14 +952,14 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 	klog.Infof("Current policy does not appear to match new policy: %s - creating new policy",
 		newPolicy.Name)
 	if err = nrc.incrementAndCreatePolicy(currentPolicyName, &newPolicy); err != nil {
-		return fmt.Errorf("could not increment and create new policy: %v", err)
+		return fmt.Errorf("could not increment and create new policy: %w", err)
 	}
 
 	klog.Infof("Ensuring that policy %s is assigned", newPolicy.Name)
 	err = nrc.assignPolicyByName(&newPolicy, gobgpapi.PolicyDirection_POLICY_DIRECTION_IMPORT,
 		gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT)
 	if err != nil {
-		return fmt.Errorf("could not assign policy by name: %v", err)
+		return fmt.Errorf("could not assign policy by name: %w", err)
 	}
 
 	if currentPolicyFound {
@@ -967,7 +967,7 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 			newPolicy.Name, currentPolicyName)
 		if err = nrc.unassignAndRemovePolicy(currentPolicyName, gobgpapi.PolicyDirection_POLICY_DIRECTION_IMPORT,
 			gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT); err != nil {
-			return fmt.Errorf("could not clean up old policy: %v", err)
+			return fmt.Errorf("could not clean up old policy: %w", err)
 		}
 	}
 
@@ -1026,7 +1026,7 @@ func (nrc *NetworkRoutingController) ensureStatementExists(st *gobgpapi.Statemen
 			}
 		})
 	if err != nil {
-		return fmt.Errorf("could not list statements: %v", err)
+		return fmt.Errorf("could not list statements: %w", err)
 	}
 
 	if found {
@@ -1037,7 +1037,7 @@ func (nrc *NetworkRoutingController) ensureStatementExists(st *gobgpapi.Statemen
 		Statement: st,
 	})
 	if err != nil {
-		return fmt.Errorf("could not add statement: %v", err)
+		return fmt.Errorf("could not add statement: %w", err)
 	}
 
 	return nil
@@ -1061,7 +1061,7 @@ func (nrc *NetworkRoutingController) incrementAndCreatePolicy(curPolName string,
 	case 3:
 		polBaseName = matches[1]
 		if polVer, err = strconv.Atoi(matches[2]); err != nil {
-			return fmt.Errorf("failed to parse %s GoBGP policy name: %v", curPolName, err)
+			return fmt.Errorf("failed to parse %s GoBGP policy name: %w", curPolName, err)
 		}
 	default:
 		return fmt.Errorf("failed to parse %s GoBGP policy name via regex", curPolName)
@@ -1074,7 +1074,7 @@ func (nrc *NetworkRoutingController) incrementAndCreatePolicy(curPolName string,
 		ReferExistingStatements: true,
 	})
 	if err != nil {
-		return errors.New("Failed to add policy: " + err.Error())
+		return fmt.Errorf("Failed to add policy: %w", err)
 	}
 
 	return nil
@@ -1096,7 +1096,7 @@ func (nrc *NetworkRoutingController) assignPolicyByName(newPolicy *gobgpapi.Poli
 		&gobgpapi.ListPolicyAssignmentRequest{Name: "global", Direction: polDir},
 		checkExistingPolicyAssignment)
 	if err != nil {
-		return errors.New("Failed to verify if kube-router BGP export policy assignment exists: " + err.Error())
+		return fmt.Errorf("Failed to verify if kube-router BGP export policy assignment exists: %w", err)
 	}
 	if policyAssignmentExists {
 		return nil
@@ -1112,7 +1112,7 @@ func (nrc *NetworkRoutingController) assignPolicyByName(newPolicy *gobgpapi.Poli
 	err = nrc.bgpServer.AddPolicyAssignment(context.Background(),
 		&gobgpapi.AddPolicyAssignmentRequest{Assignment: &policyAssignment})
 	if err != nil {
-		return errors.New("Failed to add policy assignment: " + err.Error())
+		return fmt.Errorf("Failed to add policy assignment: %w", err)
 	}
 
 	return nil
@@ -1133,7 +1133,7 @@ func (nrc *NetworkRoutingController) unassignAndRemovePolicy(policyName string,
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("could not delete policy assignment for: %s - %v", policyName, err)
+		return fmt.Errorf("could not delete policy assignment for: %s - %w", policyName, err)
 	}
 
 	err = nrc.bgpServer.DeletePolicy(context.Background(), &gobgpapi.DeletePolicyRequest{
@@ -1142,7 +1142,7 @@ func (nrc *NetworkRoutingController) unassignAndRemovePolicy(policyName string,
 		All:                true, // All here tells GoBGP to delete the policy instead of just clearing the statements
 	})
 	if err != nil {
-		return fmt.Errorf("could not delete policy for: %s - %v", policyName, err)
+		return fmt.Errorf("could not delete policy for: %s - %w", policyName, err)
 	}
 
 	return nil

--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -1593,7 +1593,7 @@ func checkPolicies(t *testing.T, testcase PolicyTestCase, gobgpDirection gobgpap
 	if !policyAssignmentExists {
 		t.Errorf("%s policy assignment 'kube_router_%s' was not added", direction, direction)
 	}
-	err = testcase.nrc.bgpServer.ListPolicy(context.Background(), &gobgpapi.ListPolicyRequest{Name: fmt.Sprintf("kube_router_%s", direction)}, func(foundPolicy *gobgpapi.Policy) {
+	err = testcase.nrc.bgpServer.ListPolicy(context.Background(), &gobgpapi.ListPolicyRequest{Name: "kube_router_" + direction}, func(foundPolicy *gobgpapi.Policy) {
 		for _, expectedStatement := range policyStatements {
 			found := false
 			for _, statement := range foundPolicy.Statements {

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -571,7 +571,7 @@ func (nrc *NetworkRoutingController) advertisePodRoute() error {
 	if nrc.krNode.IsIPv4Capable() {
 		nodePrimaryIPv4IP := nrc.krNode.FindBestIPv4NodeAddress()
 		if nodePrimaryIPv4IP == nil {
-			return fmt.Errorf("previous logic marked this node as IPv4 capable, but we couldn't find any " +
+			return errors.New("previous logic marked this node as IPv4 capable, but we couldn't find any " +
 				"available IPv4 node IPs, this shouldn't happen")
 		}
 
@@ -584,7 +584,7 @@ func (nrc *NetworkRoutingController) advertisePodRoute() error {
 	if nrc.krNode.IsIPv6Capable() {
 		nodePrimaryIPv6IP := nrc.krNode.FindBestIPv6NodeAddress()
 		if nodePrimaryIPv6IP == nil {
-			return fmt.Errorf(
+			return errors.New(
 				"previous logic marked this node as IPv6 capable, but we couldn't find any " +
 					"available IPv6 node IPs, this shouldn't happen",
 			)

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -764,7 +764,7 @@ func (nrc *NetworkRoutingController) isPeerEstablished(peerIP string) (bool, err
 		Address: peerIP,
 	}, peerFunc)
 	if err != nil {
-		return false, fmt.Errorf("unable to list peers to see if tunnel & routes need to be removed: %v", err)
+		return false, fmt.Errorf("unable to list peers to see if tunnel & routes need to be removed: %w", err)
 	}
 
 	return peerConnected, nil
@@ -896,7 +896,7 @@ func (nrc *NetworkRoutingController) syncNodeIPSets() error {
 		multiFamilySetNames := utils.GenerateMultiFamilySetNames([]string{podSubnetsIPSetName, nodeAddrsIPSetName})
 		err = ipSetHandler.RestoreSets(multiFamilySetNames)
 		if err != nil {
-			return fmt.Errorf("failed to sync pod subnets / node addresses ipsets: %v", err)
+			return fmt.Errorf("failed to sync pod subnets / node addresses ipsets: %w", err)
 		}
 	}
 	return nil
@@ -911,12 +911,12 @@ func (nrc *NetworkRoutingController) enableForwarding() error {
 		args := []string{"-m", "comment", "--comment", comment, "-i", "kube-bridge", "-j", "ACCEPT"}
 		exists, err := iptablesCmdHandler.Exists("filter", "FORWARD", args...)
 		if err != nil {
-			return fmt.Errorf("failed to run iptables command: %s", err.Error())
+			return fmt.Errorf("failed to run iptables command: %w", err)
 		}
 		if !exists {
 			err := iptablesCmdHandler.Insert("filter", "FORWARD", 1, args...)
 			if err != nil {
-				return fmt.Errorf("failed to run iptables command: %s", err.Error())
+				return fmt.Errorf("failed to run iptables command: %w", err)
 			}
 		}
 
@@ -924,12 +924,12 @@ func (nrc *NetworkRoutingController) enableForwarding() error {
 		args = []string{"-m", "comment", "--comment", comment, "-o", "kube-bridge", "-j", "ACCEPT"}
 		exists, err = iptablesCmdHandler.Exists("filter", "FORWARD", args...)
 		if err != nil {
-			return fmt.Errorf("failed to run iptables command: %s", err.Error())
+			return fmt.Errorf("failed to run iptables command: %w", err)
 		}
 		if !exists {
 			err = iptablesCmdHandler.Insert("filter", "FORWARD", 1, args...)
 			if err != nil {
-				return fmt.Errorf("failed to run iptables command: %s", err.Error())
+				return fmt.Errorf("failed to run iptables command: %w", err)
 			}
 		}
 
@@ -937,12 +937,12 @@ func (nrc *NetworkRoutingController) enableForwarding() error {
 		args = []string{"-m", "comment", "--comment", comment, "-o", nrc.krNode.GetNodeInterfaceName(), "-j", "ACCEPT"}
 		exists, err = iptablesCmdHandler.Exists("filter", "FORWARD", args...)
 		if err != nil {
-			return fmt.Errorf("failed to run iptables command: %s", err.Error())
+			return fmt.Errorf("failed to run iptables command: %w", err)
 		}
 		if !exists {
 			err = iptablesCmdHandler.Insert("filter", "FORWARD", 1, args...)
 			if err != nil {
-				return fmt.Errorf("failed to run iptables command: %s", err.Error())
+				return fmt.Errorf("failed to run iptables command: %w", err)
 			}
 		}
 	}
@@ -954,7 +954,7 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 	var nodeAsnNumber uint32
 	node, err := utils.GetNodeObject(nrc.clientset, nrc.hostnameOverride)
 	if err != nil {
-		return errors.New("failed to get node object from api server: " + err.Error())
+		return fmt.Errorf("failed to get node object from api server: %w", err)
 	}
 
 	if nrc.bgpFullMeshMode {
@@ -1108,7 +1108,7 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 
 	intBGPPort, err := safecast.Convert[int32](nrc.bgpPort)
 	if err != nil {
-		return fmt.Errorf("failed to convert BGP port to int32: %v", err)
+		return fmt.Errorf("failed to convert BGP port to int32: %w", err)
 	}
 
 	global := &gobgpapi.Global{
@@ -1119,7 +1119,7 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 	}
 
 	if err := nrc.bgpServer.StartBgp(context.Background(), &gobgpapi.StartBgpRequest{Global: global}); err != nil {
-		return fmt.Errorf("failed to start BGP server due to: %v", err)
+		return fmt.Errorf("failed to start BGP server due to: %w", err)
 	}
 
 	go nrc.watchBgpUpdates()
@@ -1156,7 +1156,7 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 				klog.Errorf("Failed to stop bgpServer: %s", err2)
 			}
 
-			return fmt.Errorf("failed to process Global Peer Router configs: %s", err)
+			return fmt.Errorf("failed to process Global Peer Router configs: %w", err)
 		}
 
 		nrc.nodePeerRouters = peerCfgs.RemoteIPStrings()
@@ -1197,7 +1197,7 @@ func (nrc *NetworkRoutingController) setupHandlers(node *v1core.Node) error {
 		if err != nil {
 			klog.Fatalf("Failed to get pod CIDRs from node spec. kube-router relies on kube-controller-manager to"+
 				"allocate pod CIDRs for the node or an annotation `kube-router.io/pod-cidrs`. Error: %v", err)
-			return fmt.Errorf("failed to get pod CIDRs detail from Node.spec: %v", err)
+			return fmt.Errorf("failed to get pod CIDRs detail from Node.spec: %w", err)
 		}
 	}
 
@@ -1285,7 +1285,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	nrc.hostnameOverride = kubeRouterConfig.HostnameOverride
 	node, err := utils.GetNodeObject(clientset, nrc.hostnameOverride)
 	if err != nil {
-		return nil, errors.New("failed getting node object from API server: " + err.Error())
+		return nil, fmt.Errorf("failed getting node object from API server: %w", err)
 	}
 
 	nrc.krNode, err = utils.NewKRNode(node, nil, kubeRouterConfig.EnableIPv4, kubeRouterConfig.EnableIPv6)
@@ -1323,7 +1323,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	if err != nil {
 		klog.Fatalf("Failed to get pod CIDR from node spec. kube-router relies on kube-controller-manager to "+
 			"allocate pod CIDR for the node or an annotation `kube-router.io/pod-cidr`. Error: %v", err)
-		return nil, fmt.Errorf("failed to get pod CIDR details from Node.spec: %v", err)
+		return nil, fmt.Errorf("failed to get pod CIDR details from Node.spec: %w", err)
 	}
 	nrc.podCidr = cidr
 
@@ -1385,7 +1385,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	for _, i := range kubeRouterConfig.PeerASNs {
 		ui, err := safecast.Convert[uint32](i)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert Peer ASNs to uint32: %s", err)
+			return nil, fmt.Errorf("failed to convert Peer ASNs to uint32: %w", err)
 		}
 
 		peerASNs = append(peerASNs, ui)
@@ -1396,7 +1396,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	for _, i := range kubeRouterConfig.PeerPorts {
 		ui, err := safecast.Convert[uint32](i)
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert Peer Port to uint32: %s", err)
+			return nil, fmt.Errorf("failed to convert Peer Port to uint32: %w", err)
 		}
 
 		peerPorts = append(peerPorts, ui)
@@ -1407,18 +1407,18 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 	if len(kubeRouterConfig.PeerPasswords) != 0 {
 		peerPasswords, err = stringSliceB64Decode(kubeRouterConfig.PeerPasswords)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse CLI Peer Passwords flag: %s", err)
+			return nil, fmt.Errorf("failed to parse CLI Peer Passwords flag: %w", err)
 		}
 	} else if len(kubeRouterConfig.PeerPasswordsFile) != 0 {
 		// Contents of the pw file should be in the same format as pw from CLI arg
 		pwFileBytes, err := os.ReadFile(kubeRouterConfig.PeerPasswordsFile)
 		if err != nil {
-			return nil, fmt.Errorf("error loading Peer Passwords File : %s", err)
+			return nil, fmt.Errorf("error loading Peer Passwords File : %w", err)
 		}
 		pws := strings.Split(string(pwFileBytes), ",")
 		peerPasswords, err = stringSliceB64Decode(pws)
 		if err != nil {
-			return nil, fmt.Errorf("failed to decode CLI Peer Passwords file: %s", err)
+			return nil, fmt.Errorf("failed to decode CLI Peer Passwords file: %w", err)
 		}
 	}
 
@@ -1445,7 +1445,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		nrc.krNode.GetPrimaryNodeIP().String(),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error processing Global Peer Router configs: %s", err)
+		return nil, fmt.Errorf("error processing Global Peer Router configs: %w", err)
 	}
 
 	bgpLocalAddressListAnnotation, ok := node.Annotations[bgpLocalAddressAnnotation]

--- a/pkg/controllers/routing/pod_egress.go
+++ b/pkg/controllers/routing/pod_egress.go
@@ -61,7 +61,7 @@ func (nrc *NetworkRoutingController) deletePodEgressRule() error {
 
 		exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", podEgressArgs...)
 		if err != nil {
-			return fmt.Errorf("Failed to lookup iptables rule to masquerade outbound traffic from pods: %w", err)
+			return fmt.Errorf("failed to lookup iptables rule to masquerade outbound traffic from pods: %w", err)
 		}
 
 		if exists {

--- a/pkg/controllers/routing/pod_egress.go
+++ b/pkg/controllers/routing/pod_egress.go
@@ -61,7 +61,7 @@ func (nrc *NetworkRoutingController) deletePodEgressRule() error {
 
 		exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", podEgressArgs...)
 		if err != nil {
-			return errors.New("Failed to lookup iptables rule to masquerade outbound traffic from pods: " + err.Error())
+			return fmt.Errorf("Failed to lookup iptables rule to masquerade outbound traffic from pods: %w", err)
 		}
 
 		if exists {
@@ -96,7 +96,7 @@ func (nrc *NetworkRoutingController) deleteBadPodEgressRules() error {
 		for _, args := range podEgressArgsBad {
 			exists, err := iptablesCmdHandler.Exists("nat", "POSTROUTING", args...)
 			if err != nil {
-				return fmt.Errorf("failed to lookup iptables rule: %s", err.Error())
+				return fmt.Errorf("failed to lookup iptables rule: %w", err)
 			}
 
 			if exists {

--- a/pkg/controllers/testhelpers/ipset_fixture_helpers.go
+++ b/pkg/controllers/testhelpers/ipset_fixture_helpers.go
@@ -3,7 +3,7 @@ package testhelpers
 import (
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -179,7 +179,7 @@ func (h *FakeIPSetHandler) Snapshot() map[string]IPSetExpectation {
 		for i, entry := range state.entries {
 			entries[i] = NormalizeSnapshotEntry(strings.Join(entry, " "))
 		}
-		sort.Strings(entries)
+		slices.Sort(entries)
 		res[name] = IPSetExpectation{SetType: state.setType, Entries: entries}
 	}
 	return res
@@ -276,7 +276,7 @@ func ParseSnapshotWithFilter(t *testing.T, path string, includeFn func(string) b
 		}
 	}
 	for name, exp := range result {
-		sort.Strings(exp.Entries)
+		slices.Sort(exp.Entries)
 		if exp.Entries == nil {
 			exp.Entries = []string{}
 		}
@@ -362,7 +362,7 @@ func ParseRestoreScript(script string) map[string]IPSetExpectation {
 			seen[entry] = struct{}{}
 			deduped = append(deduped, entry)
 		}
-		sort.Strings(deduped)
+		slices.Sort(deduped)
 		exp.Entries = deduped
 		result[name] = exp
 	}
@@ -386,6 +386,6 @@ func ExpectedKeys(m map[string]IPSetExpectation) []string {
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	return keys
 }

--- a/pkg/routes/linux_routes.go
+++ b/pkg/routes/linux_routes.go
@@ -23,12 +23,12 @@ func DeleteByDestination(destinationSubnet *net.IPNet) error {
 		Dst: destinationSubnet, Protocol: ZebraOriginator,
 	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_PROTOCOL)
 	if err != nil {
-		return fmt.Errorf("failed to get routes from netlink: %v", err)
+		return fmt.Errorf("failed to get routes from netlink: %w", err)
 	}
 	for i, r := range routes {
 		klog.V(2).Infof("Found route to remove: %s", r.String())
 		if err = netlink.RouteDel(&routes[i]); err != nil {
-			return fmt.Errorf("failed to remove route due to %v", err)
+			return fmt.Errorf("failed to remove route due to %w", err)
 		}
 	}
 	return nil

--- a/pkg/routes/pbr.go
+++ b/pkg/routes/pbr.go
@@ -45,7 +45,7 @@ func NewPolicyBasedRules(nfa utils.NodeFamilyAware, podIPv4CIDRs, podIPv6CIDRs [
 func ipRuleAbstraction(ipFamily int, ipOp int, cidr string) error {
 	_, nSrc, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return fmt.Errorf("failed to parse CIDR: %s", err.Error())
+		return fmt.Errorf("failed to parse CIDR: %w", err)
 	}
 
 	nRule := netlink.NewRule()
@@ -59,7 +59,7 @@ func ipRuleAbstraction(ipFamily int, ipOp int, cidr string) error {
 	rules := make([]netlink.Rule, 0)
 	isDefaultRoute, err := utils.IsDefaultRoute(nSrc)
 	if err != nil {
-		return fmt.Errorf("failed to check if CIDR is a default route: %v", err)
+		return fmt.Errorf("failed to check if CIDR is a default route: %w", err)
 	}
 
 	ctx := context.Background()
@@ -67,7 +67,7 @@ func ipRuleAbstraction(ipFamily int, ipOp int, cidr string) error {
 		var tmpRules []netlink.Rule
 		tmpRules, err = nlretry.RuleListFiltered(ctx, ipFamily, nRule, netlink.RT_FILTER_TABLE)
 		if err != nil {
-			return fmt.Errorf("failed to list rules: %s", err.Error())
+			return fmt.Errorf("failed to list rules: %w", err)
 		}
 
 		// Check if one or more of the rules returned are a default route rule
@@ -80,17 +80,17 @@ func ipRuleAbstraction(ipFamily int, ipOp int, cidr string) error {
 	} else {
 		rules, err = nlretry.RuleListFiltered(ctx, ipFamily, nRule, netlink.RT_FILTER_SRC|netlink.RT_FILTER_TABLE)
 		if err != nil {
-			return fmt.Errorf("failed to list rules: %s", err.Error())
+			return fmt.Errorf("failed to list rules: %w", err)
 		}
 	}
 
 	if ipOp == PBRRuleDel && len(rules) > 0 {
 		if err := netlink.RuleDel(nRule); err != nil {
-			return fmt.Errorf("failed to delete rule: %s", err.Error())
+			return fmt.Errorf("failed to delete rule: %w", err)
 		}
 	} else if ipOp == PBRRuleAdd && len(rules) < 1 {
 		if err := netlink.RuleAdd(nRule); err != nil {
-			return fmt.Errorf("failed to add rule: %s", err.Error())
+			return fmt.Errorf("failed to add rule: %w", err)
 		}
 	}
 
@@ -102,7 +102,7 @@ func ipRuleAbstraction(ipFamily int, ipOp int, cidr string) error {
 func (pbr *PolicyBasedRules) Enable() error {
 	err := utils.RouteTableAdd(CustomTableID, CustomTableName)
 	if err != nil {
-		return fmt.Errorf("failed to update rt_tables file: %s", err)
+		return fmt.Errorf("failed to update rt_tables file: %w", err)
 	}
 
 	if pbr.nfa.IsIPv4Capable() {
@@ -127,7 +127,7 @@ func (pbr *PolicyBasedRules) Enable() error {
 func (pbr *PolicyBasedRules) Disable() error {
 	err := utils.RouteTableAdd(CustomTableID, CustomTableName)
 	if err != nil {
-		return fmt.Errorf("failed to update rt_tables file: %s", err)
+		return fmt.Errorf("failed to update rt_tables file: %w", err)
 	}
 
 	if pbr.nfa.IsIPv4Capable() {

--- a/pkg/tunnels/linux_tunnels.go
+++ b/pkg/tunnels/linux_tunnels.go
@@ -350,7 +350,7 @@ func (o *OverlayTunnel) ensureFOUPort(config *tunnelConfig) error {
 	}
 
 	if err := netlink.FouAdd(*fouPort); err != nil {
-		return fmt.Errorf("failed to set FoU tunnel port - error: %v", err)
+		return fmt.Errorf("failed to set FoU tunnel port - error: %w", err)
 	}
 
 	return nil
@@ -387,7 +387,7 @@ func (o *OverlayTunnel) bringTunnelUp(tunnelName string) (netlink.Link, error) {
 	}
 
 	if err = netlink.LinkSetUp(link); err != nil {
-		return nil, fmt.Errorf("failed to bring tunnel interface %s up due to: %v", tunnelName, err)
+		return nil, fmt.Errorf("failed to bring tunnel interface %s up due to: %w", tunnelName, err)
 	}
 
 	return link, nil
@@ -411,12 +411,12 @@ func (o *OverlayTunnel) addTunnelRoute(link netlink.Link, nextHop net.IP, isIPv6
 	routeList, err := nlretry.RouteListFiltered(context.Background(), routeFamily, route,
 		netlink.RT_FILTER_OIF|netlink.RT_FILTER_TABLE|netlink.RT_FILTER_DST)
 	if err != nil {
-		return fmt.Errorf("failed to list routes in custom table: %v", err)
+		return fmt.Errorf("failed to list routes in custom table: %w", err)
 	}
 
 	if len(routeList) < 1 {
 		if err = netlink.RouteAdd(route); err != nil {
-			return fmt.Errorf("failed to add route in custom route table, err: %v", err)
+			return fmt.Errorf("failed to add route in custom route table, err: %w", err)
 		}
 	} else {
 		klog.V(2).Infof("Route for %s already exists in custom table", nextHop.String())
@@ -495,7 +495,7 @@ func fouPortAndProtoExist(port EncapPort, isIPv6 bool) bool {
 func linkFOUEnabled(linkName string) (bool, error) {
 	link, err := nlretry.LinkByName(context.Background(), linkName)
 	if err != nil {
-		return false, fmt.Errorf("failed to get link by name: %v", err)
+		return false, fmt.Errorf("failed to get link by name: %w", err)
 	}
 
 	switch link := link.(type) {

--- a/pkg/tunnels/linux_tunnels.go
+++ b/pkg/tunnels/linux_tunnels.go
@@ -8,6 +8,7 @@ package tunnels
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"os/exec"
@@ -459,7 +460,7 @@ func GenerateTunnelName(nodeIP string) string {
 	h.Write([]byte(strippedIP))
 	sum := h.Sum(nil)
 
-	return "tun-" + fmt.Sprintf("%x", sum)[0:11]
+	return "tun-" + hex.EncodeToString(sum)[0:11]
 }
 
 // fouPortAndProtoExist checks to see if the given FoU port is already configured on the system via iproute2

--- a/pkg/utils/cni.go
+++ b/pkg/utils/cni.go
@@ -22,7 +22,7 @@ func NewCNINetworkConfig(cniConfFilePath string) (*cniNetworkConfig, error) {
 
 	cniFileBytes, err := os.ReadFile(cniConfFilePath)
 	if err != nil {
-		return nil, fmt.Errorf("error reading %s: %v", cniConfFilePath, err)
+		return nil, fmt.Errorf("error reading %s: %w", cniConfFilePath, err)
 	}
 
 	// If we're working with a conflist setup
@@ -30,7 +30,7 @@ func NewCNINetworkConfig(cniConfFilePath string) (*cniNetworkConfig, error) {
 		confList := new(ConfList)
 		err = json.Unmarshal(cniFileBytes, confList)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load CNI conflist file: %v", err)
+			return nil, fmt.Errorf("failed to load CNI conflist file: %w", err)
 		}
 		if len(confList.Plugins) == 0 {
 			return nil, fmt.Errorf("CNI config list %s has no plugins", cniConfFilePath)
@@ -41,7 +41,7 @@ func NewCNINetworkConfig(cniConfFilePath string) (*cniNetworkConfig, error) {
 		conf := new(Conf)
 		err = json.Unmarshal(cniFileBytes, conf)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load CNI conf file: %v", err)
+			return nil, fmt.Errorf("failed to load CNI conf file: %w", err)
 		}
 		if conf.Type == "" {
 			return nil, fmt.Errorf("error load CNI config, file appears to have no type: %s", cniConfFilePath)
@@ -139,7 +139,7 @@ func (c *cniNetworkConfig) InsertPodCIDRIntoIPAM(cidr string) error {
 	// too safe...
 	_, _, err := net.ParseCIDR(cidr)
 	if err != nil {
-		return fmt.Errorf("unable to parse input cidr: %s - %v", cidr, err)
+		return fmt.Errorf("unable to parse input cidr: %s - %w", cidr, err)
 	}
 
 	// Check that we don't already have the cidr in our list of ranges already, if so, consider it a no-op
@@ -169,18 +169,18 @@ func (c *cniNetworkConfig) WriteCNIConfig() error {
 	if c.IsConfList() {
 		cniBytes, err = json.Marshal(c.ConfList)
 		if err != nil {
-			return fmt.Errorf("unable to marshal CNI ConfList: %v", err)
+			return fmt.Errorf("unable to marshal CNI ConfList: %w", err)
 		}
 	} else {
 		cniBytes, err = json.Marshal(c.Conf)
 		if err != nil {
-			return fmt.Errorf("unable to marshal CNI Conf: %v", err)
+			return fmt.Errorf("unable to marshal CNI Conf: %w", err)
 		}
 	}
 
 	err = os.WriteFile(c.FilePath, cniBytes, 0644)
 	if err != nil {
-		return fmt.Errorf("failed to write into CNI conf file: %v", err)
+		return fmt.Errorf("failed to write into CNI conf file: %w", err)
 	}
 
 	return nil

--- a/pkg/utils/cni_test.go
+++ b/pkg/utils/cni_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -329,14 +330,14 @@ func TestNewCNINetworkConfig(t *testing.T) {
 			filename:   "10-kuberouter.conf",
 			isConfList: false,
 			content:    getConfWithNoType(),
-			err:        fmt.Errorf("error load CNI config, file appears to have no type: "),
+			err:        errors.New("error load CNI config, file appears to have no type: "),
 		},
 		{
 			name:       "Ensure error upon reading from conflist with no plugins",
 			filename:   "10-kuberouter.conflist",
 			isConfList: true,
 			content:    getConfListWithNoPlugins(),
-			err:        fmt.Errorf("CNI config list "),
+			err:        errors.New("CNI config list "),
 		},
 		{
 			name:       "Ensure conf subnet get consolidated into ranges when only subnet exists",

--- a/pkg/utils/cni_test.go
+++ b/pkg/utils/cni_test.go
@@ -590,7 +590,11 @@ func TestCniNetworkConfig_InsertPodCIDRIntoIPAM(t *testing.T) {
 
 			for _, cidr := range testcase.insertRanges {
 				err = cni.InsertPodCIDRIntoIPAM(cidr)
-				assert.Equal(t, testcase.err, err)
+				if testcase.err != nil {
+					assert.EqualError(t, err, testcase.err.Error())
+				} else {
+					assert.NoError(t, err)
+				}
 			}
 
 			expectedSubnets := make([]string, 0)

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -115,12 +115,12 @@ func IsDefaultRoute(cidr *net.IPNet) (bool, error) {
 	if cidr.IP.To4() != nil {
 		_, defaultPrefixCIDR, err = net.ParseCIDR(IPv4DefaultRoute)
 		if err != nil {
-			return false, fmt.Errorf("failed to parse default route: %s", err.Error())
+			return false, fmt.Errorf("failed to parse default route: %w", err)
 		}
 	} else {
 		_, defaultPrefixCIDR, err = net.ParseCIDR(IPv6DefaultRoute)
 		if err != nil {
-			return false, fmt.Errorf("failed to parse default route: %s", err.Error())
+			return false, fmt.Errorf("failed to parse default route: %w", err)
 		}
 	}
 	return IPNetEqual(defaultPrefixCIDR, cidr), nil

--- a/pkg/utils/ipset.go
+++ b/pkg/utils/ipset.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os/exec"
 	"slices"
-	"sort"
 	"strings"
 
 	"k8s.io/klog/v2"
@@ -300,7 +299,7 @@ func (ipset *IPSet) Create(setName string, createOptions ...string) (*Set, error
 		klog.V(2).Infof("running ipset command: %s", args)
 		_, err := ipset.run(args...)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create ipset set on system: %s", err)
+			return nil, fmt.Errorf("failed to create ipset set on system: %w", err)
 		}
 	}
 	return ipset.sets[ipsetName], nil
@@ -541,7 +540,7 @@ func BuildIPSetRestore(ipset *IPSet, setIncludeNames []string) string {
 		setNames = append(setNames, setName)
 	}
 
-	sort.Strings(setNames)
+	slices.Sort(setNames)
 
 	tmpSets := map[string]string{}
 	ipSetRestore := &strings.Builder{}
@@ -582,7 +581,7 @@ func BuildIPSetRestore(ipset *IPSet, setIncludeNames []string) string {
 		setsToDestroy = append(setsToDestroy, tmpSetName)
 	}
 	// need to destroy the sets in a predictable order for unit test!
-	sort.Strings(setsToDestroy)
+	slices.Sort(setsToDestroy)
 	for _, tmpSetName := range setsToDestroy {
 		// finally, destroy the tmp sets.
 		fmt.Fprintf(ipSetRestore, "destroy %s\n", tmpSetName)

--- a/pkg/utils/ipset_test.go
+++ b/pkg/utils/ipset_test.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -270,13 +269,13 @@ func Test_buildIPSetRestore_setIncludeNames(t *testing.T) {
 
 			// Check that expected sets are included
 			for _, expectedSet := range tt.expectedSets {
-				assert.Contains(t, result, fmt.Sprintf("create %s", expectedSet),
+				assert.Contains(t, result, "create "+expectedSet,
 					"Expected set %s should be created", expectedSet)
 			}
 
 			// Check that excluded sets are not included
 			for _, excludedSet := range tt.excludedSets {
-				assert.NotContains(t, result, fmt.Sprintf("create %s", excludedSet),
+				assert.NotContains(t, result, "create "+excludedSet,
 					"Excluded set %s should not be created", excludedSet)
 			}
 
@@ -621,10 +620,10 @@ func Test_buildIPSetRestore_integrationRealWorldSets(t *testing.T) {
 				}
 
 				if shouldBeIncluded {
-					assert.Contains(t, result, fmt.Sprintf("create %s", setName),
+					assert.Contains(t, result, "create "+setName,
 						"Set %s should be included in restore", setName)
 				} else {
-					assert.NotContains(t, result, fmt.Sprintf("create %s", setName),
+					assert.NotContains(t, result, "create "+setName,
 						"Set %s should not be included in restore", setName)
 				}
 			}

--- a/pkg/utils/linux_routing.go
+++ b/pkg/utils/linux_routing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/vishvananda/netlink"
@@ -53,7 +54,7 @@ func RouteTableAdd(tableNumber int, tableName string) error {
 			return fmt.Errorf("failed to open: %w", err)
 		}
 		defer CloseCloserDisregardError(f)
-		if _, err = f.WriteString(fmt.Sprint(tableNumber) + " " + tableName + "\n"); err != nil {
+		if _, err = f.WriteString(strconv.Itoa(tableNumber) + " " + tableName + "\n"); err != nil {
 			return fmt.Errorf("failed to write: %w", err)
 		}
 	}

--- a/pkg/utils/linux_routing.go
+++ b/pkg/utils/linux_routing.go
@@ -44,17 +44,17 @@ func RouteTableAdd(tableNumber int, tableName string) error {
 
 	b, err := os.ReadFile(rtTablesLoc)
 	if err != nil {
-		return fmt.Errorf("failed to read: %s", err.Error())
+		return fmt.Errorf("failed to read: %w", err)
 	}
 
 	if !strings.Contains(string(b), tableName) {
 		f, err := os.OpenFile(rtTablesLoc, os.O_APPEND|os.O_WRONLY, 0600)
 		if err != nil {
-			return fmt.Errorf("failed to open: %s", err.Error())
+			return fmt.Errorf("failed to open: %w", err)
 		}
 		defer CloseCloserDisregardError(f)
 		if _, err = f.WriteString(fmt.Sprint(tableNumber) + " " + tableName + "\n"); err != nil {
-			return fmt.Errorf("failed to write: %s", err.Error())
+			return fmt.Errorf("failed to write: %w", err)
 		}
 	}
 

--- a/pkg/utils/linux_routingtest.go
+++ b/pkg/utils/linux_routingtest.go
@@ -2,7 +2,7 @@ package utils
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net"
 
 	"github.com/stretchr/testify/mock"
@@ -59,7 +59,7 @@ func (f *FakeLocalLinkQuerier) AddrList(_ context.Context, link netlink.Link, fa
 	addrs := make([]netlink.Addr, 1)
 	addrs[0] = netlink.Addr{IPNet: f.addrs[link.Attrs().Index]}
 	if link.Attrs().MTU == 0 {
-		return nil, fmt.Errorf("MTU was set to 0 to simulate an error")
+		return nil, errors.New("MTU was set to 0 to simulate an error")
 	}
 	return addrs, nil
 }

--- a/pkg/utils/node.go
+++ b/pkg/utils/node.go
@@ -231,12 +231,12 @@ func NewKRNode(node *apiv1.Node, linkQ LocalLinkQuerier, enableIPv4, enableIPv6 
 	ipv4Addrs, ipv6Addrs := getAllNodeIPs(node)
 	if enableIPv4 && len(ipv4Addrs[apiv1.NodeInternalIP]) < 1 &&
 		len(ipv4Addrs[apiv1.NodeExternalIP]) < 1 {
-		return nil, fmt.Errorf("IPv4 was enabled, but no IPv4 address was found on the node")
+		return nil, errors.New("IPv4 was enabled, but no IPv4 address was found on the node")
 	}
 
 	if enableIPv6 && len(ipv6Addrs[apiv1.NodeInternalIP]) < 1 &&
 		len(ipv6Addrs[apiv1.NodeExternalIP]) < 1 {
-		return nil, fmt.Errorf("IPv6 was enabled, but no IPv6 address was found on the node")
+		return nil, errors.New("IPv6 was enabled, but no IPv6 address was found on the node")
 	}
 
 	_, nodeInterfaceName, err := GetNodeSubnet(primaryNodeIP, linkQ)

--- a/pkg/utils/pod_cidr.go
+++ b/pkg/utils/pod_cidr.go
@@ -21,7 +21,7 @@ func GetPodCidrFromNodeSpec(node *v1core.Node) (string, error) {
 	if cidr, ok := node.Annotations[podCIDRAnnotation]; ok {
 		_, _, err := net.ParseCIDR(cidr)
 		if err != nil {
-			return "", fmt.Errorf("error parsing pod CIDR in node annotation: %v", err)
+			return "", fmt.Errorf("error parsing pod CIDR in node annotation: %w", err)
 		}
 
 		return cidr, nil
@@ -42,7 +42,7 @@ func GetPodCIDRsFromNodeSpecDualStack(node *v1core.Node) ([]string, []string, er
 	if podCIDRs, ok := node.Annotations[podCIDRsAnnotation]; ok {
 		for _, cidr := range strings.Split(podCIDRs, ",") {
 			if _, _, err := net.ParseCIDR(cidr); err != nil {
-				return podIPv4CIDRs, podIPv6CIDRs, fmt.Errorf("error parsing pod CIDR in node annotation: %v", err)
+				return podIPv4CIDRs, podIPv6CIDRs, fmt.Errorf("error parsing pod CIDR in node annotation: %w", err)
 			}
 			if netutils.IsIPv4CIDRString(cidr) {
 				podIPv4CIDRs = append(podIPv4CIDRs, cidr)

--- a/pkg/utils/sysctl.go
+++ b/pkg/utils/sysctl.go
@@ -73,7 +73,7 @@ func (n *SysctlConfig) WriteVal(val int8) *SysctlError {
 }
 
 func sysctlStat(path string, hasValue bool, value int) (string, *SysctlError) {
-	sysctlPath := fmt.Sprintf("/proc/sys/%s", path)
+	sysctlPath := "/proc/sys/" + path
 	if _, err := os.Stat(sysctlPath); err != nil {
 		if os.IsNotExist(err) {
 			return sysctlPath, &SysctlError{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?

<!--
Please choose one of the following kinds:
-->
cleanup

#### What this PR does / why we need it:
- Replace fmt.Errorf %s/%v + err.Error() with %w for proper error wrapping and errors.Is/As chain support across all packages
- Replace errors.New("msg" + err.Error()) with fmt.Errorf("msg: %w", err)
- Replace strings.Contains(err.Error(), ...) with errors.Is(err, syscall.EEXIST) and errors.Is(err, syscall.ESRCH) in linux_networking.go
- Remove now-unused IfaceHasAddr and IpvsServerExists string constants
- Replace sort.Strings with slices.Sort in bgp_policies.go, ipset.go, and testhelpers
- Replace sort.SliceStable with slices.SortStableFunc in bgp_policies.go
- Replace reflect.DeepEqual on []string with slices.Equal in bgp_policies.go (also fixes bug: was comparing map to slice instead of slice to slice)
- Replace reflect.DeepEqual on []*gobgpapi.Prefix with slices.EqualFunc comparing exported fields to avoid protobuf internal state comparison
- Replace strings.Index + manual slicing with strings.Cut in docker.go and classify.go
- Update cni_test.go to use assert.EqualError instead of assert.Equal for wrapped error comparison

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->

#### Was AI used during the creation of this PR?
<!--
We are not against AI, but in the current era of tech AI is being used more and more to help upstream projects and it is
useful for the maintainers of this project to understand if AI was used and to what extent it was used. Please see our
AI policy: https://github.com/cloudnativelabs/kube-router/blob/master/AI_POLICY.md

If no AI was used during the generation of this PR, please remove the following content and simply put "No" for this
section.
-->

* What tool was used: <!-- One of Claude, Codex, Copilot, etc. -->
* To what extent was the tool used? <!-- Anything from line autofill to it drafted the entire PR or anything imbetween -->
* If drafted, how detailed of a plan did you create for the AI? <!-- Very detailed (multiple paragraphs) to not at all detailed (I gave it a single line prompt) -->
* Help us understand if a human was in the loop or not for this PR? Yes or No
Copilot

Yes
#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->

#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Anything else the reviewer should know that wasn't already covered?

