### PR TITLE
build: Dependency bumps to prep for release 2.9.0

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Set up Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       id: go
       with:
         go-version: ${{ inputs.go-version }}

--- a/.github/workflows/ci-container.yml
+++ b/.github/workflows/ci-container.yml
@@ -43,7 +43,7 @@ jobs:
 
     # Authenticate to DockerHub so subsequent push steps and cosign attestation pushes succeed.
     - name: Login to DockerHub
-      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -53,7 +53,7 @@ jobs:
     # OIDC token issued to this workflow, rooted in Sigstore Fulcio and logged in Rekor.
     - name: Install cosign
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22  # v4.1.0
+      uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4.1.1
 
     # Parse the branch name from GITHUB_REF for use as the image tag on non-tag branch pushes.
     - name: Extract branch from github ref - New Push
@@ -72,7 +72,7 @@ jobs:
     # Build and push a multi-arch image tagged with the branch name on direct pushes to tracked
     # branches (master, v*, prep-v*). Not run on PRs or tag pushes.
     - name: Build and push - New Push
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
       if: ${{ startsWith(github.ref, 'refs/tags/v') != true && github.event_name != 'pull_request' }}
       with:
         context: .
@@ -91,7 +91,7 @@ jobs:
     # Build and push a single-arch (amd64) image tagged with the PR number for pull requests.
     # Multi-arch is skipped here as it adds 30+ minutes to PR feedback time.
     - name: Build and push - New PR
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
       if: github.event_name == 'pull_request'
       with:
         context: .
@@ -111,7 +111,7 @@ jobs:
     # Build and push the multi-arch release candidate image. The step id captures the digest
     # so subsequent signing and attestation steps can reference the exact immutable image.
     - name: Build and push - New Tag (Release Candidate)
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
       id: push_rc
       if: ${{ startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '-rc') }}
       with:
@@ -172,7 +172,7 @@ jobs:
     # Build and push the multi-arch production release image. Updates both the versioned tag and
     # `latest`. The step id captures the digest for signing and attestation.
     - name: Build and push - New Tag
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
       id: push_release
       if: ${{ startsWith(github.ref, 'refs/tags/v') && ! contains(github.ref, '-rc') }}
       with:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -34,7 +34,7 @@ jobs:
     # Build multi-arch binaries, create archives, generate checksums, and publish a GitHub release.
     # The release is created as a draft (see .goreleaser.yml) pending manual review before publish.
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  # v7.0.0
+      uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8  # v7.2.1
       with:
         version: "~> v2"
         distribution: goreleaser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ permissions:
   contents: read
 
 env:
-  BUILDTIME_BASE: &buildtime_base "golang:1.25.7-alpine3.23@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced"
-  RUNTIME_BASE: &runtime_base "alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659"
-  GO_VERSION: &go_version "~1.25.7"
+  BUILDTIME_BASE: &buildtime_base "golang:1.25.9-alpine3.23@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f"
+  RUNTIME_BASE: &runtime_base "alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11"
+  GO_VERSION: &go_version "~1.25.9"
 
 jobs:
   # Phase 1: Run all code quality checks (unicode scan, lint, tests, binary build).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,14 +34,14 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
         with:
           languages: go
 
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,6 +50,6 @@ jobs:
     # Upload Scorecard findings to the GitHub Security tab so each failing check appears as an
     # individual code scanning alert with remediation guidance.
     - name: Upload Scorecard results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4.34.1
+      uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
       with:
         sarif_file: scorecard-results.sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILDTIME_BASE=golang:1-alpine
-ARG RUNTIME_BASE=alpine:latest
+ARG BUILDTIME_BASE=golang:1-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1
+ARG RUNTIME_BASE=alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 ARG TARGETPLATFORM
 ARG CNI_VERSION
 FROM ${BUILDTIME_BASE} AS builder
@@ -14,7 +14,7 @@ RUN apk add --no-cache make git tar curl \
 
 WORKDIR /iptables-wrappers
 # This is the latest commit on the master branch.
-ENV IPTABLES_WRAPPERS_VERSION=c6b9b2d4ee8701f3d476768ab8732d1b85ec7fef
+ENV IPTABLES_WRAPPERS_VERSION=bfef9e5087a198b50a4124bb9ce9d2c7c99025dd
 RUN git clone https://github.com/kubernetes-sigs/iptables-wrappers.git . \
     && git checkout "${IPTABLES_WRAPPERS_VERSION}" \
     && make build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ ENV IPTABLES_WRAPPERS_VERSION=bfef9e5087a198b50a4124bb9ce9d2c7c99025dd
 RUN git clone https://github.com/kubernetes-sigs/iptables-wrappers.git . \
     && git checkout "${IPTABLES_WRAPPERS_VERSION}" \
     && make build \
-    && test -x bin/iptables-wrapper \
-    && test -x iptables-wrapper-installer.sh
+    && test -x bin/iptables-wrapper 
 
 FROM ${RUNTIME_BASE}
 
@@ -49,7 +48,6 @@ COPY --from=builder /build/cni-download /usr/libexec/cni
 # which version is used should be based on the host system as well as where rules that may have been added before
 # kube-router are being placed. For more information see: https://github.com/kubernetes-sigs/iptables-wrappers
 COPY --from=builder /iptables-wrappers/bin/iptables-wrapper /
-COPY --from=builder /iptables-wrappers/iptables-wrapper-installer.sh /
 # This is necessary because of the bug reported here: https://github.com/flannel-io/flannel/pull/1340/files
 # Basically even under QEMU emulation, it still doesn't have an ARM kernel in-play which means that calls to
 # iptables-nft will fail in the build process. The sanity check here only makes sure that iptables-nft and iptables-legacy
@@ -66,7 +64,7 @@ RUN if ! command -v iptables-nft > /dev/null; then \
         echo "ERROR: ip6tables is not installed" 1>&2; \
         exit 1; \
     fi && \
-    /iptables-wrapper-installer.sh --no-sanity-check
+    /iptables-wrapper install
 
 WORKDIR /root
 ENTRYPOINT ["/usr/local/bin/kube-router"]

--- a/Makefile
+++ b/Makefile
@@ -18,34 +18,34 @@ MAKEFILE_DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 UPSTREAM_IMPORT_PATH=$(GOPATH)/src/github.com/cloudnativelabs/kube-router/
 BUILD_IN_DOCKER?=true
 # See Versions: https://hub.docker.com/_/golang
-DOCKER_BUILD_IMAGE?=golang:1.25.7-alpine3.23@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced
+DOCKER_BUILD_IMAGE?=golang:1.25.9-alpine3.23@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f
 ## These variables are used by the Dockerfile as the bases for building and creating the runtime container
 ## During CI these come from .github/workflows/ci.yaml below we define for local builds as well
 GO_CACHE?=$(shell go env GOCACHE)
 GO_MOD_CACHE?=$(shell go env GOMODCACHE)
 BUILDTIME_BASE?=$(DOCKER_BUILD_IMAGE)
 # See Versions: https://hub.docker.com/_/alpine
-RUNTIME_BASE?=alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+RUNTIME_BASE?=alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 # See Versions: https://hub.docker.com/r/golangci/golangci-lint/tags
-DOCKER_LINT_IMAGE?=golangci/golangci-lint:v2.8.0
+DOCKER_LINT_IMAGE?=golangci/golangci-lint:v2.11.4@sha256:67dfc9eeeb0eb13fc1a36329c2c378197dc561f1edf1a7792e3f771606bb0e15
 # See Versions: https://hub.docker.com/r/tmknom/markdownlint/tags
-DOCKER_MARKDOWNLINT_IMAGE?=tmknom/markdownlint:0.45.0
+DOCKER_MARKDOWNLINT_IMAGE?=tmknom/markdownlint:0.45.0@sha256:a9509a9d50a82781aa4cd0a48f182da55233071fb19454bc70cecc2782359c3c
 # See Versions: https://hub.docker.com/_/node
-DOCKER_DOCTOC_IMAGE?=node:alpine
+DOCKER_DOCTOC_IMAGE?=node:alpine@sha256:bdf2cca6fe3dabd014ea60163eca3f0f7015fbd5c7ee1b0e9ccb4ced6eb02ef4
 # See Versions: https://www.npmjs.com/package/doctoc
-DOCTOC_VERSION=2.3.0
+DOCTOC_VERSION=2.4.1
 # See Versions: https://github.com/crate-ci/typos/releases
-TYPOS_VERSION=v1.33.1
+TYPOS_VERSION=v1.45.2
 # See Versions: https://github.com/osrg/gobgp/releases
-GOBGP_VERSION=v4.2.0
-QEMU_IMAGE?=multiarch/qemu-user-static
+GOBGP_VERSION=v4.4.0
+QEMU_IMAGE?=multiarch/qemu-user-static:7.2.0-1@sha256:fe60359c92e86a43cc87b3d906006245f77bfc0565676b80004cc666e4feb9f0
 # See Versions: https://github.com/goreleaser/goreleaser/releases
-GORELEASER_VERSION=v2.13.3
+GORELEASER_VERSION=v2.15.4
 # See Versions: https://github.com/anchore/grype/releases
-GRYPE_VERSION=v0.110.0
+GRYPE_VERSION=v0.111.1
 GRYPE_IMAGE?=anchore/grype:$(GRYPE_VERSION)
 # See Versions: https://github.com/containernetworking/plugins/releases
-CNI_VERSION=v1.9.0
+CNI_VERSION=v1.9.1
 UID?=$(shell id -u)
 ifeq ($(GOARCH), arm)
 ARCH_TAG_PREFIX=$(GOARCH)

--- a/_typos.toml
+++ b/_typos.toml
@@ -23,10 +23,13 @@ extend-glob = ["testdata/**", "*_test.go"]
 
 [type.testdata.extend-words]
 # Ipset hash names and tunnel names contain arbitrary letter sequences
-IZ = "IZ"
 UE = "UE"
 Ba = "Ba"
 ba = "ba"
 
 # "mis-configured" is valid hyphenated usage
 mis = "mis"
+
+[type.txt.extend-words]
+# Ipset hash names and tunnel names contain arbitrary letter sequences
+IZ = "IZ"

--- a/docs/bgp.md
+++ b/docs/bgp.md
@@ -21,6 +21,7 @@ pod IPs, service IPs, etc.).
   - [Custom BGP Import Policy Reject](#custom-bgp-import-policy-reject)
 - [BGP listen address list](#bgp-listen-address-list)
 - [GoBGP Admin gRPC Server](#gobgp-admin-grpc-server)
+  - [Restoring pre-2.9.0 behavior](#restoring-pre-290-behavior)
 - [Overriding the next hop](#overriding-the-next-hop)
 - [Overriding the next hop and enable IPIP/tunnel](#overriding-the-next-hop-and-enable-ipiptunnel)
 

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 
 go 1.25.0
 
-toolchain go1.25.1
+toolchain go1.25.9
 
 tool (
 	github.com/matryer/moq

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -1979,6 +1979,9 @@ func (nsc *NetworkServicesController) handleServiceDelete(obj interface{}) {
 
 // setupHandlers Here we test to see whether the node is IPv6 capable, if the user has enabled IPv6 (via command-line
 // options) and the node has an IPv6 address, the following method will return an IPv6 address
+// TODO: replace klog.Fatalf with Errorf and return error, then remove nolint comment below
+//
+//nolint:unparam
 func (nsc *NetworkServicesController) setupHandlers(node *v1.Node) error {
 	nsc.ipSetHandlers = make(map[v1.IPFamily]utils.IPSetHandler)
 	nsc.iptablesCmdHandlers = make(map[v1.IPFamily]utils.IPTablesHandler)

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -1187,6 +1187,9 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 	return nil
 }
 
+// TODO: replace klog.Fatalf with Errorf and return error, then remove nolint comment below
+//
+//nolint:unparam
 func (nrc *NetworkRoutingController) setupHandlers(node *v1core.Node) error {
 	var err error
 
@@ -1314,6 +1317,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		if nrc.cniConfFile == "" {
 			nrc.cniConfFile = "/etc/cni/net.d/10-kuberouter.conf"
 		}
+		// #nosec G703: cniConfFile is not untrusted user input
 		if _, err := os.Stat(nrc.cniConfFile); os.IsNotExist(err) {
 			return nil, errors.New("CNI conf file " + nrc.cniConfFile + " does not exist.")
 		}

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -2682,6 +2682,7 @@ func Test_bgpPeerConfigsFromAnnotations(t *testing.T) {
 }
 
 func Test_bgpPeerConfigsFromIndividualAnnotations(t *testing.T) {
+	// #nosec G101: not real passwords
 	testCases := []struct {
 		name            string
 		nodeAnnotations map[string]string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?

dependency

#### What this PR does / why we need it:

Result of running `make prep-release`.

Summarizing the list of changes required due to the dependency bumps:

* Updated `_typos.toml` since crate-ci/typos seems to have changed the order of what file types are evaluated (txt rules seem to be evaluated before custom rules)
* Updated Dockerfile to use new [iptables-wrapper installation instructions](https://github.com/kubernetes-sigs/iptables-wrappers/commit/bfef9e5087a198b50a4124bb9ce9d2c7c99025dd)

#### Which issue(s) this PR is related to:

N/A

#### Was AI used during the creation of this PR?

No

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?

None - just dependency bumps for a release

#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

#### Anything else the reviewer should know that wasn't already covered?

