### PR TITLE
Recognize headless label on EndpointSlices

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -84,7 +84,7 @@ const (
 
 	// kubernetes standard labels / annotations
 	svcProxyNameLabel = "service.kubernetes.io/service-proxy-name"
-	svcHeadlessLabel  = "service.kubernetes.io/headless"
+	headlessLabel     = "service.kubernetes.io/headless"
 
 	// All IPSET names need to be less than 31 characters in order for the Kernel to accept them. Keep in mind that the
 	// actual formulation for this may be inet6:<setNameBase> depending on ip family, plus when we change ipsets we use
@@ -861,7 +861,7 @@ func (nsc *NetworkServicesController) buildServicesInfo() serviceInfoMap {
 
 		// We handle headless service labels differently from a "None" or blank ClusterIP because ClusterIP is
 		// guaranteed to be immuteable whereas labels can be added / removed
-		_, err = getLabelFromMap(svcHeadlessLabel, svc.Labels)
+		_, err = getLabelFromMap(headlessLabel, svc.Labels)
 		if err == nil {
 			klog.V(2).Infof("Skipping service name:%s namespace:%s due to headless label being set", svc.Name,
 				svc.Namespace)
@@ -1002,6 +1002,13 @@ func (nsc *NetworkServicesController) buildEndpointSliceInfo() endpointSliceInfo
 		var isIPv4, isIPv6 bool
 		es := obj.(*discoveryv1.EndpointSlice)
 		klog.V(2).Infof("Building endpoint info for EndpointSlice: %s/%s", es.Namespace, es.Name)
+
+		if _, hasHeadless := es.Labels[headlessLabel]; hasHeadless {
+			klog.V(2).Infof("Skipping EndpointSlice %s/%s due to headless label being set",
+				es.Namespace, es.Name)
+			continue
+		}
+
 		switch es.AddressType {
 		case discoveryv1.AddressTypeIPv4:
 			isIPv4 = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?

<!--
Please choose one of the following kinds:
-->
bug

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
https://github.com/cloudnativelabs/kube-router/issues/2006#issuecomment-4375528427

#### Was AI used during the creation of this PR?
<!--
We are not against AI, but in the current era of tech AI is being used more and more to help upstream projects and it is
useful for the maintainers of this project to understand if AI was used and to what extent it was used. Please see our
AI policy: https://github.com/cloudnativelabs/kube-router/blob/master/AI_POLICY.md

If no AI was used during the generation of this PR, please remove the following content and simply put "No" for this
section.
-->

* What tool was used: Claude
* To what extent was the tool used? Troubleshooting the [failing test](https://testgrid.k8s.io/kops-network-plugins#kops-aws-cni-kuberouter) and developing the patch
* If drafted, how detailed of a plan did you create for the AI? We have [this context](https://github.com/kubernetes/kops/blob/master/docs/e2e-failure-troubleshooting.md) that assists with troubleshooting, allowing the prompt itself to be rather simple.
* Help us understand if a human was in the loop or not for this PR? Yes

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->

I have not done any integration testing. We can discuss possible testing strategies in the PR, including opening a Kops PR to temporarily test a custom kube-router image.

#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

