### PR TITLE
Update netlink dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,18 @@ else
 	go test -v -timeout 30s github.com/cloudnativelabs/kube-router/v2/cmd/kube-router/ github.com/cloudnativelabs/kube-router/v2/...
 endif
 
+test-privileged: ## Runs only privileged tests (netlink, netns, etc) that require root. Use Docker or run as root.
+ifeq "$(BUILD_IN_DOCKER)" "true"
+	$(DOCKER) run --privileged -v $(PWD):/go/src/github.com/cloudnativelabs/kube-router \
+		-v $(GO_CACHE):/root/.cache/go-build \
+		-v $(GO_MOD_CACHE):/go/pkg/mod \
+		-w /go/src/github.com/cloudnativelabs/kube-router $(DOCKER_BUILD_IMAGE) \
+		sh -c \
+		'CGO_ENABLED=0 go test -v -timeout 30s -tags privileged -run "^TestPrivileged" $$(find . -name "*_privileged_test.go" -exec dirname {} + | sort -u)'
+else
+	go test -v -timeout 30s -tags privileged -run '^TestPrivileged' $$(find . -name '*_privileged_test.go' -exec dirname {} + | sort -u)
+endif
+
 test-pretty: gofmt ## Runs code quality pipelines (gofmt, tests, coverage, etc)
 ifeq "$(BUILD_IN_DOCKER)" "true"
 	$(DOCKER) run -v $(PWD):/go/src/github.com/cloudnativelabs/kube-router \
@@ -326,7 +338,7 @@ help:
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: clean container run release goreleaser push gofmt gofmt-fix gomoqs scan
-.PHONY: test test-pretty lint docker-login push-manifest push-manifest-release
+.PHONY: test test-privileged test-pretty lint docker-login push-manifest push-manifest-release
 .PHONY: push-release github-release help multiarch-binverify markdownlint doctoc
 .PHONY: spellcheck update-deps update-deps-dry prep-release
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	github.com/vishvananda/netlink v1.3.1
+	github.com/vishvananda/netlink v1.3.2-0.20260505210927-99e979749d3e
 	github.com/vishvananda/netns v0.0.5
 	golang.org/x/net v0.53.0
 	golang.org/x/sys v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW6bV0=
-github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
+github.com/vishvananda/netlink v1.3.2-0.20260505210927-99e979749d3e h1:P2oj+7IBc6qc2Ie+Ie07RRKdShl+6PN6MW87OQaUOHA=
+github.com/vishvananda/netlink v1.3.2-0.20260505210927-99e979749d3e/go.mod h1:lEui7SPMd9fgxzHVGRAvTxsBGCF6PRH81o2kLWLWHgw=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
@@ -302,9 +302,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=

--- a/pkg/routes/pbr.go
+++ b/pkg/routes/pbr.go
@@ -53,35 +53,13 @@ func ipRuleAbstraction(ipFamily int, ipOp int, cidr string) error {
 	nRule.Src = nSrc
 	nRule.Table = CustomTableID
 
-	// If the rule that we are abstracting has either the src or dst set to a default route, then we need to handle it
-	// differently. For more information, see: https://github.com/vishvananda/netlink/issues/1080
-	// TODO: If the above issue is resolved, some of the below logic can be removed
-	rules := make([]netlink.Rule, 0)
-	isDefaultRoute, err := utils.IsDefaultRoute(nSrc)
-	if err != nil {
-		return fmt.Errorf("failed to check if CIDR is a default route: %w", err)
-	}
-
+	// Default route Src/Dst filtering (0.0.0.0/0 or ::/0) relies on the upstream fix in:
+	// https://github.com/vishvananda/netlink/pull/1178
+	// Regression is guarded by TestPrivilegedRuleListFilteredDefaultRoute in pbr_privileged_test.go
 	ctx := context.Background()
-	if isDefaultRoute {
-		var tmpRules []netlink.Rule
-		tmpRules, err = nlretry.RuleListFiltered(ctx, ipFamily, nRule, netlink.RT_FILTER_TABLE)
-		if err != nil {
-			return fmt.Errorf("failed to list rules: %w", err)
-		}
-
-		// Check if one or more of the rules returned are a default route rule
-		for _, rule := range tmpRules {
-			// If the rule has no src, then it is a default route rule which is the match criteria for the rule
-			if rule.Src == nil {
-				rules = append(rules, rule)
-			}
-		}
-	} else {
-		rules, err = nlretry.RuleListFiltered(ctx, ipFamily, nRule, netlink.RT_FILTER_SRC|netlink.RT_FILTER_TABLE)
-		if err != nil {
-			return fmt.Errorf("failed to list rules: %w", err)
-		}
+	rules, err := nlretry.RuleListFiltered(ctx, ipFamily, nRule, netlink.RT_FILTER_SRC|netlink.RT_FILTER_TABLE)
+	if err != nil {
+		return fmt.Errorf("failed to list rules: %w", err)
 	}
 
 	if ipOp == PBRRuleDel && len(rules) > 0 {

--- a/pkg/routes/pbr_privileged_test.go
+++ b/pkg/routes/pbr_privileged_test.go
@@ -1,0 +1,349 @@
+//go:build linux && privileged
+
+package routes
+
+import (
+	"net"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+// setUpNetlinkTest creates an isolated network namespace for testing netlink operations. The returned cleanup function
+// restores the original namespace. Tests using this helper require root privileges and will be skipped otherwise.
+func setUpNetlinkTest(t *testing.T) {
+	t.Helper()
+
+	if os.Getuid() != 0 {
+		t.Skip("Test requires root privileges.")
+	}
+
+	runtime.LockOSThread()
+
+	origNS, err := netns.Get()
+	require.NoError(t, err, "failed to get current namespace")
+
+	ns, err := netns.New()
+	if err != nil {
+		_ = netns.Set(origNS)
+		runtime.UnlockOSThread()
+		require.NoError(t, err, "failed to create new namespace")
+	}
+
+	t.Cleanup(func() {
+		ns.Close()
+		err := netns.Set(origNS)
+		if err != nil {
+			t.Fatalf("Failed to restore original namespace: %v", err)
+		}
+		_ = origNS.Close()
+		runtime.UnlockOSThread()
+	})
+}
+
+// TestRuleListFilteredDefaultRoute verifies that netlink.RuleListFiltered correctly matches rules whose Src or Dst is
+// a default route (0.0.0.0/0 or ::/0). This is a regression test for https://github.com/vishvananda/netlink/issues/1080
+// which was fixed upstream in https://github.com/vishvananda/netlink/pull/1178.
+//
+// When the kernel returns a rule with Src/Dst set to a default route, it omits the FRA_SRC/FRA_DST attribute (prefix
+// length is 0), so the parsed rule.Src/rule.Dst is nil. The fix ensures that the filter logic treats nil as equivalent
+// to /0, so that filtering by Src = 0.0.0.0/0 correctly matches these rules.
+func TestPrivilegedRuleListFilteredDefaultRoute(t *testing.T) {
+	tests := []struct {
+		name       string
+		family     int
+		src        *net.IPNet
+		table      int
+		filterMask uint64
+	}{
+		{
+			name:       "IPv4 default route Src filtered by RT_FILTER_SRC",
+			family:     netlink.FAMILY_V4,
+			src:        &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
+			table:      100,
+			filterMask: netlink.RT_FILTER_SRC,
+		},
+		{
+			name:       "IPv4 default route Src filtered by RT_FILTER_SRC and RT_FILTER_TABLE",
+			family:     netlink.FAMILY_V4,
+			src:        &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
+			table:      101,
+			filterMask: netlink.RT_FILTER_SRC | netlink.RT_FILTER_TABLE,
+		},
+		{
+			name:       "IPv6 default route Src filtered by RT_FILTER_SRC",
+			family:     netlink.FAMILY_V6,
+			src:        &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
+			table:      102,
+			filterMask: netlink.RT_FILTER_SRC,
+		},
+		{
+			name:       "IPv6 default route Src filtered by RT_FILTER_SRC and RT_FILTER_TABLE",
+			family:     netlink.FAMILY_V6,
+			src:        &net.IPNet{IP: net.IPv6zero, Mask: net.CIDRMask(0, 128)},
+			table:      103,
+			filterMask: netlink.RT_FILTER_SRC | netlink.RT_FILTER_TABLE,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setUpNetlinkTest(t)
+
+			// Add a rule with a default route Src
+			rule := netlink.NewRule()
+			rule.Family = tt.family
+			rule.Src = tt.src
+			rule.Table = tt.table
+			rule.Priority = 1000
+			require.NoError(t, netlink.RuleAdd(rule), "failed to add rule")
+			t.Cleanup(func() {
+				_ = netlink.RuleDel(rule)
+			})
+
+			// Build the filter — this is how ipRuleAbstraction does it
+			filter := netlink.NewRule()
+			filter.Family = tt.family
+			filter.Src = tt.src
+			filter.Table = tt.table
+
+			// This is the call that was broken before the upstream fix: filtering by RT_FILTER_SRC with a
+			// default route Src would return 0 results because the kernel returns nil for default route Src
+			// and the old code treated nil as "not matching".
+			rules, err := netlink.RuleListFiltered(tt.family, filter, tt.filterMask)
+			require.NoError(t, err, "RuleListFiltered failed")
+
+			assert.NotEmpty(t, rules,
+				"RuleListFiltered with default route Src returned no results — "+
+					"this indicates https://github.com/vishvananda/netlink/issues/1080 has regressed")
+
+			// Verify our rule is among the results. We can't assume it's at index 0 because a fresh
+			// network namespace has pre-existing rules (e.g. "from all lookup local", table 255)
+			// that also match a default route Src filter when RT_FILTER_TABLE is not set.
+			found := false
+			for _, r := range rules {
+				if r.Table == tt.table {
+					found = true
+					break
+				}
+			}
+			assert.True(t, found,
+				"expected to find rule with table %d in filtered results, got tables: %v",
+				tt.table, ruleTables(rules))
+		})
+	}
+}
+
+// TestRuleListFilteredNonDefaultRoute verifies that RuleListFiltered still works correctly for non-default (normal)
+// routes alongside the default route fix. This ensures the upstream fix didn't break normal filtering behavior.
+func TestPrivilegedRuleListFilteredNonDefaultRoute(t *testing.T) {
+	tests := []struct {
+		name   string
+		family int
+		src    *net.IPNet
+		table  int
+	}{
+		{
+			name:   "IPv4 specific CIDR",
+			family: netlink.FAMILY_V4,
+			src:    &net.IPNet{IP: net.IPv4(172, 20, 0, 0), Mask: net.CIDRMask(24, 32)},
+			table:  110,
+		},
+		{
+			name:   "IPv6 specific CIDR",
+			family: netlink.FAMILY_V6,
+			src:    &net.IPNet{IP: net.ParseIP("fd00:db8::"), Mask: net.CIDRMask(64, 128)},
+			table:  111,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setUpNetlinkTest(t)
+
+			rule := netlink.NewRule()
+			rule.Family = tt.family
+			rule.Src = tt.src
+			rule.Table = tt.table
+			rule.Priority = 1000
+			require.NoError(t, netlink.RuleAdd(rule), "failed to add rule")
+			t.Cleanup(func() {
+				_ = netlink.RuleDel(rule)
+			})
+
+			filter := netlink.NewRule()
+			filter.Family = tt.family
+			filter.Src = tt.src
+			filter.Table = tt.table
+
+			rules, err := netlink.RuleListFiltered(tt.family, filter,
+				netlink.RT_FILTER_SRC|netlink.RT_FILTER_TABLE)
+			require.NoError(t, err, "RuleListFiltered failed")
+
+			assert.Len(t, rules, 1, "expected exactly one matching rule")
+			if len(rules) > 0 {
+				assert.Equal(t, tt.table, rules[0].Table, "matched rule has unexpected table")
+			}
+		})
+	}
+}
+
+// TestRuleListFilteredDefaultRouteDoesNotMatchSpecific verifies that a default route filter does NOT match rules with
+// a specific (non-default) Src. This ensures the nil ≡ /0 equivalence in the upstream fix is correctly scoped.
+func TestPrivilegedRuleListFilteredDefaultRouteDoesNotMatchSpecific(t *testing.T) {
+	setUpNetlinkTest(t)
+
+	// Add a rule with a specific (non-default) Src
+	specificSrc := &net.IPNet{IP: net.IPv4(10, 0, 0, 0), Mask: net.CIDRMask(8, 32)}
+	rule := netlink.NewRule()
+	rule.Family = netlink.FAMILY_V4
+	rule.Src = specificSrc
+	rule.Table = 120
+	rule.Priority = 1000
+	require.NoError(t, netlink.RuleAdd(rule), "failed to add rule")
+	t.Cleanup(func() {
+		_ = netlink.RuleDel(rule)
+	})
+
+	// Filter with a default route Src — this should NOT match the specific rule above
+	defaultSrc := &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}
+	filter := netlink.NewRule()
+	filter.Family = netlink.FAMILY_V4
+	filter.Src = defaultSrc
+	filter.Table = 120
+
+	rules, err := netlink.RuleListFiltered(netlink.FAMILY_V4, filter,
+		netlink.RT_FILTER_SRC|netlink.RT_FILTER_TABLE)
+	require.NoError(t, err, "RuleListFiltered failed")
+
+	assert.Empty(t, rules,
+		"default route filter should NOT match a rule with a specific Src (10.0.0.0/8)")
+}
+
+// TestIpRuleAbstractionDefaultRoute exercises the full ipRuleAbstraction function with a default route CIDR, verifying
+// the add and delete lifecycle works end-to-end.
+func TestPrivilegedIpRuleAbstractionDefaultRoute(t *testing.T) {
+	tests := []struct {
+		name   string
+		family int
+		cidr   string
+	}{
+		{
+			name:   "IPv4 default route",
+			family: netlink.FAMILY_V4,
+			cidr:   "0.0.0.0/0",
+		},
+		{
+			name:   "IPv6 default route",
+			family: netlink.FAMILY_V6,
+			cidr:   "::/0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setUpNetlinkTest(t)
+
+			// Add the rule via ipRuleAbstraction
+			err := ipRuleAbstraction(tt.family, PBRRuleAdd, tt.cidr)
+			require.NoError(t, err, "ipRuleAbstraction add failed")
+
+			// Verify the rule was created by listing with RT_FILTER_TABLE
+			_, nSrc, _ := net.ParseCIDR(tt.cidr)
+			filter := netlink.NewRule()
+			filter.Family = tt.family
+			filter.Src = nSrc
+			filter.Table = CustomTableID
+
+			rules, err := netlink.RuleListFiltered(tt.family, filter,
+				netlink.RT_FILTER_SRC|netlink.RT_FILTER_TABLE)
+			require.NoError(t, err, "RuleListFiltered failed")
+			assert.NotEmpty(t, rules, "rule should exist after add")
+
+			// Adding again should be idempotent (no error, no duplicate)
+			err = ipRuleAbstraction(tt.family, PBRRuleAdd, tt.cidr)
+			require.NoError(t, err, "idempotent add failed")
+
+			// Delete the rule via ipRuleAbstraction
+			err = ipRuleAbstraction(tt.family, PBRRuleDel, tt.cidr)
+			require.NoError(t, err, "ipRuleAbstraction del failed")
+
+			// Verify the rule was removed
+			rules, err = netlink.RuleListFiltered(tt.family, filter,
+				netlink.RT_FILTER_SRC|netlink.RT_FILTER_TABLE)
+			require.NoError(t, err, "RuleListFiltered failed")
+			assert.Empty(t, rules, "rule should not exist after delete")
+
+			// Deleting again should be idempotent (no error)
+			err = ipRuleAbstraction(tt.family, PBRRuleDel, tt.cidr)
+			require.NoError(t, err, "idempotent del failed")
+		})
+	}
+}
+
+// TestIpRuleAbstractionNonDefaultRoute exercises ipRuleAbstraction with typical pod CIDRs (the common case) to ensure
+// the default route changes didn't break normal behavior.
+func TestPrivilegedIpRuleAbstractionNonDefaultRoute(t *testing.T) {
+	tests := []struct {
+		name   string
+		family int
+		cidr   string
+	}{
+		{
+			name:   "IPv4 pod CIDR",
+			family: netlink.FAMILY_V4,
+			cidr:   "172.20.0.0/24",
+		},
+		{
+			name:   "IPv6 pod CIDR",
+			family: netlink.FAMILY_V6,
+			cidr:   "fd00:db8:42:2::/64",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setUpNetlinkTest(t)
+
+			// Add
+			err := ipRuleAbstraction(tt.family, PBRRuleAdd, tt.cidr)
+			require.NoError(t, err, "ipRuleAbstraction add failed")
+
+			// Verify
+			_, nSrc, _ := net.ParseCIDR(tt.cidr)
+			filter := netlink.NewRule()
+			filter.Family = tt.family
+			filter.Src = nSrc
+			filter.Table = CustomTableID
+
+			rules, err := netlink.RuleListFiltered(tt.family, filter,
+				netlink.RT_FILTER_SRC|netlink.RT_FILTER_TABLE)
+			require.NoError(t, err, "RuleListFiltered failed")
+			assert.Len(t, rules, 1, "expected exactly one matching rule")
+
+			// Delete
+			err = ipRuleAbstraction(tt.family, PBRRuleDel, tt.cidr)
+			require.NoError(t, err, "ipRuleAbstraction del failed")
+
+			// Verify deletion
+			rules, err = netlink.RuleListFiltered(tt.family, filter,
+				netlink.RT_FILTER_SRC|netlink.RT_FILTER_TABLE)
+			require.NoError(t, err, "RuleListFiltered failed")
+			assert.Empty(t, rules, "rule should not exist after delete")
+		})
+	}
+}
+
+// ruleTables extracts the Table field from a slice of rules for diagnostic output.
+func ruleTables(rules []netlink.Rule) []int {
+	tables := make([]int, len(rules))
+	for i, r := range rules {
+		tables[i] = r.Table
+	}
+	return tables
+}

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"bytes"
-	"fmt"
 	"net"
 )
 
@@ -105,23 +104,4 @@ func IsIPInRanges(ip net.IP, ranges []net.IPNet) bool {
 		}
 	}
 	return false
-}
-
-// IsDefaultRoute checks if a given CIDR is a default route by comparing it to the default routes for IPv4 and IPv6
-func IsDefaultRoute(cidr *net.IPNet) (bool, error) {
-	var defaultPrefixCIDR *net.IPNet
-	var err error
-
-	if cidr.IP.To4() != nil {
-		_, defaultPrefixCIDR, err = net.ParseCIDR(IPv4DefaultRoute)
-		if err != nil {
-			return false, fmt.Errorf("failed to parse default route: %w", err)
-		}
-	} else {
-		_, defaultPrefixCIDR, err = net.ParseCIDR(IPv6DefaultRoute)
-		if err != nil {
-			return false, fmt.Errorf("failed to parse default route: %w", err)
-		}
-	}
-	return IPNetEqual(defaultPrefixCIDR, cidr), nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?

<!--
Please choose one of the following kinds:
-->
bug

#### What this PR does / why we need it:

Upgrades the netlink library to the most recent git commit (a release hasn't been cut in a year and there have been 55 improvements and bug fixes since then).

This also adds some regression tests that would catch if this error comes back. It also adds a mechanisms for running unit tests that require privileged execution like these ones do (in order to create new network namespaces and not mess with the testing host's routing tables).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->

This fixes #2070 thanks for reporting and fixing upstream @cheina97!

#### Was AI used during the creation of this PR?
<!--
We are not against AI, but in the current era of tech AI is being used more and more to help upstream projects and it is
useful for the maintainers of this project to understand if AI was used and to what extent it was used. Please see our
AI policy: https://github.com/cloudnativelabs/kube-router/blob/master/AI_POLICY.md

If no AI was used during the generation of this PR, please remove the following content and simply put "No" for this
section.
-->

* What tool was used: Claude
* To what extent was the tool used? Most code generation
* If drafted, how detailed of a plan did you create for the AI? Very detailed (multiple paragraph long prompts)
* Help us understand if a human was in the loop or not for this PR? Yes

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->

No integration testing has been performed yet, but I intend on doing more integration tests prior to cutting the next release.

#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

