### PR TITLE
Add deny by default to netpol

### DIFF
--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -38,6 +38,7 @@ solutions.
 - [Network Policy Issues](#network-policy-issues)
   - [Egress Policy Blocking Service Access](#egress-policy-blocking-service-access)
   - [Pods Have Network Access Before Policy is Applied](#pods-have-network-access-before-policy-is-applied)
+  - [NetworkPolicy not enforced on freshly-launched pods](#networkpolicy-not-enforced-on-freshly-launched-pods)
   - [ipBlock Not Matching Real Client IP](#ipblock-not-matching-real-client-ip)
 - [Overlay and Tunnel Issues](#overlay-and-tunnel-issues)
   - [Cross-Subnet Connectivity Failures](#cross-subnet-connectivity-failures)
@@ -620,7 +621,103 @@ this window persist because `ESTABLISHED,RELATED` flows are always allowed
 
 **Solution:** This is an architectural limitation. Modern versions sync policies within a few seconds. For
 critical workloads, add an `initContainer` that waits for network readiness before starting the main
-container.
+container. For a stricter posture, set `--netpol-default-deny=true` so kube-router REJECTs traffic
+during this window instead of allowing it — see
+[NetworkPolicy not enforced on freshly-launched pods](#networkpolicy-not-enforced-on-freshly-launched-pods)
+for the operational details.
+
+### NetworkPolicy not enforced on freshly-launched pods
+
+**Symptoms:** A pod is launched with a NetworkPolicy that should block some of its outbound or
+inbound traffic, but during the first few seconds of the pod's lifecycle the traffic the policy
+should reject succeeds anyway. Short-lived workloads such as CronJobs sometimes complete before
+the policy ever takes effect, and long-running connections that get established in this window
+keep working forever afterwards because conntrack lets `ESTABLISHED,RELATED` flows through.
+
+**Diagnosis:**
+
+```sh
+# From the freshly-launched pod, try the destination the policy should block. The first attempt
+# often succeeds; a few seconds later the policy is in effect and the same call fails.
+kubectl exec <pod> -- curl -m 2 http://blocked-service.namespace/
+
+# On the node where the pod is running, list the per-pod firewall chains. If the chain for this
+# pod is not in the list yet, the pod's traffic is currently unenforced.
+iptables -t filter -L -n | grep KUBE-POD-FW-
+```
+
+**Root Cause:** The CNI plugin wires the pod's networking before kube-router has a chance to
+program the pod's `KUBE-POD-FW-*` firewall chain. Between the moment the pod becomes routable on
+the node and the moment kube-router's next NetworkPolicy sync writes the chain, there is a brief
+window where the pod's traffic is not evaluated against any NetworkPolicy. By default kube-router
+fails open during this window so unrelated traffic on the node is not disrupted.
+
+**Solution — enable `--netpol-default-deny`:** Pass `--netpol-default-deny=true` to kube-router
+to fail closed during the race window instead. With the flag on, kube-router installs catch-all
+REJECT rules in the `KUBE-NWPLCY-TAIL` iptables chain that drop any traffic to or from a local
+pod whose firewall chain has not yet been programmed for the current sync. The pod sees
+"connection refused" during the race window and once kube-router programs the pod's chain (a few
+seconds at most under default sync settings) the NetworkPolicy takes over normally.
+
+The trade-off is that traffic the NetworkPolicy *would* have allowed is also rejected during the
+same window. Most applications can simply retry, but workloads that cannot tolerate the initial
+failure should leave `--netpol-default-deny` off and use an `initContainer` that waits for
+network readiness before the main container starts.
+
+**Requirements:** kube-router can only install the catch-all REJECT rules when it knows the
+node's pod CIDRs. It reads them from one of two places on the Node object, in this order:
+
+- The `kube-router.io/pod-cidrs` annotation, if present. Set this when kube-controller-manager is
+  not handling pod CIDR allocation for your cluster.
+- Otherwise, `node.spec.podCIDRs` — the field `kube-controller-manager` populates when started
+  with `--allocate-node-cidrs=true` (the typical Kubernetes default). The legacy single-CIDR
+  `node.spec.podCIDR` field is also populated but kube-router uses the plural list.
+
+You can verify the source kube-router will use with `kubectl`:
+
+```sh
+# What kube-controller-manager allocated (when --allocate-node-cidrs=true is in effect):
+kubectl get node <node-name> -o jsonpath='{.spec.podCIDRs}{"\n"}'
+
+# What the annotation override is set to (empty when no annotation is present):
+kubectl get node <node-name> -o jsonpath='{.metadata.annotations.kube-router\.io/pod-cidrs}{"\n"}'
+```
+
+If neither source is populated, kube-router logs the message below at startup, silently disables
+`--netpol-default-deny`, and continues without protection. Either enable `--allocate-node-cidrs`
+on kube-controller-manager or set the `kube-router.io/pod-cidrs` annotation on the affected
+nodes, then restart kube-router on those nodes to pick up the change.
+
+```text
+we were unable to intuit the default pod IP CIDRs for this node ... Disabling this option as
+it would not be safe to other node traffic
+```
+
+**Verifying the feature is active:**
+
+```sh
+# KUBE-NWPLCY-TAIL should contain REJECTs that consult the kube-router-local-pods ipset, one
+# per pod CIDR per direction:
+iptables -t filter -L KUBE-NWPLCY-TAIL -n -v --line-numbers
+
+# The ipset should contain the IP of every local pod whose firewall chain has been programmed
+# in the current sync:
+ipset list kube-router-local-pods
+
+# IPv6 equivalent when --enable-ipv6 is set:
+ip6tables -t filter -L KUBE-NWPLCY-TAIL -n -v --line-numbers
+ipset list inet6:kube-router-local-pods
+```
+
+If the `kube-router-local-pods` ipset is destroyed out-of-band, kube-router recreates it during
+its per-sync drift check and the next full sync repopulates it. The same warning fires once at
+kube-router startup (when the set is created for the first time) and is informational there; if
+it keeps reappearing during normal operation, find and stop whichever process is destroying the
+ipset (it is not kube-router):
+
+```text
+kube-router-local-pods ipset for family IPv4 was missing; creating
+```
 
 ### ipBlock Not Matching Real Client IP
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -152,6 +152,7 @@ Usage of kube-router:
       --metrics-addr string                           Prometheus metrics address to listen on, (Default: all interfaces)
       --metrics-path string                           Prometheus metrics path (default "/metrics")
       --metrics-port uint16                           Prometheus metrics port, (Default 0, Disabled)
+      --netpol-default-deny                           Default policy to use for pods to have before NetworkPolicy is applied
       --nodeport-bindon-all-ip                        For service of NodePort type create IPVS service that listens on all IP's of the node.
       --nodes-full-mesh                               Each node in the cluster will setup BGP peering with rest of the nodes. (default true)
       --overlay-encap string                          Valid encapsulation types are "ipip" or "fou" (if set to "fou", the udp port can be specified via "overlay-encap-port") (default "ipip")

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -29,6 +29,7 @@
   - [Configuration Examples](#configuration-examples)
   - [Upgrading](#upgrading)
   - [Shared Flags](#shared-flags)
+- [NetworkPolicy Default-Deny](#networkpolicy-default-deny)
 - [Controlling Service Locality or Traffic Policies](#controlling-service-locality-or-traffic-policies)
 - [Hairpin Mode](#hairpin-mode)
   - [Hairpin Mode Example](#hairpin-mode-example)
@@ -453,6 +454,24 @@ The `--service-external-ip-range` and `--loadbalancer-ip-range` flags serve mult
 
 If you were already using these flags for other controllers, the proxy module will automatically benefit from the same
 configuration.
+
+## NetworkPolicy Default-Deny
+
+When `--netpol-default-deny` is enabled, kube-router rejects traffic to and from local pods during the brief window
+between a pod becoming routable on this node and its per-pod `KUBE-POD-FW-*` firewall chain being installed. Without
+this flag, a freshly-launched pod can briefly reach destinations that its NetworkPolicy would otherwise block — a
+race short-lived workloads such as CronJobs occasionally lose.
+
+To detect this node's pod CIDRs, kube-router relies on either the `--allocate-node-cidrs=true` flag on
+kube-controller-manager (the typical Kubernetes default) or the `kube-router.io/pod-cidrs` node annotation. If neither
+is configured the controller logs an error during startup, disables `--netpol-default-deny`, and continues without
+default-deny protection — it is not safe to install REJECTs against pod CIDRs we cannot trust.
+
+For details on how to verify the feature is doing what you expect (and on the failure modes when the node's pod
+CIDRs cannot be detected), see [NetworkPolicy not enforced on freshly-launched pods][netpol-default-deny] in the
+troubleshooting guide.
+
+[netpol-default-deny]: troubleshoot.md#networkpolicy-not-enforced-on-freshly-launched-pods
 
 ## Controlling Service Locality or Traffic Policies
 

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -662,7 +662,7 @@ func (npc *NetworkPolicyController) ensureLocalPodsIPSetExists() {
 	if !npc.defaultDeny {
 		return
 	}
-	if nil != npc.ipsetMutex {
+	if npc.ipsetMutex != nil {
 		klog.V(2).Infof("Attempting to attain ipset mutex lock for protected-pods ipset check")
 		npc.ipsetMutex.Lock()
 		klog.V(2).Infof("Attained ipset mutex lock for protected-pods ipset check, continuing...")
@@ -777,7 +777,7 @@ func (npc *NetworkPolicyController) populateProtectedPodsIPSet(activePodIPs map[
 	if !npc.defaultDeny {
 		return
 	}
-	if nil != npc.ipsetMutex {
+	if npc.ipsetMutex != nil {
 		klog.V(2).Infof("Attempting to attain ipset mutex lock for protected-pods refresh")
 		npc.ipsetMutex.Lock()
 		klog.V(2).Infof("Attained ipset mutex lock for protected-pods refresh, continuing...")
@@ -1003,7 +1003,7 @@ func (npc *NetworkPolicyController) cleanupStaleIPSets(activePolicyIPSets map[st
 	// There are certain actions like Cleanup() actions that aren't working with full instantiations of the controller
 	// and in these instances the mutex may not be present and may not need to be present as they are operating out of a
 	// single goroutine where there is no need for locking
-	if nil != npc.ipsetMutex {
+	if npc.ipsetMutex != nil {
 		klog.V(1).Infof("Attempting to attain ipset mutex lock")
 		npc.ipsetMutex.Lock()
 		klog.V(1).Infof("Attained ipset mutex lock, continuing...")

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -1224,11 +1224,10 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	if npc.defaultDeny {
 		podIPv4CIDRs, podIPv6CIDRs, err := utils.GetPodCIDRsFromNodeSpecDualStack(node)
 		if err != nil {
-			klog.Error("we were unable to intuit the default pod IP CIDRs for this node (likely not setting either" +
+			return nil, errors.New("we were unable to intuit the default pod IP CIDRs for this node (likely not setting either" +
 				"kube-router pod CIDR node annotations or using the k8s allocate pod CIDRs option. However, we were told " +
 				"to run with default deny (--netpol-default-deny). Disabling this option as it would not be safe to " +
 				"other node traffic")
-			npc.defaultDeny = false
 		} else {
 			npc.podCIDRs = make(map[v1core.IPFamily][]string)
 			npc.podCIDRs[v1core.IPv4Protocol] = podIPv4CIDRs

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -37,6 +37,7 @@ const (
 	kubeOutputChainName          = "KUBE-ROUTER-OUTPUT"
 	kubeDefaultNetpolChain       = "KUBE-NWPLCY-DEFAULT"
 	kubeCommonNetpolChain        = "KUBE-NWPLCY-COMMON"
+	kubeTailNetpolChain          = "KUBE-NWPLCY-TAIL"
 
 	kubeIngressPolicyType = "ingress"
 	kubeEgressPolicyType  = "egress"
@@ -75,6 +76,8 @@ type NetworkPolicyController struct {
 	healthChan           chan<- *healthcheck.ControllerHeartbeat
 	fullSyncRequestChan  chan struct{}
 	ipsetMutex           *sync.Mutex
+	defaultDeny          bool
+	podCIDRs             map[v1core.IPFamily][]string
 
 	iptablesCmdHandlers map[v1core.IPFamily]utils.IPTablesHandler
 	iptablesSaveRestore map[v1core.IPFamily]utils.IPTablesSaveRestorer
@@ -173,6 +176,9 @@ func (npc *NetworkPolicyController) Run(healthChan chan<- *healthcheck.Controlle
 	// setup common network policy chain that is applied to all bi-directional traffic
 	npc.ensureCommonPolicyChain()
 
+	// setup KUBE-ROUTER-(INPUT/OUTPUT/FORWARD) tail chain which contains explicit ACCEPT / REJECT rules
+	npc.ensureDefaultTailChain()
+
 	// Full syncs of the network policy controller take a lot of time and can only be processed one at a time,
 	// therefore, we start it in it's own goroutine and request a sync through a single item channel
 	klog.Info("Starting network policy controller full sync goroutine")
@@ -268,6 +274,9 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 	// ensure common network policy chain that is applied to all bi-directional traffic
 	npc.ensureCommonPolicyChain()
 
+	// Per-sync safety net for KUBE-NWPLCY-TAIL; the chain itself is built by ensureDefaultTailChain() in Run().
+	npc.ensureDefaultTailChainExists()
+
 	networkPoliciesInfo, err = npc.buildNetworkPoliciesInfo()
 	if err != nil {
 		klog.Errorf("Aborting sync. Failed to build network policies: %v", err.Error())
@@ -304,9 +313,8 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 
 	activePodFwChains := npc.syncPodFirewallChains(networkPoliciesInfo, syncVersion)
 
-	// Makes sure that the ACCEPT rules for packets marked with "0x20000" are added to the end of each of kube-router's
-	// top level chains
-	npc.ensureExplicitAccept()
+	// Ensure the KUBE-NWPLCY-TAIL jump sits at the end of each top-level chain, after the per-pod jumps above.
+	npc.ensureTailChainPosition()
 
 	err = npc.cleanupStaleRules(activePolicyChains, activePodFwChains, false)
 	if err != nil {
@@ -564,14 +572,111 @@ func (npc *NetworkPolicyController) ensureTopLevelChains() {
 	}
 }
 
-func (npc *NetworkPolicyController) ensureExplicitAccept() {
-	// for the traffic to/from the local pod's let network policy controller be
-	// authoritative entity to ACCEPT the traffic if it complies to network policies
+// ensureDefaultTailChain (re)creates KUBE-NWPLCY-TAIL and populates it from scratch, wiping any prior contents so
+// toggling --netpol-default-deny across restarts is idempotent. Call from Run() only; fullPolicySync uses
+// ensureDefaultTailChainExists to avoid a ClearChain/Append leak window on every pod event.
+func (npc *NetworkPolicyController) ensureDefaultTailChain() {
+	for family, iptablesCmdHandler := range npc.iptablesCmdHandlers {
+		exists, err := iptablesCmdHandler.ChainExists("filter", kubeTailNetpolChain)
+		if err != nil {
+			klog.Fatalf("failed to check for the existence of chain %s, error: %v",
+				kubeTailNetpolChain, err)
+		}
+		if !exists {
+			if err = iptablesCmdHandler.NewChain("filter", kubeTailNetpolChain); err != nil {
+				klog.Fatalf("failed to create %s chain due to %s",
+					kubeTailNetpolChain, err.Error())
+			}
+		} else {
+			// Wipe stale contents (e.g. REJECT rules from a previous run where --netpol-default-deny was
+			// enabled but is now disabled, or vice versa).
+			if err = iptablesCmdHandler.ClearChain("filter", kubeTailNetpolChain); err != nil {
+				klog.Fatalf("failed to clear %s chain due to %s",
+					kubeTailNetpolChain, err.Error())
+			}
+		}
+		npc.populateDefaultTailChain(family, iptablesCmdHandler)
+	}
+}
+
+// ensureDefaultTailChainExists is the per-sync safety net: it recreates KUBE-NWPLCY-TAIL only if the chain has gone
+// missing entirely, and otherwise just runs a cheap rule-count drift check and logs a warning on mismatch. We don't
+// auto-rebuild on drift because doing so would re-introduce the leak window ensureDefaultTailChain avoids.
+func (npc *NetworkPolicyController) ensureDefaultTailChainExists() {
+	for family, iptablesCmdHandler := range npc.iptablesCmdHandlers {
+		exists, err := iptablesCmdHandler.ChainExists("filter", kubeTailNetpolChain)
+		if err != nil {
+			klog.Fatalf("failed to check for the existence of chain %s, error: %v",
+				kubeTailNetpolChain, err)
+		}
+		if !exists {
+			klog.Warningf("%s chain was missing during sync; recreating", kubeTailNetpolChain)
+			if err = iptablesCmdHandler.NewChain("filter", kubeTailNetpolChain); err != nil {
+				klog.Fatalf("failed to create %s chain due to %s",
+					kubeTailNetpolChain, err.Error())
+			}
+			npc.populateDefaultTailChain(family, iptablesCmdHandler)
+			continue
+		}
+
+		// Cheap drift detection: count the rules and compare to what we expect to be there. This catches
+		// the case where someone (or something) has tampered with the chain, without rebuilding it
+		// underneath live traffic.
+		rules, err := iptablesCmdHandler.List("filter", kubeTailNetpolChain)
+		if err != nil {
+			klog.Warningf("unable to list rules in %s for drift check: %v", kubeTailNetpolChain, err)
+			continue
+		}
+		// List returns "-N CHAIN" as rules[0] followed by one "-A CHAIN ..." per rule, so subtract one.
+		expected := 1
+		if npc.defaultDeny {
+			expected += 2 * len(npc.podCIDRs[family])
+		}
+		if actual := len(rules) - 1; actual != expected {
+			klog.Warningf("%s has %d rules but expected %d; chain contents have drifted, "+
+				"restart kube-router to rebuild", kubeTailNetpolChain, actual, expected)
+		}
+	}
+}
+
+// populateDefaultTailChain appends the ACCEPT-marked rule and (when --netpol-default-deny is enabled) the per-CIDR
+// REJECT rules into KUBE-NWPLCY-TAIL. Callers must ensure the chain exists and is empty.
+func (npc *NetworkPolicyController) populateDefaultTailChain(
+	family v1core.IPFamily, iptablesCmdHandler utils.IPTablesHandler,
+) {
+	acceptComment := "rule to explicitly ACCEPT traffic that comply to network policies"
+	acceptArgs := []string{"-m", "comment", "--comment", acceptComment,
+		"-m", "mark", "--mark", "0x20000/0x20000", "-j", "ACCEPT"}
+	if err := iptablesCmdHandler.Append("filter", kubeTailNetpolChain, acceptArgs...); err != nil {
+		klog.Fatalf("failed to add ACCEPT rule to %s due to %s",
+			kubeTailNetpolChain, err.Error())
+	}
+
+	if !npc.defaultDeny {
+		return
+	}
+	rejectComment := "REJECT traffic before NetPol is applied (--netpol-default-deny is enabled)"
+	for _, cidr := range npc.podCIDRs[family] {
+		srcArgs := []string{"-s", cidr, "-m", "comment", "--comment", rejectComment, "-j", "REJECT"}
+		if err := iptablesCmdHandler.Append("filter", kubeTailNetpolChain, srcArgs...); err != nil {
+			klog.Fatalf("failed to add source REJECT rule to %s due to %s",
+				kubeTailNetpolChain, err.Error())
+		}
+		dstArgs := []string{"-d", cidr, "-m", "comment", "--comment", rejectComment, "-j", "REJECT"}
+		if err := iptablesCmdHandler.Append("filter", kubeTailNetpolChain, dstArgs...); err != nil {
+			klog.Fatalf("failed to add destination REJECT rule to %s due to %s",
+				kubeTailNetpolChain, err.Error())
+		}
+	}
+}
+
+// ensureTailChainPosition ensures each KUBE-ROUTER-{INPUT,FORWARD,OUTPUT} chain ends with a jump into
+// KUBE-NWPLCY-TAIL, placing it after the per-pod KUBE-POD-FW-* jumps written earlier in the same sync.
+func (npc *NetworkPolicyController) ensureTailChainPosition() {
 	for _, filterTableRules := range npc.filterTableRules {
 		for _, chain := range defaultChains {
-			comment := "\"rule to explicitly ACCEPT traffic that comply to network policies\""
-			args := []string{"-m", "comment", "--comment", comment, "-m", "mark", "--mark", "0x20000/0x20000",
-				"-j", "ACCEPT"}
+			comment := "\"rule to explicitly handle traffic for network policies ACCEPT/REJECT decision\""
+			args := []string{"-m", "comment", "--comment", comment, "-j", kubeTailNetpolChain}
 			utils.AppendUnique(filterTableRules, chain, args)
 		}
 	}
@@ -686,6 +791,9 @@ func (npc *NetworkPolicyController) cleanupStaleRules(activePolicyChains, active
 				if chain == kubeCommonNetpolChain {
 					continue
 				}
+				if chain == kubeTailNetpolChain {
+					continue
+				}
 				if _, ok := activePolicyChains[chain]; !ok {
 					cleanupPolicyChains = append(cleanupPolicyChains, chain)
 					continue
@@ -720,7 +828,7 @@ func (npc *NetworkPolicyController) cleanupStaleRules(activePolicyChains, active
 			}
 			if deleteDefaultChains {
 				for _, chain := range []string{kubeInputChainName, kubeForwardChainName, kubeOutputChainName,
-					kubeDefaultNetpolChain, kubeCommonNetpolChain} {
+					kubeDefaultNetpolChain, kubeCommonNetpolChain, kubeTailNetpolChain} {
 					if strings.Contains(rule, chain) {
 						skipRule = true
 						break
@@ -943,6 +1051,26 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	node, err := utils.GetNodeObject(clientset, config.HostnameOverride)
 	if err != nil {
 		return nil, err
+	}
+
+	npc.defaultDeny = config.NetPolDefaultDeny
+	// We try to get the IPv4 and IPv6 CIDRs here, knowing that it may fail if the user is not either running with
+	// annotations on their node (kube-router.io/pod-cidrs) or running kube-controller-manager with CIDR allocation on
+	// (--allocate-node-cidrs=true). These CIDRs are only used to enforce early network policy and there is only so much
+	// conformance we can guarantee with pod routing implementations other than ours.
+	if npc.defaultDeny {
+		podIPv4CIDRs, podIPv6CIDRs, err := utils.GetPodCIDRsFromNodeSpecDualStack(node)
+		if err != nil {
+			klog.Error("we were unable to intuit the default pod IP CIDRs for this node (likely not setting either" +
+				"kube-router pod CIDR node annotations or using the k8s allocate pod CIDRs option. However, we were told " +
+				"to run with default deny (--netpol-default-deny). Disabling this option as it would not be safe to " +
+				"other node traffic")
+			npc.defaultDeny = false
+		} else {
+			npc.podCIDRs = make(map[v1core.IPFamily][]string)
+			npc.podCIDRs[v1core.IPv4Protocol] = podIPv4CIDRs
+			npc.podCIDRs[v1core.IPv6Protocol] = podIPv6CIDRs
+		}
 	}
 
 	npc.krNode, err = utils.NewKRNode(node, linkQ, config.EnableIPv4, config.EnableIPv6)

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -38,6 +38,9 @@ const (
 	kubeDefaultNetpolChain       = "KUBE-NWPLCY-DEFAULT"
 	kubeCommonNetpolChain        = "KUBE-NWPLCY-COMMON"
 	kubeTailNetpolChain          = "KUBE-NWPLCY-TAIL"
+	// kubeLocalPodsIPSetName is the per-family ipset of local pod IPs whose KUBE-POD-FW-* chain has been
+	// programmed this sync. It gates the default-deny REJECT rules at the head of KUBE-NWPLCY-TAIL.
+	kubeLocalPodsIPSetName = "kube-router-local-pods"
 
 	kubeIngressPolicyType = "ingress"
 	kubeEgressPolicyType  = "egress"
@@ -311,7 +314,11 @@ func (npc *NetworkPolicyController) fullPolicySync() {
 		return
 	}
 
-	activePodFwChains := npc.syncPodFirewallChains(networkPoliciesInfo, syncVersion)
+	activePodFwChains, activePodIPs := npc.syncPodFirewallChains(networkPoliciesInfo, syncVersion)
+
+	// Refresh the kube-router-local-pods ipset before ensureTailChainPosition installs the TAIL jump, so the
+	// rules never reference a stale set. No-op when --netpol-default-deny is disabled.
+	npc.populateProtectedPodsIPSet(activePodIPs)
 
 	// Ensure the KUBE-NWPLCY-TAIL jump sits at the end of each top-level chain, after the per-pod jumps above.
 	npc.ensureTailChainPosition()
@@ -576,6 +583,10 @@ func (npc *NetworkPolicyController) ensureTopLevelChains() {
 // toggling --netpol-default-deny across restarts is idempotent. Call from Run() only; fullPolicySync uses
 // ensureDefaultTailChainExists to avoid a ClearChain/Append leak window on every pod event.
 func (npc *NetworkPolicyController) ensureDefaultTailChain() {
+	// Set must exist before the rules that reference it are appended. Empty is fine — the first
+	// populateProtectedPodsIPSet during fullPolicySync fills it.
+	npc.ensureLocalPodsIPSetExists()
+
 	for family, iptablesCmdHandler := range npc.iptablesCmdHandlers {
 		exists, err := iptablesCmdHandler.ChainExists("filter", kubeTailNetpolChain)
 		if err != nil {
@@ -599,10 +610,13 @@ func (npc *NetworkPolicyController) ensureDefaultTailChain() {
 	}
 }
 
-// ensureDefaultTailChainExists is the per-sync safety net: it recreates KUBE-NWPLCY-TAIL only if the chain has gone
-// missing entirely, and otherwise just runs a cheap rule-count drift check and logs a warning on mismatch. We don't
-// auto-rebuild on drift because doing so would re-introduce the leak window ensureDefaultTailChain avoids.
+// ensureDefaultTailChainExists is the per-sync safety net: it recreates KUBE-NWPLCY-TAIL only if the chain has
+// gone missing entirely, otherwise it runs a cheap rule-count drift check. With --netpol-default-deny on it
+// also makes sure the kube-router-local-pods ipset still exists; the next populateProtectedPodsIPSet repopulates
+// it.
 func (npc *NetworkPolicyController) ensureDefaultTailChainExists() {
+	npc.ensureLocalPodsIPSetExists()
+
 	for family, iptablesCmdHandler := range npc.iptablesCmdHandlers {
 		exists, err := iptablesCmdHandler.ChainExists("filter", kubeTailNetpolChain)
 		if err != nil {
@@ -630,7 +644,9 @@ func (npc *NetworkPolicyController) ensureDefaultTailChainExists() {
 		// List returns "-N CHAIN" as rules[0] followed by one "-A CHAIN ..." per rule, so subtract one.
 		expected := 1
 		if npc.defaultDeny {
-			expected += 2 * len(npc.podCIDRs[family])
+			// 2 ipset-gated REJECTs (src/dst) + 2 CIDR REJECTs (src/dst) per CIDR, plus the single
+			// ACCEPT-on-mark rule.
+			expected += 4 * len(npc.podCIDRs[family])
 		}
 		if actual := len(rules) - 1; actual != expected {
 			klog.Warningf("%s has %d rules but expected %d; chain contents have drifted, "+
@@ -639,11 +655,63 @@ func (npc *NetworkPolicyController) ensureDefaultTailChainExists() {
 	}
 }
 
-// populateDefaultTailChain appends the ACCEPT-marked rule and (when --netpol-default-deny is enabled) the per-CIDR
-// REJECT rules into KUBE-NWPLCY-TAIL. Callers must ensure the chain exists and is empty.
+// ensureLocalPodsIPSetExists makes sure the kube-router-local-pods ipset exists for every IP family. No-op when
+// --netpol-default-deny is disabled. The Save+Sets lookup exists only so we can log a one-shot "was missing"
+// warning on drift; Create itself is idempotent via `create -exist`.
+func (npc *NetworkPolicyController) ensureLocalPodsIPSetExists() {
+	if !npc.defaultDeny {
+		return
+	}
+	if nil != npc.ipsetMutex {
+		klog.V(2).Infof("Attempting to attain ipset mutex lock for protected-pods ipset check")
+		npc.ipsetMutex.Lock()
+		klog.V(2).Infof("Attained ipset mutex lock for protected-pods ipset check, continuing...")
+		defer func() {
+			npc.ipsetMutex.Unlock()
+			klog.V(2).Infof("Returned ipset mutex lock for protected-pods ipset check")
+		}()
+	}
+	for family, ipSetHandler := range npc.ipSetHandlers {
+		if err := ipSetHandler.Save(); err != nil {
+			klog.Warningf("failed to save ipsets while checking %s on family %s: %v",
+				kubeLocalPodsIPSetName, family, err)
+		}
+		setNameForFamily := ipSetHandler.Name(kubeLocalPodsIPSetName)
+		if _, exists := ipSetHandler.Sets()[setNameForFamily]; exists {
+			continue
+		}
+		klog.Warningf("%s ipset for family %s was missing; creating",
+			setNameForFamily, family)
+		if _, err := ipSetHandler.Create(kubeLocalPodsIPSetName, utils.TypeHashIP, utils.OptionTimeout, "0"); err != nil {
+			klog.Fatalf("failed to create %s ipset for family %s: %v",
+				setNameForFamily, family, err)
+		}
+	}
+}
+
+// populateDefaultTailChain appends rules into KUBE-NWPLCY-TAIL. Callers must ensure the chain exists and is empty.
+//
+// When --netpol-default-deny is disabled, only the ACCEPT-on-mark rule is appended (1 rule total).
+//
+// When --netpol-default-deny is enabled, the chain layout is, per CIDR:
+//  1. -s <CIDR> -m set ! --match-set kube-router-local-pods src -j REJECT  (ipset-gated, NEW)
+//  2. -d <CIDR> -m set ! --match-set kube-router-local-pods dst -j REJECT  (ipset-gated, NEW)
+//  3. -m mark --mark 0x20000/0x20000                              -j ACCEPT
+//  4. -s <CIDR>                                                   -j REJECT  (existing defense-in-depth)
+//  5. -d <CIDR>                                                   -j REJECT  (existing defense-in-depth)
+//
+// The ipset-gated REJECTs are placed ahead of the ACCEPT so they fire for traffic to or from a local pod whose
+// KUBE-POD-FW-* chain has not yet been programmed; this closes the race window where another local pod's chain
+// would mark the packet 0x20000 and the ACCEPT would let it through. The existing CIDR-scoped REJECTs at the
+// tail of the chain remain as defense-in-depth for traffic between unprotected local pods and external
+// destinations (no destination chain to mark, no ipset entry on either end).
 func (npc *NetworkPolicyController) populateDefaultTailChain(
 	family v1core.IPFamily, iptablesCmdHandler utils.IPTablesHandler,
 ) {
+	if npc.defaultDeny {
+		npc.appendIPSetGatedRejects(family, iptablesCmdHandler)
+	}
+
 	acceptComment := "rule to explicitly ACCEPT traffic that comply to network policies"
 	acceptArgs := []string{"-m", "comment", "--comment", acceptComment,
 		"-m", "mark", "--mark", "0x20000/0x20000", "-j", "ACCEPT"}
@@ -655,6 +723,38 @@ func (npc *NetworkPolicyController) populateDefaultTailChain(
 	if !npc.defaultDeny {
 		return
 	}
+	npc.appendCIDRRejects(family, iptablesCmdHandler)
+}
+
+// appendIPSetGatedRejects emits rules 1-2 of the per-CIDR layout documented on populateDefaultTailChain — the
+// REJECTs that fire when a source/destination is in the node's pod CIDR but not yet in kube-router-local-pods.
+func (npc *NetworkPolicyController) appendIPSetGatedRejects(
+	family v1core.IPFamily, iptablesCmdHandler utils.IPTablesHandler,
+) {
+	ipSetName := npc.ipSetHandlers[family].Name(kubeLocalPodsIPSetName)
+	comment := "REJECT traffic to/from local pods without a programmed firewall chain " +
+		"(--netpol-default-deny is enabled)"
+	for _, cidr := range npc.podCIDRs[family] {
+		srcArgs := []string{"-s", cidr, "-m", "comment", "--comment", comment,
+			"-m", "set", "!", "--match-set", ipSetName, "src", "-j", "REJECT"}
+		if err := iptablesCmdHandler.Append("filter", kubeTailNetpolChain, srcArgs...); err != nil {
+			klog.Fatalf("failed to add ipset-gated source REJECT rule to %s due to %s",
+				kubeTailNetpolChain, err.Error())
+		}
+		dstArgs := []string{"-d", cidr, "-m", "comment", "--comment", comment,
+			"-m", "set", "!", "--match-set", ipSetName, "dst", "-j", "REJECT"}
+		if err := iptablesCmdHandler.Append("filter", kubeTailNetpolChain, dstArgs...); err != nil {
+			klog.Fatalf("failed to add ipset-gated destination REJECT rule to %s due to %s",
+				kubeTailNetpolChain, err.Error())
+		}
+	}
+}
+
+// appendCIDRRejects emits rules 4-5 of the per-CIDR layout documented on populateDefaultTailChain — the
+// CIDR-scoped REJECTs that catch unprotected pods talking to external destinations.
+func (npc *NetworkPolicyController) appendCIDRRejects(
+	family v1core.IPFamily, iptablesCmdHandler utils.IPTablesHandler,
+) {
 	rejectComment := "REJECT traffic before NetPol is applied (--netpol-default-deny is enabled)"
 	for _, cidr := range npc.podCIDRs[family] {
 		srcArgs := []string{"-s", cidr, "-m", "comment", "--comment", rejectComment, "-j", "REJECT"}
@@ -667,6 +767,47 @@ func (npc *NetworkPolicyController) populateDefaultTailChain(
 			klog.Fatalf("failed to add destination REJECT rule to %s due to %s",
 				kubeTailNetpolChain, err.Error())
 		}
+	}
+}
+
+// populateProtectedPodsIPSet refreshes the kube-router-local-pods ipset (per family) with the IPs of local pods
+// whose KUBE-POD-FW-* chains were programmed this sync, and is a no-op when --netpol-default-deny is disabled.
+// RestoreSets is atomic per set, so readers never see a partially-updated ipset.
+func (npc *NetworkPolicyController) populateProtectedPodsIPSet(activePodIPs map[v1core.IPFamily][]string) {
+	if !npc.defaultDeny {
+		return
+	}
+	if nil != npc.ipsetMutex {
+		klog.V(2).Infof("Attempting to attain ipset mutex lock for protected-pods refresh")
+		npc.ipsetMutex.Lock()
+		klog.V(2).Infof("Attained ipset mutex lock for protected-pods refresh, continuing...")
+		defer func() {
+			npc.ipsetMutex.Unlock()
+			klog.V(2).Infof("Returned ipset mutex lock for protected-pods refresh")
+		}()
+	}
+	for family, ipSetHandler := range npc.ipSetHandlers {
+		// Snapshot the kernel state so the handler's internal Sets() map matches reality before RestoreSets.
+		if err := ipSetHandler.Save(); err != nil {
+			klog.Errorf("failed to save ipsets before refreshing %s for family %s: %v",
+				kubeLocalPodsIPSetName, family, err)
+			continue
+		}
+
+		entries := make([][]string, 0, len(activePodIPs[family]))
+		for _, ip := range activePodIPs[family] {
+			entries = append(entries, []string{ip, utils.OptionTimeout, "0"})
+		}
+		ipSetHandler.RefreshSet(kubeLocalPodsIPSetName, entries, utils.TypeHashIP)
+
+		setNameForFamily := ipSetHandler.Name(kubeLocalPodsIPSetName)
+		if err := ipSetHandler.RestoreSets([]string{setNameForFamily}); err != nil {
+			klog.Errorf("failed to restore %s ipset for family %s: %v",
+				setNameForFamily, family, err)
+			continue
+		}
+		klog.V(2).Infof("refreshed %s ipset for family %s with %d entries",
+			setNameForFamily, family, len(entries))
 	}
 }
 
@@ -950,7 +1091,29 @@ func (npc *NetworkPolicyController) Cleanup() {
 		return
 	}
 
+	// cleanupStaleIPSets only handles KUBE-SRC-/KUBE-DST- per-policy sets; the singleton needs an explicit pass.
+	npc.destroyLocalPodsIPSet()
+
 	klog.Infof("Successfully cleaned the NetworkPolicyController configurations done by kube-router")
+}
+
+// destroyLocalPodsIPSet removes the kube-router-local-pods ipset per family if it exists; otherwise a no-op.
+func (npc *NetworkPolicyController) destroyLocalPodsIPSet() {
+	for family, ipSetHandler := range npc.ipSetHandlers {
+		if err := ipSetHandler.Save(); err != nil {
+			klog.Errorf("failed to save ipsets for %s cleanup on family %s: %v",
+				kubeLocalPodsIPSetName, family, err)
+			continue
+		}
+		setNameForFamily := ipSetHandler.Name(kubeLocalPodsIPSetName)
+		if _, ok := ipSetHandler.Sets()[setNameForFamily]; !ok {
+			continue
+		}
+		if err := ipSetHandler.Destroy(kubeLocalPodsIPSetName); err != nil {
+			klog.Errorf("failed to destroy %s ipset for family %s: %v",
+				setNameForFamily, family, err)
+		}
+	}
 }
 
 func NewIPTablesHandlers(config *options.KubeRouterConfig) (

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -666,10 +666,21 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 
 type fakeIPTables struct {
 	protocol iptables.Protocol
+	// appendedRules captures the rules appended to a chain in the order Append was called. Keyed by
+	// "<table>/<chain>". Empty unless set by the test (the default is to behave like a fully working iptables
+	// shim).
+	appendedRules map[string][][]string
+	// listOverride, if non-nil, is the response returned by List() keyed by "<table>/<chain>". When the chain
+	// is not in the map List returns its default (nil, nil) so existing tests that don't care about List
+	// behavior keep working.
+	listOverride map[string][]string
+	// chainExistsOverride mirrors listOverride for ChainExists. When the chain is not in the map ChainExists
+	// returns (true, nil) as before.
+	chainExistsOverride map[string]bool
 }
 
 func newFakeIPTables(protocol iptables.Protocol) *fakeIPTables {
-	return &fakeIPTables{protocol}
+	return &fakeIPTables{protocol: protocol, appendedRules: make(map[string][][]string)}
 }
 
 func (ipt *fakeIPTables) Proto() iptables.Protocol {
@@ -685,6 +696,11 @@ func (ipt *fakeIPTables) Insert(table, chain string, pos int, rulespec ...string
 }
 
 func (ipt *fakeIPTables) Append(table, chain string, rulespec ...string) error {
+	if ipt.appendedRules == nil {
+		ipt.appendedRules = make(map[string][][]string)
+	}
+	key := table + "/" + chain
+	ipt.appendedRules[key] = append(ipt.appendedRules[key], append([]string(nil), rulespec...))
 	return nil
 }
 
@@ -701,6 +717,12 @@ func (ipt *fakeIPTables) DeleteIfExists(table, chain string, rulespec ...string)
 }
 
 func (ipt *fakeIPTables) List(table, chain string) ([]string, error) {
+	if ipt.listOverride == nil {
+		return nil, nil
+	}
+	if rules, ok := ipt.listOverride[table+"/"+chain]; ok {
+		return rules, nil
+	}
 	return nil, nil
 }
 
@@ -713,6 +735,12 @@ func (ipt *fakeIPTables) ListChains(table string) ([]string, error) {
 }
 
 func (ipt *fakeIPTables) ChainExists(table, chain string) (bool, error) {
+	if ipt.chainExistsOverride == nil {
+		return true, nil
+	}
+	if exists, ok := ipt.chainExistsOverride[table+"/"+chain]; ok {
+		return exists, nil
+	}
 	return true, nil
 }
 
@@ -768,19 +796,77 @@ func (ipt *fakeIPTables) GetIptablesVersion() (int, int, int) {
 	return 1, 8, 0
 }
 
-type fakeIPSet struct{}
+// fakeIPSet is a minimal stand-in for utils.IPSetHandler. It tracks the operations the test cases need to assert
+// on (Create, RefreshSet, RestoreSets, Destroy) and otherwise no-ops every call. The "stored" sets are keyed by
+// set name to mirror the way the real ipset handler exposes Sets().
+type fakeIPSet struct {
+	stored          map[string]*utils.Set
+	createCalls     []string
+	destroyCalls    []string
+	refreshCalls    []fakeIPSetRefresh
+	restoreCalls    [][]string
+	saveErr         error
+	createErr       error
+	restoreErr      error
+	isIpv6          bool
+	destroyErrTimes int
+}
+
+type fakeIPSetRefresh struct {
+	name    string
+	setType string
+	entries [][]string
+}
+
+func newFakeIPSet() *fakeIPSet {
+	return &fakeIPSet{stored: make(map[string]*utils.Set)}
+}
 
 func (ips *fakeIPSet) Create(setName string, createOptions ...string) (*utils.Set, error) {
-	return nil, nil
+	if ips.stored == nil {
+		ips.stored = make(map[string]*utils.Set)
+	}
+	if ips.createErr != nil {
+		return nil, ips.createErr
+	}
+	resolved := ips.Name(setName)
+	ips.createCalls = append(ips.createCalls, resolved)
+	if existing, ok := ips.stored[resolved]; ok {
+		return existing, nil
+	}
+	s := &utils.Set{Name: resolved, Options: append([]string(nil), createOptions...)}
+	ips.stored[resolved] = s
+	return s, nil
 }
 
 func (ips *fakeIPSet) Add(set *utils.Set) error {
 	return nil
 }
 
-func (ips *fakeIPSet) RefreshSet(setName string, entriesWithOptions [][]string, setType string) {}
+func (ips *fakeIPSet) RefreshSet(setName string, entriesWithOptions [][]string, setType string) {
+	if ips.stored == nil {
+		ips.stored = make(map[string]*utils.Set)
+	}
+	resolved := ips.Name(setName)
+	ips.refreshCalls = append(ips.refreshCalls, fakeIPSetRefresh{
+		name:    resolved,
+		setType: setType,
+		entries: entriesWithOptions,
+	})
+	// Mirror the real handler: RefreshSet creates the set entry if it does not exist yet.
+	if _, ok := ips.stored[resolved]; !ok {
+		ips.stored[resolved] = &utils.Set{Name: resolved}
+	}
+}
 
 func (ips *fakeIPSet) Destroy(setName string) error {
+	resolved := ips.Name(setName)
+	ips.destroyCalls = append(ips.destroyCalls, resolved)
+	if ips.destroyErrTimes > 0 {
+		ips.destroyErrTimes--
+		return fmt.Errorf("destroy failed for %s", resolved)
+	}
+	delete(ips.stored, resolved)
 	return nil
 }
 
@@ -789,15 +875,16 @@ func (ips *fakeIPSet) DestroyAllWithin() error {
 }
 
 func (ips *fakeIPSet) Save() error {
-	return nil
+	return ips.saveErr
 }
 
 func (ips *fakeIPSet) Restore() error {
 	return nil
 }
 
-func (ips *fakeIPSet) RestoreSets(_ []string) error {
-	return nil
+func (ips *fakeIPSet) RestoreSets(setNames []string) error {
+	ips.restoreCalls = append(ips.restoreCalls, append([]string(nil), setNames...))
+	return ips.restoreErr
 }
 
 func (ips *fakeIPSet) Flush() error {
@@ -805,15 +892,302 @@ func (ips *fakeIPSet) Flush() error {
 }
 
 func (ips *fakeIPSet) Get(setName string) *utils.Set {
-	return nil
+	if ips.stored == nil {
+		return nil
+	}
+	return ips.stored[ips.Name(setName)]
 }
 
 func (ips *fakeIPSet) Sets() map[string]*utils.Set {
-	return nil
+	return ips.stored
 }
 
 func (ips *fakeIPSet) Name(name string) string {
+	if ips.isIpv6 && !strings.HasPrefix(name, utils.IPv6SetPrefix+":") {
+		return utils.IPv6SetPrefix + ":" + name
+	}
 	return name
+}
+
+// newTailChainTestController returns a minimally-wired NetworkPolicyController suitable for exercising
+// populateDefaultTailChain / populateProtectedPodsIPSet / ensureDefaultTailChainExists. The handlers are fake so
+// the test can inspect the rules and ipset operations that were performed.
+func newTailChainTestController(defaultDeny bool, podCIDRs map[v1.IPFamily][]string) (*NetworkPolicyController,
+	map[v1.IPFamily]*fakeIPTables, map[v1.IPFamily]*fakeIPSet) {
+	npc := &NetworkPolicyController{defaultDeny: defaultDeny, podCIDRs: podCIDRs}
+	npc.iptablesCmdHandlers = make(map[v1.IPFamily]utils.IPTablesHandler)
+	npc.ipSetHandlers = make(map[v1.IPFamily]utils.IPSetHandler)
+
+	iptHandlers := make(map[v1.IPFamily]*fakeIPTables)
+	ipsHandlers := make(map[v1.IPFamily]*fakeIPSet)
+
+	for family := range podCIDRs {
+		fakeIPT := newFakeIPTables(iptables.ProtocolIPv4)
+		if family == v1.IPv6Protocol {
+			fakeIPT = newFakeIPTables(iptables.ProtocolIPv6)
+		}
+		npc.iptablesCmdHandlers[family] = fakeIPT
+		iptHandlers[family] = fakeIPT
+
+		fakeIPS := newFakeIPSet()
+		if family == v1.IPv6Protocol {
+			fakeIPS.isIpv6 = true
+		}
+		npc.ipSetHandlers[family] = fakeIPS
+		ipsHandlers[family] = fakeIPS
+	}
+
+	return npc, iptHandlers, ipsHandlers
+}
+
+// TestPopulateDefaultTailChainDefaultDenyEnabled verifies that when --netpol-default-deny is enabled,
+// populateDefaultTailChain emits the documented 5-rule layout per CIDR: two ipset-gated REJECTs first, then the
+// ACCEPT-on-mark, then the two CIDR-scoped REJECTs as defense-in-depth.
+func TestPopulateDefaultTailChainDefaultDenyEnabled(t *testing.T) {
+	cidr := "10.244.0.0/24"
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv4Protocol: {cidr}}
+	npc, iptHandlers, _ := newTailChainTestController(true, podCIDRs)
+
+	npc.populateDefaultTailChain(v1.IPv4Protocol, npc.iptablesCmdHandlers[v1.IPv4Protocol])
+
+	rules := iptHandlers[v1.IPv4Protocol].appendedRules["filter/"+kubeTailNetpolChain]
+	if got, want := len(rules), 5; got != want {
+		t.Fatalf("expected %d rules appended for 1 CIDR with defaultDeny=true, got %d: %v", want, got, rules)
+	}
+
+	// Rule 1: ipset-gated source REJECT
+	assertRuleMatches(t, "ipset-gated src REJECT", rules[0], []string{
+		"-s", cidr, "-m", "set", "!", "--match-set", kubeLocalPodsIPSetName, "src", "-j", "REJECT",
+	})
+
+	// Rule 2: ipset-gated destination REJECT
+	assertRuleMatches(t, "ipset-gated dst REJECT", rules[1], []string{
+		"-d", cidr, "-m", "set", "!", "--match-set", kubeLocalPodsIPSetName, "dst", "-j", "REJECT",
+	})
+
+	// Rule 3: ACCEPT-on-mark
+	assertRuleMatches(t, "ACCEPT-on-mark", rules[2], []string{
+		"-m", "mark", "--mark", "0x20000/0x20000", "-j", "ACCEPT",
+	})
+
+	// Rule 4: CIDR source REJECT
+	assertRuleMatches(t, "CIDR src REJECT", rules[3], []string{
+		"-s", cidr, "-j", "REJECT",
+	})
+
+	// Rule 5: CIDR destination REJECT
+	assertRuleMatches(t, "CIDR dst REJECT", rules[4], []string{
+		"-d", cidr, "-j", "REJECT",
+	})
+}
+
+// TestPopulateDefaultTailChainMultipleCIDRs verifies that the per-CIDR rule layout is repeated for every CIDR in
+// the family so a dual-CIDR node ends up with 1 + 4*N rules.
+func TestPopulateDefaultTailChainMultipleCIDRs(t *testing.T) {
+	cidrs := []string{"10.244.0.0/24", "10.245.0.0/24"}
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv4Protocol: cidrs}
+	npc, iptHandlers, _ := newTailChainTestController(true, podCIDRs)
+
+	npc.populateDefaultTailChain(v1.IPv4Protocol, npc.iptablesCmdHandlers[v1.IPv4Protocol])
+
+	rules := iptHandlers[v1.IPv4Protocol].appendedRules["filter/"+kubeTailNetpolChain]
+	// 2 ipset-gated REJECTs per CIDR + 1 ACCEPT + 2 CIDR REJECTs per CIDR == 1 + 4*N.
+	if got, want := len(rules), 1+4*len(cidrs); got != want {
+		t.Fatalf("expected %d rules for %d CIDRs with defaultDeny=true, got %d", want, len(cidrs), got)
+	}
+}
+
+// TestPopulateDefaultTailChainDefaultDenyDisabled verifies that when --netpol-default-deny is disabled, the chain
+// receives only the original ACCEPT-on-mark rule, regardless of how many pod CIDRs the node has.
+func TestPopulateDefaultTailChainDefaultDenyDisabled(t *testing.T) {
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv4Protocol: {"10.244.0.0/24", "10.245.0.0/24"}}
+	npc, iptHandlers, _ := newTailChainTestController(false, podCIDRs)
+
+	npc.populateDefaultTailChain(v1.IPv4Protocol, npc.iptablesCmdHandlers[v1.IPv4Protocol])
+
+	rules := iptHandlers[v1.IPv4Protocol].appendedRules["filter/"+kubeTailNetpolChain]
+	if got, want := len(rules), 1; got != want {
+		t.Fatalf("expected exactly 1 rule when defaultDeny=false, got %d: %v", got, rules)
+	}
+	assertRuleMatches(t, "ACCEPT-on-mark", rules[0], []string{
+		"-m", "mark", "--mark", "0x20000/0x20000", "-j", "ACCEPT",
+	})
+}
+
+// TestPopulateProtectedPodsIPSetDefaultDenyEnabled verifies that the refresh/restore happens for every family with a
+// known pod IP. We pass two IPs for IPv4 and confirm the refresh entries and the ipset name passed to
+// RestoreSets.
+func TestPopulateProtectedPodsIPSetDefaultDenyEnabled(t *testing.T) {
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv4Protocol: {"10.244.0.0/24"}}
+	npc, _, ipsHandlers := newTailChainTestController(true, podCIDRs)
+
+	activeIPs := map[v1.IPFamily][]string{v1.IPv4Protocol: {"10.244.0.7", "10.244.0.8"}}
+	npc.populateProtectedPodsIPSet(activeIPs)
+
+	ips := ipsHandlers[v1.IPv4Protocol]
+	if got, want := len(ips.refreshCalls), 1; got != want {
+		t.Fatalf("expected exactly 1 RefreshSet call, got %d", got)
+	}
+	call := ips.refreshCalls[0]
+	if call.name != kubeLocalPodsIPSetName {
+		t.Errorf("expected refresh of %q, got %q", kubeLocalPodsIPSetName, call.name)
+	}
+	if call.setType != utils.TypeHashIP {
+		t.Errorf("expected setType %q, got %q", utils.TypeHashIP, call.setType)
+	}
+	if got, want := len(call.entries), 2; got != want {
+		t.Errorf("expected %d entries in refresh, got %d: %v", want, got, call.entries)
+	}
+	for i, ip := range []string{"10.244.0.7", "10.244.0.8"} {
+		if call.entries[i][0] != ip {
+			t.Errorf("entry[%d] = %v, want first element %q", i, call.entries[i], ip)
+		}
+	}
+	if got, want := len(ips.restoreCalls), 1; got != want {
+		t.Fatalf("expected exactly 1 RestoreSets call, got %d", got)
+	}
+	if ips.restoreCalls[0][0] != kubeLocalPodsIPSetName {
+		t.Errorf("expected RestoreSets called with %q, got %v",
+			kubeLocalPodsIPSetName, ips.restoreCalls[0])
+	}
+}
+
+// TestPopulateProtectedPodsIPSetDefaultDenyDisabled verifies that the function is a no-op when --netpol-default-deny
+// is disabled: no refresh, no restore, the ipset stays untouched.
+func TestPopulateProtectedPodsIPSetDefaultDenyDisabled(t *testing.T) {
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv4Protocol: {"10.244.0.0/24"}}
+	npc, _, ipsHandlers := newTailChainTestController(false, podCIDRs)
+
+	npc.populateProtectedPodsIPSet(map[v1.IPFamily][]string{v1.IPv4Protocol: {"10.244.0.7"}})
+
+	ips := ipsHandlers[v1.IPv4Protocol]
+	if len(ips.refreshCalls) != 0 {
+		t.Errorf("RefreshSet should not be called when defaultDeny is disabled, got %v", ips.refreshCalls)
+	}
+	if len(ips.restoreCalls) != 0 {
+		t.Errorf("RestoreSets should not be called when defaultDeny is disabled, got %v", ips.restoreCalls)
+	}
+}
+
+// TestPopulateProtectedPodsIPSetIPv6 verifies that the IPv6 handler is fed the inet6-prefixed set name when
+// RestoreSets is invoked. This guards the per-family name resolution path through IPSetHandler.Name().
+func TestPopulateProtectedPodsIPSetIPv6(t *testing.T) {
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv6Protocol: {"2001:db8::/64"}}
+	npc, _, ipsHandlers := newTailChainTestController(true, podCIDRs)
+
+	npc.populateProtectedPodsIPSet(map[v1.IPFamily][]string{v1.IPv6Protocol: {"2001:db8::7"}})
+
+	ips := ipsHandlers[v1.IPv6Protocol]
+	if len(ips.restoreCalls) != 1 {
+		t.Fatalf("expected exactly 1 RestoreSets call, got %d", len(ips.restoreCalls))
+	}
+	want := utils.IPv6SetPrefix + ":" + kubeLocalPodsIPSetName
+	if ips.restoreCalls[0][0] != want {
+		t.Errorf("expected IPv6-prefixed RestoreSets target %q, got %v", want, ips.restoreCalls[0])
+	}
+}
+
+// TestEnsureLocalPodsIPSetExistsCreatesWhenMissing covers the two callers of ensureLocalPodsIPSetExists that matter at
+// runtime: the startup path (Run() -> ensureDefaultTailChain) and the per-sync drift recovery path
+// (fullPolicySync -> ensureDefaultTailChainExists). In both cases the stored map starts empty so the function
+// must call Create(); the real handler's Create uses `create -exist` internally so the call is also safe when
+// the kernel already has the set.
+func TestEnsureLocalPodsIPSetExistsCreatesWhenMissing(t *testing.T) {
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv4Protocol: {"10.244.0.0/24"}}
+	npc, _, ipsHandlers := newTailChainTestController(true, podCIDRs)
+
+	npc.ensureLocalPodsIPSetExists()
+
+	calls := ipsHandlers[v1.IPv4Protocol].createCalls
+	if len(calls) != 1 || calls[0] != kubeLocalPodsIPSetName {
+		t.Errorf("expected single Create(%q), got %v", kubeLocalPodsIPSetName, calls)
+	}
+}
+
+// TestEnsureLocalPodsIPSetExistsLeavesExisting verifies that an already-present ipset is not recreated by
+// ensureLocalPodsIPSetExists. The fake records every Create call so we can spot unnecessary work; the real handler's
+// Create is idempotent but still issues an `ipset` invocation, which we'd rather avoid every sync.
+func TestEnsureLocalPodsIPSetExistsLeavesExisting(t *testing.T) {
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv4Protocol: {"10.244.0.0/24"}}
+	npc, _, ipsHandlers := newTailChainTestController(true, podCIDRs)
+	ipsHandlers[v1.IPv4Protocol].stored[kubeLocalPodsIPSetName] = &utils.Set{Name: kubeLocalPodsIPSetName}
+
+	npc.ensureLocalPodsIPSetExists()
+
+	if calls := ipsHandlers[v1.IPv4Protocol].createCalls; len(calls) != 0 {
+		t.Errorf("expected no Create calls when ipset already exists, got %v", calls)
+	}
+}
+
+// TestEnsureLocalPodsIPSetExistsNoOpWhenDisabled guards the disabled path: with --netpol-default-deny off
+// ensureLocalPodsIPSetExists must never touch the ipset handler at all.
+func TestEnsureLocalPodsIPSetExistsNoOpWhenDisabled(t *testing.T) {
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv4Protocol: {"10.244.0.0/24"}}
+	npc, _, ipsHandlers := newTailChainTestController(false, podCIDRs)
+
+	npc.ensureLocalPodsIPSetExists()
+
+	if calls := ipsHandlers[v1.IPv4Protocol].createCalls; len(calls) != 0 {
+		t.Errorf("expected no Create calls when defaultDeny=false, got %v", calls)
+	}
+	if calls := ipsHandlers[v1.IPv4Protocol].destroyCalls; len(calls) != 0 {
+		t.Errorf("expected no Destroy calls when defaultDeny=false, got %v", calls)
+	}
+}
+
+// TestDestroyLocalPodsIPSetSkipsMissing verifies that Cleanup() does not call Destroy on a set that does not
+// exist on the system. The real handler exposes Sets() from its in-memory map; the fake mirrors that, and a
+// nil/empty stored map means the lookup misses.
+func TestDestroyLocalPodsIPSetSkipsMissing(t *testing.T) {
+	podCIDRs := map[v1.IPFamily][]string{v1.IPv4Protocol: {"10.244.0.0/24"}}
+	npc, _, ipsHandlers := newTailChainTestController(true, podCIDRs)
+
+	npc.destroyLocalPodsIPSet()
+
+	if calls := ipsHandlers[v1.IPv4Protocol].destroyCalls; len(calls) != 0 {
+		t.Errorf("expected no Destroy calls when ipset is missing, got %v", calls)
+	}
+}
+
+// TestDestroyLocalPodsIPSetDestroysPresent verifies that Cleanup() destroys an existing set. With dual-stack
+// enabled we also check that the IPv6 set name is properly prefixed for the IPv6 family handler.
+func TestDestroyLocalPodsIPSetDestroysPresent(t *testing.T) {
+	podCIDRs := map[v1.IPFamily][]string{
+		v1.IPv4Protocol: {"10.244.0.0/24"},
+		v1.IPv6Protocol: {"2001:db8::/64"},
+	}
+	npc, _, ipsHandlers := newTailChainTestController(true, podCIDRs)
+	ipsHandlers[v1.IPv4Protocol].stored[kubeLocalPodsIPSetName] = &utils.Set{Name: kubeLocalPodsIPSetName}
+	ipv6Name := utils.IPv6SetPrefix + ":" + kubeLocalPodsIPSetName
+	ipsHandlers[v1.IPv6Protocol].stored[ipv6Name] = &utils.Set{Name: ipv6Name}
+
+	npc.destroyLocalPodsIPSet()
+
+	if calls := ipsHandlers[v1.IPv4Protocol].destroyCalls; len(calls) != 1 || calls[0] != kubeLocalPodsIPSetName {
+		t.Errorf("expected IPv4 Destroy(%q), got %v", kubeLocalPodsIPSetName, calls)
+	}
+	if calls := ipsHandlers[v1.IPv6Protocol].destroyCalls; len(calls) != 1 || calls[0] != ipv6Name {
+		t.Errorf("expected IPv6 Destroy(%q), got %v", ipv6Name, calls)
+	}
+}
+
+// assertRuleMatches ensures every fragment of `expected` appears in `actual` (an iptables rulespec); it does not
+// compare exact slices because populateDefaultTailChain interleaves -m comment / --comment args we don't want
+// every test to rebuild verbatim.
+func assertRuleMatches(t *testing.T, label string, actual, expected []string) {
+	t.Helper()
+	for _, want := range expected {
+		found := false
+		for _, got := range actual {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s: expected fragment %q in rule, got: %v", label, want, actual)
+		}
+	}
 }
 
 func TestNetworkPolicyController(t *testing.T) {

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -88,10 +88,14 @@ func (npc *NetworkPolicyController) handlePodDelete(obj interface{}) {
 	npc.RequestFullSync()
 }
 
+// syncPodFirewallChains emits per-pod KUBE-POD-FW-* chains and the rules that jump into them for every local
+// pod. Returns the active pod-firewall chain names (for stale-rule cleanup) and a per-family map of pod IPs
+// whose chain was programmed this sync (consumed by populateProtectedPodsIPSet).
 func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []networkPolicyInfo,
-	version string) map[string]bool {
+	version string) (map[string]bool, map[api.IPFamily][]string) {
 
 	activePodFwChains := make(map[string]bool)
+	activePodIPs := make(map[api.IPFamily][]string)
 
 	dropUnmarkedTrafficRules := func(pod podInfo, podFwChainName string) {
 		for ipFamily, filterTableRules := range npc.filterTableRules {
@@ -139,7 +143,7 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 		// ensure pod specific firewall chain exist for all the pods that need ingress firewall
 		podFwChainName := podFirewallChainName(pod.namespace, pod.name, version)
 		for ipFamily, filterTableRules := range npc.filterTableRules {
-			_, err := getPodIPForFamily(pod, ipFamily)
+			ip, err := getPodIPForFamily(pod, ipFamily)
 			if err != nil {
 				// If the pod doesn't have an address in this family we skip it here and all the various places below
 				// because there won't be a valid source or destination address for iptables, and it will stop iptables
@@ -150,6 +154,8 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 			}
 
 			filterTableRules.WriteString(":" + podFwChainName + "\n")
+			// Record for populateProtectedPodsIPSet: only IPs whose chain we just programmed are "protected".
+			activePodIPs[ipFamily] = append(activePodIPs[ipFamily], ip)
 		}
 
 		activePodFwChains[podFwChainName] = true
@@ -182,7 +188,7 @@ func (npc *NetworkPolicyController) syncPodFirewallChains(networkPoliciesInfo []
 		}
 	}
 
-	return activePodFwChains
+	return activePodFwChains, activePodIPs
 }
 
 // setup rules to jump to applicable network policy chains for the traffic from/to the pod

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -590,7 +590,7 @@ func (nsc *NetworkServicesController) cleanupIpvsFirewall() {
 	// There are certain actions like Cleanup() actions that aren't working with full instantiations of the controller
 	// and in these instances the mutex may not be present and may not need to be present as they are operating out of a
 	// single goroutine where there is no need for locking
-	if nil != nsc.ipsetMutex {
+	if nsc.ipsetMutex != nil {
 		klog.V(1).Infof("Attempting to attain ipset mutex lock")
 		nsc.ipsetMutex.Lock()
 		klog.V(1).Infof("Attained ipset mutex lock, continuing...")

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -807,7 +807,7 @@ func (nrc *NetworkRoutingController) Cleanup() {
 	// There are certain actions like Cleanup() actions that aren't working with full instantiations of the controller
 	// and in these instances the mutex may not be present and may not need to be present as they are operating out of a
 	// single goroutine where there is no need for locking
-	if nil != nrc.ipsetMutex {
+	if nrc.ipsetMutex != nil {
 		klog.V(1).Infof("Attempting to attain ipset mutex lock")
 		nrc.ipsetMutex.Lock()
 		klog.V(1).Infof("Attained ipset mutex lock, continuing...")

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -66,6 +66,7 @@ type KubeRouterConfig struct {
 	MetricsPath                    string
 	MetricsPort                    uint16
 	MetricsAddr                    string
+	NetPolDefaultDeny              bool
 	NodePortBindOnAllIP            bool
 	NodePortRange                  string
 	OverlayType                    string
@@ -214,6 +215,8 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.Uint16Var(&s.MetricsPort, "metrics-port", 0, "Prometheus metrics port, (Default 0, Disabled)")
 	fs.StringVar(&s.MetricsAddr, "metrics-addr", "", "Prometheus metrics address to listen on, (Default: all "+
 		"interfaces)")
+	fs.BoolVar(&s.NetPolDefaultDeny, "netpol-default-deny", false,
+		"Default policy to use for pods to have before NetworkPolicy is applied")
 	fs.BoolVar(&s.NodePortBindOnAllIP, "nodeport-bindon-all-ip", false,
 		"For service of NodePort type create IPVS service that listens on all IP's of the node.")
 	fs.BoolVar(&s.FullMeshMode, "nodes-full-mesh", true,

--- a/pkg/routes/route_sync.go
+++ b/pkg/routes/route_sync.go
@@ -102,7 +102,7 @@ func (rs *RouteSync) Run(healthChan chan<- *healthcheck.ControllerHeartbeat, sto
 					klog.Errorf("route could not be replaced due to: %v", err)
 				}
 				// Some of our unit tests send a nil health channel
-				if nil != healthChan && err == nil {
+				if healthChan != nil && err == nil {
 					healthcheck.SendHeartBeat(healthChan, healthcheck.RouteSyncController)
 				}
 			case <-stopCh:


### PR DESCRIPTION
#### What type of PR is this?

feature

#### What this PR does / why we need it:

Closes the race window where a new pod is routable on the node before its `KUBE-POD-FW-*` chain has been programmed, by introducing `--netpol-default-deny` command line option. The initial commit on this branch added CIDR-scoped REJECTs at the tail of `KUBE-NWPLCY-TAIL`, but those failed for pod-to-pod traffic on the same node because every per-pod chain marks accepted packets with `0x20000`, and the `KUBE-NWPLCY-TAIL` ACCEPT-on-mark rule fired before the CIDR REJECTs could.

This PR finishes the feature by introducing a per-IP-family `kube-router-local-pods` ipset of pod IPs whose firewall chain has been programmed this sync. Two new ipset-gated REJECT rules are prepended to `KUBE-NWPLCY-TAIL` ahead of the ACCEPT-on-mark; they fire for any local pod IP not yet in the set. The existing CIDR-scoped REJECTs stay at the tail as defense-in-depth.

When `--netpol-default-deny` is disabled the ipset is never created and the rule layout is unchanged from today. The feature self-disables (with an error log) when this node's pod CIDRs cannot be detected via `node.spec.podCIDRs` or the `kube-router.io/pod-cidrs` annotation.

The user-guide gets a brief section on the feature; the troubleshooting guide gets a symptom-first entry ("NetworkPolicy not enforced on freshly-launched pods") with the operational details.

#### Which issue(s) this PR is related to:

Further protects against findings discussed in #873 

#### Was AI used during the creation of this PR?

* What tool was used: Claude (opencode)
* To what extent was the tool used? Drafted the implementation, tests, and docs on the second commit (`feat(npc): enable default deny for pod<->pod`) and the third commit  (`doc: how --netpol-default-deny works`) from a detailed plan. The first commit on the branch was hand-written.
* If drafted, how detailed of a plan did you create for the AI? Very detailed
* Help us understand if a human was in the loop or not for this PR? Yes — every change was  reviewed and the AI was redirected several times (troubleshooting framing, helper  consolidation, function renames, docstring brevity).

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?

Unit tests cover the new rule layout, ipset refresh, drift recovery, IPv6 prefix handling, and cleanup. Manual cluster validation (deploying the `netpol-race-tester` DaemonSet from `kube-router-automation`, verifying `iptables -L KUBE-NWPLCY-TAIL` and `ipset list kube-router-local-pods`, toggling the flag off and confirming the ipset and extra rules are gone) is the remaining checklist item before merge.

I also tested against a local Kubernetes cluster with a custom pod workload that attempted to make early connections both to cluster internal and cluster external endpoints. I toggled default-deny on and off and watched the workloads.

#### Does this PR introduce a breaking change?

```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

* The feature is gated behind `--netpol-default-deny` (off by default), so this is purely  additive for existing deployments.
* This features **ONLY** works when kube-router is aware of the pod CIDRs on a per-node basis. This happens by default when kube-router is operating the pod routing, and it can also happen with other cluster networking plugins that use `--allocate-node-cidrs=true` from kube-controller-manager. It can also be used by other more custom configurations as long as the user annotates the node with the kube-router `kube-router.io/pod-cidrs` annotation. If neither or these are configured, kube-router cannot safely gate traffic and will warn and continue.
* The per-sync ipset refresh runs **before** `ensureTailChainPosition` installs the TAIL jump in the iptables-restore buffer, so the new rules cannot fire against a stale ipset during a fresh kube-router start.