### PR TITLE
fix(bgp): also reject defaultRouteSetV6 from peers

### DIFF
--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -870,12 +870,12 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 			statementNames = append(statementNames, statement.Name)
 		}
 
-		for _, defaultset := range []string{defaultRouteSet, defaultRouteSetV6} {
+		for _, defaultSet := range []string{defaultRouteSet, defaultRouteSetV6} {
 			statement := gobgpapi.Statement{
 				Conditions: &gobgpapi.Conditions{
 					PrefixSet: &gobgpapi.MatchSet{
 						Type: gobgpapi.MatchSet_TYPE_ANY,
-						Name: defaultset,
+						Name: defaultSet,
 					},
 					NeighborSet: &gobgpapi.MatchSet{
 						Type: gobgpapi.MatchSet_TYPE_ANY,
@@ -883,7 +883,7 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 					},
 				},
 				Actions: &actions,
-				Name:    defaultset + peerSet,
+				Name:    defaultSet + peerSet,
 			}
 			if err = nrc.ensureStatementExists(&statement); err != nil {
 				return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)

--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -870,27 +870,29 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 			statementNames = append(statementNames, statement.Name)
 		}
 
-		statement := gobgpapi.Statement{
-			Conditions: &gobgpapi.Conditions{
-				PrefixSet: &gobgpapi.MatchSet{
-					Type: gobgpapi.MatchSet_TYPE_ANY,
-					Name: defaultRouteSet,
+		for _, defaultset := range []string{defaultRouteSet, defaultRouteSetV6} {
+			statement := gobgpapi.Statement{
+				Conditions: &gobgpapi.Conditions{
+					PrefixSet: &gobgpapi.MatchSet{
+						Type: gobgpapi.MatchSet_TYPE_ANY,
+						Name: defaultset,
+					},
+					NeighborSet: &gobgpapi.MatchSet{
+						Type: gobgpapi.MatchSet_TYPE_ANY,
+						Name: peerSet,
+					},
 				},
-				NeighborSet: &gobgpapi.MatchSet{
-					Type: gobgpapi.MatchSet_TYPE_ANY,
-					Name: peerSet,
-				},
-			},
-			Actions: &actions,
-			Name:    defaultRouteSet + peerSet,
+				Actions: &actions,
+				Name:    defaultset + peerSet,
+			}
+			if err = nrc.ensureStatementExists(&statement); err != nil {
+				return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
+			}
+			statementNames = append(statementNames, statement.Name)
 		}
-		if err = nrc.ensureStatementExists(&statement); err != nil {
-			return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
-		}
-		statementNames = append(statementNames, statement.Name)
 
 		if len(nrc.nodeCustomImportRejectIPNets) > 0 {
-			statement = gobgpapi.Statement{
+			statement := gobgpapi.Statement{
 				Conditions: &gobgpapi.Conditions{
 					PrefixSet: &gobgpapi.MatchSet{
 						Name: customImportRejectSet,


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Rejects IPv6 defaultroute advertisements from external peers.

#### Which issue(s) this PR is related to:

Fixes #2091

#### Was AI used during the creation of this PR?

No

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?

None

#### Does this PR introduce a breaking change?

```release-note
NONE
```
