### PR TITLE
Add better bgp policy unit testing

### DIFF
--- a/pkg/controllers/routing/bgp_policies.go
+++ b/pkg/controllers/routing/bgp_policies.go
@@ -32,9 +32,11 @@ const (
 	iBGPPeerSet       = "iBGPpeerset"
 	iBGPPeerSetV6     = "iBGPpeersetv6"
 
-	customImportRejectSet = "customimportrejectdefinedset"
-	defaultRouteSet       = "defaultroutedefinedset"
-	defaultRouteSetV6     = "defaultroutedefinedsetv6"
+	customImportRejectSet   = "customimportrejectdefinedset"
+	customImportRejectSetV6 = "customimportrejectdefinedsetv6"
+
+	defaultRouteSet   = "defaultroutedefinedset"
+	defaultRouteSetV6 = "defaultroutedefinedsetv6"
 
 	kubeRouterExportPolicy = "kube_router_export"
 	kubeRouterImportPolicy = "kube_router_import"
@@ -310,37 +312,52 @@ func (nrc *NetworkRoutingController) addDefaultRouteDefinedSet() error {
 	return nil
 }
 
-// create a defined set to represent custom annotated routes to be rejected on import
+// create defined sets to represent custom annotated routes to be rejected on import. The annotation
+// (kube-router.io/node.bgp.customimportreject) may contain a mix of IPv4 and IPv6 CIDRs; we split
+// them by family into two defined sets (customImportRejectSet for V4, customImportRejectSetV6 for
+// V6) because a GoBGP defined set cannot mix prefix families ("multiple families" error) and
+// because each family needs the correct MaskLengthMax (32 vs 128) for longest-match behavior.
 func (nrc *NetworkRoutingController) addCustomImportRejectDefinedSet() error {
-	var currentDefinedSet *gobgpapi.DefinedSet
-	currentDefinedSet, err := nrc.getDefinedSetFromGoBGP(customImportRejectSet, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX)
-	if err != nil {
-		return err
-	}
+	for setName, maxMask := range map[string]uint32{
+		customImportRejectSet:   maxIPv4MaskSize,
+		customImportRejectSetV6: maxIPv6MaskSize,
+	} {
+		currentDefinedSet, err := nrc.getDefinedSetFromGoBGP(setName, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX)
+		if err != nil {
+			return err
+		}
+		if currentDefinedSet != nil {
+			continue
+		}
 
-	if currentDefinedSet == nil {
 		prefixes := make([]*gobgpapi.Prefix, 0)
 		for _, ipNet := range nrc.nodeCustomImportRejectIPNets {
-			prefix := new(gobgpapi.Prefix)
-			prefix.IpPrefix = ipNet.String()
+			// Filter prefixes by address family so each defined set only contains entries that
+			// match its family.
+			isV4 := ipNet.IP.To4() != nil
+			if (setName == customImportRejectSet) != isV4 {
+				continue
+			}
 			mask, _ := ipNet.Mask.Size()
-
 			uIntMask, err := safecast.Convert[uint32](mask)
 			if err != nil {
 				return fmt.Errorf("failed to convert mask to uint32: %w", err)
 			}
-
-			prefix.MaskLengthMin = uIntMask
-			prefix.MaskLengthMax = uint32(ipv4MaskMinBits)
-			prefixes = append(prefixes, prefix)
+			prefixes = append(prefixes, &gobgpapi.Prefix{
+				IpPrefix:      ipNet.String(),
+				MaskLengthMin: uIntMask,
+				MaskLengthMax: maxMask,
+			})
 		}
 		customImportRejectDefinedSet := &gobgpapi.DefinedSet{
 			DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
-			Name:        customImportRejectSet,
+			Name:        setName,
 			Prefixes:    prefixes,
 		}
-		return nrc.bgpServer.AddDefinedSet(context.Background(),
-			&gobgpapi.AddDefinedSetRequest{DefinedSet: customImportRejectDefinedSet})
+		if err := nrc.bgpServer.AddDefinedSet(context.Background(),
+			&gobgpapi.AddDefinedSetRequest{DefinedSet: customImportRejectDefinedSet}); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -892,24 +909,37 @@ func (nrc *NetworkRoutingController) addImportPolicies() error {
 		}
 
 		if len(nrc.nodeCustomImportRejectIPNets) > 0 {
-			statement := gobgpapi.Statement{
-				Conditions: &gobgpapi.Conditions{
-					PrefixSet: &gobgpapi.MatchSet{
-						Name: customImportRejectSet,
-						Type: gobgpapi.MatchSet_TYPE_ANY,
+			for _, customRejectSet := range []string{customImportRejectSet, customImportRejectSetV6} {
+				// Referencing an empty defined set with MatchSet_TYPE_ANY would match all routes
+				// (see emptyCheckDefinedSets docstring), so skip families that have no entries.
+				customRejectSetEmpty, err := nrc.emptyCheckDefinedSets([]gobgpapi.ListDefinedSetRequest{
+					{DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, Name: customRejectSet},
+				})
+				if err != nil {
+					return err
+				}
+				if customRejectSetEmpty {
+					continue
+				}
+				statement := gobgpapi.Statement{
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Name: customRejectSet,
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: peerSet,
+						},
 					},
-					NeighborSet: &gobgpapi.MatchSet{
-						Type: gobgpapi.MatchSet_TYPE_ANY,
-						Name: peerSet,
-					},
-				},
-				Actions: &actions,
-				Name:    customImportRejectSet + peerSet,
+					Actions: &actions,
+					Name:    customRejectSet + peerSet,
+				}
+				if err = nrc.ensureStatementExists(&statement); err != nil {
+					return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
+				}
+				statementNames = append(statementNames, statement.Name)
 			}
-			if err = nrc.ensureStatementExists(&statement); err != nil {
-				return fmt.Errorf("could not check or create statement: %s - %w", statement.Name, err)
-			}
-			statementNames = append(statementNames, statement.Name)
 		}
 	}
 

--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -658,6 +658,396 @@ func Test_AddPolicies(t *testing.T) {
 			nil,
 		},
 		{
+			"has dual-stack nodes and services with external peers",
+			&NetworkRoutingController{
+				clientset:         fake.NewSimpleClientset(),
+				hostnameOverride:  "node-1",
+				routerID:          "10.3.0.1",
+				localAddressList:  []string{"0.0.0.0", "::"},
+				bgpPort:           10000,
+				bgpFullMeshMode:   false,
+				bgpEnableInternal: true,
+				bgpServer:         gobgp.NewBgpServer(),
+				activeNodes:       make(map[string]bool),
+				podCidr:           "172.23.0.0/24",
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP("10.3.0.2"),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("10.3.0.2")}},
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("2001:db8:42:3::2")}},
+					},
+				},
+				podIPv4CIDRs: []string{"172.23.0.0/24"},
+				podIPv6CIDRs: []string{"2001:db8:42:23::/64"},
+				globalPeerRouters: []*gobgpapi.Peer{
+					{
+						Conf: &gobgpapi.PeerConf{
+							NeighborAddress: "10.13.0.1",
+						},
+						Transport: &gobgpapi.Transport{
+							LocalAddress: "10.3.0.2",
+						},
+					},
+					{
+						Conf: &gobgpapi.PeerConf{
+							NeighborAddress: "2001:db8:42:13::1",
+						},
+						Transport: &gobgpapi.Transport{
+							LocalAddress: "2001:db8:42:3::2",
+						},
+					},
+				},
+				nodeAsnNumber: 100,
+			},
+			[]*v1core.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Annotations: map[string]string{
+							"kube-router.io/node.asn": "100",
+						},
+					},
+					Status: v1core.NodeStatus{
+						Addresses: []v1core.NodeAddress{
+							{
+								Type:    v1core.NodeInternalIP,
+								Address: "10.3.0.2",
+							},
+							{
+								Type:    v1core.NodeInternalIP,
+								Address: "2001:db8:42:3::2",
+							},
+						},
+					},
+					Spec: v1core.NodeSpec{
+						PodCIDR: "172.23.0.0/24",
+						PodCIDRs: []string{
+							"172.23.0.0/24",
+							"2001:db8:42:23::/64",
+						},
+					},
+				},
+			},
+			[]*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+					},
+					Spec: v1core.ServiceSpec{
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.13.0.5",
+						ClusterIPs:            []string{"10.13.0.5", "2001:db8:42:13::5"},
+						ExternalIPs:           []string{"1.13.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+						Labels: map[string]string{
+							"kubernetes.io/service-name": "svc-1",
+						},
+					},
+					Endpoints: []discoveryv1.Endpoint{
+						{
+							Addresses: []string{testNodeIPv4},
+						},
+					},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{
+						IpPrefix:      "172.23.0.0/24",
+						MaskLengthMin: 24,
+						MaskLengthMax: 24,
+					},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{
+						IpPrefix:      "1.13.1.1/32",
+						MaskLengthMin: 32,
+						MaskLengthMax: 32,
+					},
+					{
+						IpPrefix:      "10.13.0.5/32",
+						MaskLengthMin: 32,
+						MaskLengthMax: 32,
+					},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSet,
+				List:        []string{"10.13.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSet,
+				List:        []string{"10.13.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_export_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: iBGPPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: iBGPPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt4",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt5",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt4",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt5",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt6",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt7",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+			},
+			nil,
+		},
+		{
 			"has nodes, services with external peers and iBGP disabled",
 			&NetworkRoutingController{
 				clientset:         fake.NewSimpleClientset(),
@@ -852,6 +1242,322 @@ func Test_AddPolicies(t *testing.T) {
 						NeighborSet: &gobgpapi.MatchSet{
 							Type: gobgpapi.MatchSet_TYPE_ANY,
 							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"has dual-stack nodes, services with external peers and iBGP disabled",
+			&NetworkRoutingController{
+				clientset:         fake.NewSimpleClientset(),
+				hostnameOverride:  "node-1",
+				routerID:          "10.7.0.1",
+				localAddressList:  []string{"0.0.0.0", "::"},
+				bgpPort:           10000,
+				bgpFullMeshMode:   false,
+				bgpEnableInternal: false,
+				bgpServer:         gobgp.NewBgpServer(),
+				activeNodes:       make(map[string]bool),
+				podCidr:           "172.27.0.0/24",
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP("10.7.0.2"),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("10.7.0.2")}},
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("2001:db8:42:7::2")}},
+					},
+				},
+				podIPv4CIDRs: []string{"172.27.0.0/24"},
+				podIPv6CIDRs: []string{"2001:db8:42:27::/64"},
+				globalPeerRouters: []*gobgpapi.Peer{
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "10.17.0.1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "10.7.0.2"},
+					},
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "2001:db8:42:17::1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "2001:db8:42:7::2"},
+					},
+				},
+				nodeAsnNumber: 100,
+			},
+			[]*v1core.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "node-1",
+						Annotations: map[string]string{"kube-router.io/node.asn": "100"},
+					},
+					Status: v1core.NodeStatus{
+						Addresses: []v1core.NodeAddress{
+							{Type: v1core.NodeInternalIP, Address: "10.7.0.2"},
+							{Type: v1core.NodeInternalIP, Address: "2001:db8:42:7::2"},
+						},
+					},
+					Spec: v1core.NodeSpec{
+						PodCIDR:  "172.27.0.0/24",
+						PodCIDRs: []string{"172.27.0.0/24", "2001:db8:42:27::/64"},
+					},
+				},
+			},
+			[]*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "default"},
+					Spec: v1core.ServiceSpec{
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.17.0.5",
+						ClusterIPs:            []string{"10.17.0.5", "2001:db8:42:17::5"},
+						ExternalIPs:           []string{"1.17.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+						Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+					},
+					Endpoints: []discoveryv1.Endpoint{{Addresses: []string{testNodeIPv4}}},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "172.27.0.0/24", MaskLengthMin: 24, MaskLengthMax: 24},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "1.17.1.1/32", MaskLengthMin: 32, MaskLengthMax: 32},
+					{IpPrefix: "10.17.0.5/32", MaskLengthMin: 32, MaskLengthMax: 32},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSet,
+				List:        []string{"10.17.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSet,
+				List:        []string{"10.17.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_export_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt4",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt5",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt6",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt7",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
 						},
 						RpkiResult: -1,
 					},
@@ -1080,6 +1786,376 @@ func Test_AddPolicies(t *testing.T) {
 						NeighborSet: &gobgpapi.MatchSet{
 							Type: gobgpapi.MatchSet_TYPE_ANY,
 							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"prepends AS with dual-stack external peers",
+			&NetworkRoutingController{
+				clientset:         fake.NewSimpleClientset(),
+				hostnameOverride:  "node-1",
+				routerID:          "10.8.0.1",
+				localAddressList:  []string{"0.0.0.0", "::"},
+				bgpPort:           10000,
+				bgpEnableInternal: true,
+				bgpFullMeshMode:   false,
+				bgpServer:         gobgp.NewBgpServer(),
+				activeNodes:       make(map[string]bool),
+				podCidr:           "172.28.0.0/24",
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP("10.8.0.2"),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("10.8.0.2")}},
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("2001:db8:42:8::2")}},
+					},
+				},
+				podIPv4CIDRs: []string{"172.28.0.0/24"},
+				podIPv6CIDRs: []string{"2001:db8:42:28::/64"},
+				globalPeerRouters: []*gobgpapi.Peer{
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "10.18.0.1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "10.8.0.2"},
+					},
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "2001:db8:42:18::1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "2001:db8:42:8::2"},
+					},
+				},
+				nodeAsnNumber: 100,
+			},
+			[]*v1core.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Annotations: map[string]string{
+							"kube-router.io/node.asn":              "100",
+							"kube-router.io/path-prepend.as":       "65100",
+							"kube-router.io/path-prepend.repeat-n": "5",
+						},
+					},
+					Status: v1core.NodeStatus{
+						Addresses: []v1core.NodeAddress{
+							{Type: v1core.NodeInternalIP, Address: "10.8.0.2"},
+							{Type: v1core.NodeInternalIP, Address: "2001:db8:42:8::2"},
+						},
+					},
+					Spec: v1core.NodeSpec{
+						PodCIDR:  "172.28.0.0/24",
+						PodCIDRs: []string{"172.28.0.0/24", "2001:db8:42:28::/64"},
+					},
+				},
+			},
+			[]*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "default"},
+					Spec: v1core.ServiceSpec{
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.18.0.5",
+						ClusterIPs:            []string{"10.18.0.5", "2001:db8:42:18::5"},
+						ExternalIPs:           []string{"1.18.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+						Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+					},
+					Endpoints: []discoveryv1.Endpoint{{Addresses: []string{testNodeIPv4}}},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "172.28.0.0/24", MaskLengthMin: 24, MaskLengthMax: 24},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "1.18.1.1/32", MaskLengthMin: 32, MaskLengthMax: 32},
+					{IpPrefix: "10.18.0.5/32", MaskLengthMin: 32, MaskLengthMax: 32},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSet,
+				List:        []string{"10.18.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSet,
+				List:        []string{"10.18.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_export_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: iBGPPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: iBGPPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+						AsPrepend: &gobgpapi.AsPrependAction{
+							Asn:    65100,
+							Repeat: 5,
+						},
+					},
+				},
+				{
+					Name: "kube_router_export_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+						AsPrepend: &gobgpapi.AsPrependAction{
+							Asn:    65100,
+							Repeat: 5,
+						},
+					},
+				},
+				{
+					Name: "kube_router_export_stmt4",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+						AsPrepend: &gobgpapi.AsPrependAction{
+							Asn:    65100,
+							Repeat: 5,
+						},
+					},
+				},
+				{
+					Name: "kube_router_export_stmt5",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+						AsPrepend: &gobgpapi.AsPrependAction{
+							Asn:    65100,
+							Repeat: 5,
+						},
+					},
+				},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt4",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt5",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt6",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt7",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
 						},
 						RpkiResult: -1,
 					},
@@ -1530,6 +2606,426 @@ func Test_AddPolicies(t *testing.T) {
 			},
 			nil,
 		},
+		{
+			"has dual-stack nodes with communities defined",
+			&NetworkRoutingController{
+				clientset:         fake.NewSimpleClientset(),
+				hostnameOverride:  "node-1",
+				routerID:          "10.9.0.1",
+				localAddressList:  []string{"0.0.0.0", "::"},
+				bgpPort:           10000,
+				bgpFullMeshMode:   false,
+				bgpEnableInternal: false,
+				bgpServer:         gobgp.NewBgpServer(),
+				advertisePodCidr:  true,
+				activeNodes:       make(map[string]bool),
+				podCidr:           "172.29.0.0/24",
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP("10.9.0.2"),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("10.9.0.2")}},
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("2001:db8:42:9::2")}},
+					},
+				},
+				podIPv4CIDRs: []string{"172.29.0.0/24"},
+				podIPv6CIDRs: []string{"2001:db8:42:29::/64"},
+				globalPeerRouters: []*gobgpapi.Peer{
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "10.19.0.1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "10.9.0.2"},
+					},
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "2001:db8:42:19::1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "2001:db8:42:9::2"},
+					},
+				},
+				nodeAsnNumber: 100,
+			},
+			[]*v1core.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Annotations: map[string]string{
+							"kube-router.io/node.asn":             "100",
+							"kube-router.io/node.bgp.communities": "no-export",
+						},
+					},
+					Status: v1core.NodeStatus{
+						Addresses: []v1core.NodeAddress{
+							{Type: v1core.NodeInternalIP, Address: "10.9.0.2"},
+							{Type: v1core.NodeInternalIP, Address: "2001:db8:42:9::2"},
+						},
+					},
+					Spec: v1core.NodeSpec{
+						PodCIDR:  "172.29.0.0/24",
+						PodCIDRs: []string{"172.29.0.0/24", "2001:db8:42:29::/64"},
+					},
+				},
+			},
+			[]*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "default"},
+					Spec: v1core.ServiceSpec{
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.19.0.5",
+						ClusterIPs:            []string{"10.19.0.5", "2001:db8:42:19::5"},
+						ExternalIPs:           []string{"1.19.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+						Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+					},
+					Endpoints: []discoveryv1.Endpoint{{Addresses: []string{testNodeIPv4}}},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "172.29.0.0/24", MaskLengthMin: 24, MaskLengthMax: 24},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "1.19.1.1/32", MaskLengthMin: 32, MaskLengthMax: 32},
+					{IpPrefix: "10.19.0.5/32", MaskLengthMin: 32, MaskLengthMax: 32},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSet,
+				List:        []string{"10.19.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSet,
+				List:        []string{"10.19.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_export_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						Community: &gobgpapi.CommunityAction{
+							Type:        gobgpapi.CommunityAction_TYPE_ADD,
+							Communities: []string{"65535:65281"}, // corresponds to no-export
+						},
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						Community: &gobgpapi.CommunityAction{
+							Type:        gobgpapi.CommunityAction_TYPE_ADD,
+							Communities: []string{"65535:65281"}, // corresponds to no-export
+						},
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						Community: &gobgpapi.CommunityAction{
+							Type:        gobgpapi.CommunityAction_TYPE_ADD,
+							Communities: []string{"65535:65281"}, // corresponds to no-export
+						},
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						Community: &gobgpapi.CommunityAction{
+							Type:        gobgpapi.CommunityAction_TYPE_ADD,
+							Communities: []string{"65535:65281"}, // corresponds to no-export
+						},
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt4",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						Community: &gobgpapi.CommunityAction{
+							Type:        gobgpapi.CommunityAction_TYPE_ADD,
+							Communities: []string{"65535:65281"}, // corresponds to no-export
+						},
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt5",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						Community: &gobgpapi.CommunityAction{
+							Type:        gobgpapi.CommunityAction_TYPE_ADD,
+							Communities: []string{"65535:65281"}, // corresponds to no-export
+						},
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt6",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						Community: &gobgpapi.CommunityAction{
+							Type:        gobgpapi.CommunityAction_TYPE_ADD,
+							Communities: []string{"65535:65281"}, // corresponds to no-export
+						},
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt7",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						Community: &gobgpapi.CommunityAction{
+							Type:        gobgpapi.CommunityAction_TYPE_ADD,
+							Communities: []string{"65535:65281"}, // corresponds to no-export
+						},
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt4",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt5",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt6",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt7",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+			},
+			nil,
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -1764,4 +3260,535 @@ func normalizeConditions(c *gobgpapi.Conditions) *gobgpapi.Conditions {
 	cp, _ := proto.Clone(c).(*gobgpapi.Conditions)
 	cp.RpkiResult = 0
 	return cp
+}
+
+// DefinedSetContentsTestCase exercises the *contents* of the named GoBGP defined sets that AddPolicies()
+// constructs. It is intentionally separate from PolicyTestCase: PolicyTestCase verifies that policy
+// statements reference the right named sets (wiring), this verifies that those named sets actually
+// contain the right prefixes/neighbors (data).
+//
+// A nil expected field is treated as "do not assert this set". To assert that a set is absent from
+// GoBGP (callback never fires), pass &gobgpapi.DefinedSet{} (zero value).
+type DefinedSetContentsTestCase struct {
+	name              string
+	nrc               *NetworkRoutingController
+	existingNodes     []*v1core.Node
+	existingServices  []*v1core.Service
+	existingEndpoints []*discoveryv1.EndpointSlice
+
+	// Prefix-typed defined sets
+	expectedPodCIDRSet            *gobgpapi.DefinedSet
+	expectedPodCIDRSetV6          *gobgpapi.DefinedSet
+	expectedServiceVIPsSet        *gobgpapi.DefinedSet
+	expectedServiceVIPsSetV6      *gobgpapi.DefinedSet
+	expectedDefaultRouteSet       *gobgpapi.DefinedSet
+	expectedDefaultRouteSetV6     *gobgpapi.DefinedSet
+	expectedCustomImportRejectSet *gobgpapi.DefinedSet
+
+	// Neighbor-typed defined sets
+	expectedExternalPeerSet   *gobgpapi.DefinedSet
+	expectedExternalPeerSetV6 *gobgpapi.DefinedSet
+	expectedAllPeerSet        *gobgpapi.DefinedSet
+	expectedAllPeerSetV6      *gobgpapi.DefinedSet
+}
+
+// Test_AddDefinedSetContents verifies that AddPolicies() populates the GoBGP defined sets with the
+// correct prefixes and neighbor lists for the IPv4-only, IPv6-only, and dual-stack scenarios.
+//
+// This complements Test_AddPolicies, which only verifies that policy *statements* reference the
+// named sets correctly; here we assert the named sets actually contain the expected values. In
+// particular, this is the only place that confirms defaultRouteSetV6 actually contains "::/0".
+func Test_AddDefinedSetContents(t *testing.T) {
+	ipv4KRNode := &utils.LocalKRNode{
+		KRNode: utils.KRNode{
+			NodeName:      "node-1",
+			PrimaryIP:     net.ParseIP("10.40.0.2"),
+			NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("10.40.0.2")}},
+		},
+	}
+	ipv6KRNode := &utils.LocalKRNode{
+		KRNode: utils.KRNode{
+			NodeName:      "node-1",
+			PrimaryIP:     net.ParseIP("2001:db8:42:40::2"),
+			NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("2001:db8:42:40::2")}},
+		},
+	}
+	dualStackKRNode := &utils.LocalKRNode{
+		KRNode: utils.KRNode{
+			NodeName:      "node-1",
+			PrimaryIP:     net.ParseIP("10.41.0.2"),
+			NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("10.41.0.2")}},
+			NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("2001:db8:42:41::2")}},
+		},
+	}
+
+	testcases := []DefinedSetContentsTestCase{
+		{
+			name: "IPv4-only populates V4 sets and leaves V6 sets empty",
+			nrc: &NetworkRoutingController{
+				clientset:         fake.NewSimpleClientset(),
+				hostnameOverride:  "node-1",
+				routerID:          "10.40.0.1",
+				localAddressList:  []string{"0.0.0.0"},
+				bgpPort:           10000,
+				bgpFullMeshMode:   false,
+				bgpEnableInternal: true,
+				bgpServer:         gobgp.NewBgpServer(),
+				activeNodes:       make(map[string]bool),
+				nodeAsnNumber:     100,
+				podCidr:           "172.40.0.0/24",
+				krNode:            ipv4KRNode,
+				podIPv4CIDRs:      []string{"172.40.0.0/24"},
+				globalPeerRouters: []*gobgpapi.Peer{
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "10.140.0.1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "10.40.0.2"},
+					},
+				},
+			},
+			existingNodes: []*v1core.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "node-1",
+						Annotations: map[string]string{"kube-router.io/node.asn": "100"},
+					},
+					Status: v1core.NodeStatus{
+						Addresses: []v1core.NodeAddress{
+							{Type: v1core.NodeInternalIP, Address: "10.40.0.2"},
+						},
+					},
+					Spec: v1core.NodeSpec{PodCIDR: "172.40.0.0/24"},
+				},
+			},
+			existingServices: []*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "default"},
+					Spec: v1core.ServiceSpec{
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.140.0.5",
+						ExternalIPs:           []string{"1.40.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			existingEndpoints: []*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+						Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+					},
+					Endpoints: []discoveryv1.Endpoint{{Addresses: []string{testNodeIPv4}}},
+				},
+			},
+
+			expectedPodCIDRSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "172.40.0.0/24", MaskLengthMin: 24, MaskLengthMax: 24},
+				},
+			},
+			expectedPodCIDRSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSetV6,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			expectedServiceVIPsSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "1.40.1.1/32", MaskLengthMin: 32, MaskLengthMax: 32},
+					{IpPrefix: "10.140.0.5/32", MaskLengthMin: 32, MaskLengthMax: 32},
+				},
+			},
+			expectedServiceVIPsSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSetV6,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			expectedDefaultRouteSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        defaultRouteSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "0.0.0.0/0", MaskLengthMin: 0, MaskLengthMax: 0},
+				},
+			},
+			expectedDefaultRouteSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        defaultRouteSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "::/0", MaskLengthMin: 0, MaskLengthMax: 0},
+				},
+			},
+			expectedCustomImportRejectSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			expectedExternalPeerSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSet,
+				List:        []string{"10.140.0.1/32"},
+			},
+			expectedExternalPeerSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSetV6,
+				List:        []string{},
+			},
+			expectedAllPeerSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSet,
+				List:        []string{"10.140.0.1/32"},
+			},
+			expectedAllPeerSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSetV6,
+				List:        []string{},
+			},
+		},
+		{
+			name: "IPv6-only populates V6 sets and leaves V4 sets empty",
+			nrc: &NetworkRoutingController{
+				clientset:         fake.NewSimpleClientset(),
+				hostnameOverride:  "node-1",
+				routerID:          "10.40.0.1",
+				localAddressList:  []string{"::"},
+				bgpPort:           10000,
+				bgpFullMeshMode:   false,
+				bgpEnableInternal: true,
+				bgpServer:         gobgp.NewBgpServer(),
+				activeNodes:       make(map[string]bool),
+				nodeAsnNumber:     100,
+				podCidr:           "2001:db8:42:40::/64",
+				krNode:            ipv6KRNode,
+				podIPv6CIDRs:      []string{"2001:db8:42:40::/64"},
+				globalPeerRouters: []*gobgpapi.Peer{
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "2001:db8:42:140::1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "2001:db8:42:40::2"},
+					},
+				},
+			},
+			existingNodes: []*v1core.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "node-1",
+						Annotations: map[string]string{"kube-router.io/node.asn": "100"},
+					},
+					Status: v1core.NodeStatus{
+						Addresses: []v1core.NodeAddress{
+							{Type: v1core.NodeInternalIP, Address: "2001:db8:42:40::2"},
+						},
+					},
+					Spec: v1core.NodeSpec{PodCIDR: "2001:db8:42:40::/64"},
+				},
+			},
+			existingServices: []*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "default"},
+					Spec: v1core.ServiceSpec{
+						Type:                  ClusterIPST,
+						ClusterIP:             "2001:db8:42:140::5",
+						ClusterIPs:            []string{"2001:db8:42:140::5"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			existingEndpoints: []*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+						Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+					},
+					Endpoints: []discoveryv1.Endpoint{{Addresses: []string{"2001:db8:42:40::2"}}},
+				},
+			},
+
+			expectedPodCIDRSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			expectedPodCIDRSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "2001:db8:42:40::/64", MaskLengthMin: 64, MaskLengthMax: 64},
+				},
+			},
+			expectedServiceVIPsSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			expectedServiceVIPsSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "2001:db8:42:140::5/128", MaskLengthMin: 128, MaskLengthMax: 128},
+				},
+			},
+			expectedDefaultRouteSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        defaultRouteSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "0.0.0.0/0", MaskLengthMin: 0, MaskLengthMax: 0},
+				},
+			},
+			expectedDefaultRouteSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        defaultRouteSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "::/0", MaskLengthMin: 0, MaskLengthMax: 0},
+				},
+			},
+			expectedCustomImportRejectSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			expectedExternalPeerSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSet,
+				List:        []string{},
+			},
+			expectedExternalPeerSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSetV6,
+				List:        []string{"2001:db8:42:140::1/128"},
+			},
+			expectedAllPeerSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSet,
+				List:        []string{},
+			},
+			expectedAllPeerSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSetV6,
+				List:        []string{"2001:db8:42:140::1/128"},
+			},
+		},
+		{
+			name: "dual-stack populates both V4 and V6 sets",
+			nrc: &NetworkRoutingController{
+				clientset:         fake.NewSimpleClientset(),
+				hostnameOverride:  "node-1",
+				routerID:          "10.41.0.1",
+				localAddressList:  []string{"0.0.0.0", "::"},
+				bgpPort:           10000,
+				bgpFullMeshMode:   false,
+				bgpEnableInternal: true,
+				bgpServer:         gobgp.NewBgpServer(),
+				activeNodes:       make(map[string]bool),
+				nodeAsnNumber:     100,
+				podCidr:           "172.41.0.0/24",
+				krNode:            dualStackKRNode,
+				podIPv4CIDRs:      []string{"172.41.0.0/24"},
+				podIPv6CIDRs:      []string{"2001:db8:42:41::/64"},
+				globalPeerRouters: []*gobgpapi.Peer{
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "10.141.0.1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "10.41.0.2"},
+					},
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "2001:db8:42:141::1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "2001:db8:42:41::2"},
+					},
+				},
+			},
+			existingNodes: []*v1core.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "node-1",
+						Annotations: map[string]string{"kube-router.io/node.asn": "100"},
+					},
+					Status: v1core.NodeStatus{
+						Addresses: []v1core.NodeAddress{
+							{Type: v1core.NodeInternalIP, Address: "10.41.0.2"},
+							{Type: v1core.NodeInternalIP, Address: "2001:db8:42:41::2"},
+						},
+					},
+					Spec: v1core.NodeSpec{
+						PodCIDR:  "172.41.0.0/24",
+						PodCIDRs: []string{"172.41.0.0/24", "2001:db8:42:41::/64"},
+					},
+				},
+			},
+			existingServices: []*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "default"},
+					Spec: v1core.ServiceSpec{
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.141.0.5",
+						ClusterIPs:            []string{"10.141.0.5", "2001:db8:42:141::5"},
+						ExternalIPs:           []string{"1.41.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			existingEndpoints: []*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+						Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+					},
+					Endpoints: []discoveryv1.Endpoint{{Addresses: []string{testNodeIPv4}}},
+				},
+			},
+
+			expectedPodCIDRSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "172.41.0.0/24", MaskLengthMin: 24, MaskLengthMax: 24},
+				},
+			},
+			expectedPodCIDRSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "2001:db8:42:41::/64", MaskLengthMin: 64, MaskLengthMax: 64},
+				},
+			},
+			expectedServiceVIPsSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "1.41.1.1/32", MaskLengthMin: 32, MaskLengthMax: 32},
+					{IpPrefix: "10.141.0.5/32", MaskLengthMin: 32, MaskLengthMax: 32},
+				},
+			},
+			expectedServiceVIPsSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "2001:db8:42:141::5/128", MaskLengthMin: 128, MaskLengthMax: 128},
+				},
+			},
+			expectedDefaultRouteSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        defaultRouteSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "0.0.0.0/0", MaskLengthMin: 0, MaskLengthMax: 0},
+				},
+			},
+			expectedDefaultRouteSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        defaultRouteSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "::/0", MaskLengthMin: 0, MaskLengthMax: 0},
+				},
+			},
+			expectedCustomImportRejectSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			expectedExternalPeerSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSet,
+				List:        []string{"10.141.0.1/32"},
+			},
+			expectedExternalPeerSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSetV6,
+				List:        []string{"2001:db8:42:141::1/128"},
+			},
+			expectedAllPeerSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSet,
+				List:        []string{"10.141.0.1/32"},
+			},
+			expectedAllPeerSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSetV6,
+				List:        []string{"2001:db8:42:141::1/128"},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			startInformersForRoutes(t, tc.nrc, tc.nrc.clientset)
+
+			if err := createNodes(tc.nrc.clientset, tc.existingNodes); err != nil {
+				t.Fatalf("failed to create existing nodes: %v", err)
+			}
+			if err := createServices(tc.nrc.clientset, tc.existingServices); err != nil {
+				t.Fatalf("failed to create existing services: %v", err)
+			}
+			if err := createEndpointSlices(tc.nrc.clientset, tc.existingEndpoints); err != nil {
+				t.Fatalf("failed to create existing endpoints: %v", err)
+			}
+
+			if err := tc.nrc.startBgpServer(false); err != nil {
+				t.Fatalf("failed to start BGP server: %v", err)
+			}
+			defer func() {
+				if err := tc.nrc.bgpServer.StopBgp(context.Background(), &gobgpapi.StopBgpRequest{}); err != nil {
+					t.Fatalf("failed to stop BGP server: %s", err)
+				}
+			}()
+
+			waitForListerWithTimeout(tc.nrc.svcLister, time.Second*10, t)
+
+			tc.nrc.advertiseClusterIP = true
+			tc.nrc.advertiseExternalIP = true
+			tc.nrc.advertiseLoadBalancerIP = false
+
+			informerFactory := informers.NewSharedInformerFactory(tc.nrc.clientset, 0)
+			tc.nrc.nodeLister = informerFactory.Core().V1().Nodes().Informer().GetIndexer()
+			if err := tc.nrc.AddPolicies(); err != nil {
+				t.Fatalf("unexpected error from AddPolicies(): %v", err)
+			}
+
+			checkDefinedSet(t, tc.nrc, podCIDRSet, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedPodCIDRSet)
+			checkDefinedSet(t, tc.nrc, podCIDRSetV6, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedPodCIDRSetV6)
+			checkDefinedSet(t, tc.nrc, serviceVIPsSet, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedServiceVIPsSet)
+			checkDefinedSet(t, tc.nrc, serviceVIPsSetV6, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedServiceVIPsSetV6)
+			checkDefinedSet(t, tc.nrc, defaultRouteSet, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedDefaultRouteSet)
+			checkDefinedSet(t, tc.nrc, defaultRouteSetV6, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedDefaultRouteSetV6)
+			checkDefinedSet(t, tc.nrc, customImportRejectSet, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedCustomImportRejectSet)
+			checkDefinedSet(t, tc.nrc, externalPeerSet, gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR, tc.expectedExternalPeerSet)
+			checkDefinedSet(t, tc.nrc, externalPeerSetV6, gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR, tc.expectedExternalPeerSetV6)
+			checkDefinedSet(t, tc.nrc, allPeerSet, gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR, tc.expectedAllPeerSet)
+			checkDefinedSet(t, tc.nrc, allPeerSetV6, gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR, tc.expectedAllPeerSetV6)
+		})
+	}
+}
+
+// checkDefinedSet asserts that the named defined set in GoBGP matches `expected`. A nil `expected`
+// skips the check. If the set is absent from GoBGP (callback never fires), the actual value is
+// treated as &gobgpapi.DefinedSet{} (zero value) so absence can be expressed by passing the same.
+func checkDefinedSet(t *testing.T, nrc *NetworkRoutingController, name string,
+	defType gobgpapi.DefinedType, expected *gobgpapi.DefinedSet) {
+	t.Helper()
+	if expected == nil {
+		return
+	}
+	var actual *gobgpapi.DefinedSet
+	err := nrc.bgpServer.ListDefinedSet(context.Background(),
+		&gobgpapi.ListDefinedSetRequest{DefinedType: defType, Name: name},
+		func(ds *gobgpapi.DefinedSet) {
+			actual = ds
+		})
+	if err != nil {
+		t.Fatalf("error listing defined set %s: %v", name, err)
+	}
+	if actual == nil {
+		actual = &gobgpapi.DefinedSet{}
+	}
+	// proto.Equal compares by field semantics and ignores protobuf internal state (MessageState,
+	// sizeCache) that reflect.DeepEqual would treat as a real difference.
+	if !proto.Equal(actual, expected) {
+		t.Logf("expected %s defined set: %+v", name, expected)
+		t.Logf("actual %s defined set: %+v", name, actual)
+		t.Errorf("unexpected %s defined set contents", name)
+	}
 }

--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -396,8 +396,27 @@ func Test_AddPolicies(t *testing.T) {
 						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
 					},
 				},
+				// V6 default-route cross-family reject statement (kube-router unconditionally
+				// generates this for any peer set since defaultRouteSetV6 is always populated).
 				{
 					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt3",
 					Conditions: &gobgpapi.Conditions{
 						PrefixSet: &gobgpapi.MatchSet{
 							Type: gobgpapi.MatchSet_TYPE_ANY,
@@ -616,6 +635,25 @@ func Test_AddPolicies(t *testing.T) {
 						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
 					},
 				},
+				// V6 default-route cross-family reject statement (kube-router unconditionally
+				// generates this for any peer set since defaultRouteSetV6 is always populated).
+				{
+					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
 			},
 			nil,
 		},
@@ -791,6 +829,25 @@ func Test_AddPolicies(t *testing.T) {
 						PrefixSet: &gobgpapi.MatchSet{
 							Type: gobgpapi.MatchSet_TYPE_ANY,
 							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				// V6 default-route cross-family reject statement (kube-router unconditionally
+				// generates this for any peer set since defaultRouteSetV6 is always populated).
+				{
+					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
 						},
 						NeighborSet: &gobgpapi.MatchSet{
 							Type: gobgpapi.MatchSet_TYPE_ANY,
@@ -1000,6 +1057,25 @@ func Test_AddPolicies(t *testing.T) {
 						PrefixSet: &gobgpapi.MatchSet{
 							Type: gobgpapi.MatchSet_TYPE_ANY,
 							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				// V6 default-route cross-family reject statement (kube-router unconditionally
+				// generates this for any peer set since defaultRouteSetV6 is always populated).
+				{
+					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
 						},
 						NeighborSet: &gobgpapi.MatchSet{
 							Type: gobgpapi.MatchSet_TYPE_ANY,
@@ -1421,6 +1497,25 @@ func Test_AddPolicies(t *testing.T) {
 						PrefixSet: &gobgpapi.MatchSet{
 							Type: gobgpapi.MatchSet_TYPE_ANY,
 							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				// V6 default-route cross-family reject statement (kube-router unconditionally
+				// generates this for any peer set since defaultRouteSetV6 is always populated).
+				{
+					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
 						},
 						NeighborSet: &gobgpapi.MatchSet{
 							Type: gobgpapi.MatchSet_TYPE_ANY,

--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	gobgpapi "github.com/osrg/gobgp/v4/api"
 	gobgp "github.com/osrg/gobgp/v4/pkg/server"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 )
 
 type PolicyTestCase struct {
@@ -1555,7 +1557,7 @@ func Test_AddPolicies(t *testing.T) {
 }
 
 func checkPolicies(t *testing.T, testcase PolicyTestCase, gobgpDirection gobgpapi.PolicyDirection, policyStatements []*gobgpapi.Statement) {
-	policyExists := false
+	t.Helper()
 
 	var direction string
 	if gobgpDirection.String() == "POLICY_DIRECTION_EXPORT" {
@@ -1564,23 +1566,29 @@ func checkPolicies(t *testing.T, testcase PolicyTestCase, gobgpDirection gobgpap
 		direction = "import"
 	}
 
+	// Discover the version-suffixed name (e.g. "kube_router_import1") rather than reconstructing
+	// it, so the helper still works if AddPolicies is ever called more than once on the same server.
+	policyExists := false
+	actualPolicyName := ""
+	expectedPolicyPrefix := "kube_router_" + direction
 	err := testcase.nrc.bgpServer.ListPolicy(context.Background(), &gobgpapi.ListPolicyRequest{}, func(policy *gobgpapi.Policy) {
-		if policy.Name == "kube_router_"+direction+"1" {
+		if strings.HasPrefix(policy.Name, expectedPolicyPrefix) {
 			policyExists = true
+			actualPolicyName = policy.Name
 		}
 	})
 	if err != nil {
 		t.Fatalf("failed to get policy: %v", err)
 	}
 	if !policyExists {
-		t.Errorf("policy 'kube_router_%v' was not added", direction)
+		t.Errorf("policy with prefix %q was not added", expectedPolicyPrefix)
 	}
 
 	policyAssignmentExists := false
 	err = testcase.nrc.bgpServer.ListPolicyAssignment(context.Background(), &gobgpapi.ListPolicyAssignmentRequest{}, func(policyAssignment *gobgpapi.PolicyAssignment) {
 		if policyAssignment.Name == "global" && policyAssignment.Direction == gobgpDirection {
 			for _, policy := range policyAssignment.Policies {
-				if policy.Name == "kube_router_"+direction+"1" {
+				if policy.Name == actualPolicyName {
 					policyAssignmentExists = true
 				}
 			}
@@ -1593,11 +1601,21 @@ func checkPolicies(t *testing.T, testcase PolicyTestCase, gobgpDirection gobgpap
 	if !policyAssignmentExists {
 		t.Errorf("%s policy assignment 'kube_router_%s' was not added", direction, direction)
 	}
-	err = testcase.nrc.bgpServer.ListPolicy(context.Background(), &gobgpapi.ListPolicyRequest{Name: "kube_router_" + direction}, func(foundPolicy *gobgpapi.Policy) {
+
+	// Bail before the next ListPolicy call: an empty Name filter would match every policy and
+	// produce a misleading secondary failure.
+	if actualPolicyName == "" {
+		return
+	}
+
+	// GoBGP's ListPolicy does exact name matching, so we must pass the full versioned name.
+	policyFound := false
+	err = testcase.nrc.bgpServer.ListPolicy(context.Background(), &gobgpapi.ListPolicyRequest{Name: actualPolicyName}, func(foundPolicy *gobgpapi.Policy) {
+		policyFound = true
 		for _, expectedStatement := range policyStatements {
 			found := false
 			for _, statement := range foundPolicy.Statements {
-				if reflect.DeepEqual(statement, expectedStatement) {
+				if statementsEquivalent(statement, expectedStatement) {
 					found = true
 					break
 				}
@@ -1608,10 +1626,47 @@ func checkPolicies(t *testing.T, testcase PolicyTestCase, gobgpDirection gobgpap
 			}
 		}
 		if len(policyStatements) != len(foundPolicy.Statements) {
-			t.Errorf("unexpected statement found: %v", foundPolicy.Statements)
+			t.Errorf("expected %d statements, found %d: %v",
+				len(policyStatements), len(foundPolicy.Statements), foundPolicy.Statements)
 		}
 	})
 	if err != nil {
-		t.Fatalf("expected to find a policy, but none were returned")
+		t.Fatalf("ListPolicy failed: %v", err)
 	}
+	if !policyFound {
+		t.Fatalf("expected to find policy %q, but none matched", actualPolicyName)
+	}
+}
+
+// statementsEquivalent compares two BGP policy statements by their semantically meaningful fields
+// (Conditions and Actions), ignoring implementation-detail fields whose values are stable but not
+// what the test author intends to assert:
+//
+//   - Name: GoBGP preserves the kube-router-generated name (e.g. "servicevipsdefinedsetallpeerset"),
+//     not a sequential index like "kube_router_import_stmt0" that several test cases use. Comparing
+//     by Name would require either rewriting every expected entry or coupling the tests to the
+//     internal naming scheme.
+//   - Conditions.RpkiResult: production code never sets this field, so the actual value is always
+//     the proto default (0). Several test cases pre-fill it as -1, which would never match.
+//
+// What actually matters for these tests is *what* the statement matches (PrefixSet, NeighborSet)
+// and *what* it does (Actions), both of which are compared via proto.Equal (which understands
+// protobuf semantics and ignores internal MessageState — unlike reflect.DeepEqual).
+func statementsEquivalent(a, b *gobgpapi.Statement) bool {
+	if !proto.Equal(a.GetActions(), b.GetActions()) {
+		return false
+	}
+	return proto.Equal(normalizeConditions(a.GetConditions()), normalizeConditions(b.GetConditions()))
+}
+
+// normalizeConditions returns a copy of the given Conditions with RpkiResult zeroed out, so the
+// proto.Equal comparison ignores it. Uses proto.Clone to avoid copying the embedded sync.Mutex
+// in protoimpl.MessageState (which `go vet` flags via copylocks).
+func normalizeConditions(c *gobgpapi.Conditions) *gobgpapi.Conditions {
+	if c == nil {
+		return nil
+	}
+	cp, _ := proto.Clone(c).(*gobgpapi.Conditions)
+	cp.RpkiResult = 0
+	return cp
 }

--- a/pkg/controllers/routing/bgp_policies_test.go
+++ b/pkg/controllers/routing/bgp_policies_test.go
@@ -436,6 +436,430 @@ func Test_AddPolicies(t *testing.T) {
 			nil,
 		},
 		{
+			"has dual-stack nodes with V4+V6 custom import reject annotation",
+			&NetworkRoutingController{
+				clientset:         fake.NewSimpleClientset(),
+				hostnameOverride:  "node-1",
+				routerID:          "10.10.0.1",
+				localAddressList:  []string{"0.0.0.0", "::"},
+				bgpPort:           10000,
+				bgpFullMeshMode:   false,
+				bgpEnableInternal: true,
+				bgpServer:         gobgp.NewBgpServer(),
+				activeNodes:       make(map[string]bool),
+				nodeAsnNumber:     100,
+				podCidr:           "172.30.0.0/24",
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP("10.10.0.2"),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("10.10.0.2")}},
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("2001:db8:42:a::2")}},
+					},
+				},
+				podIPv4CIDRs: []string{"172.30.0.0/24"},
+				podIPv6CIDRs: []string{"2001:db8:42:1e::/64"},
+				globalPeerRouters: []*gobgpapi.Peer{
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "10.20.0.1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "10.10.0.2"},
+					},
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "2001:db8:42:14::1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "2001:db8:42:a::2"},
+					},
+				},
+			},
+			[]*v1core.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Annotations: map[string]string{
+							"kube-router.io/node.asn":                    "100",
+							"kube-router.io/node.bgp.customimportreject": "192.168.11.0/24,2001:db8:cafe::/48,10.1.0.0/16,2001:db8:dead::/48",
+						},
+					},
+					Status: v1core.NodeStatus{
+						Addresses: []v1core.NodeAddress{
+							{Type: v1core.NodeInternalIP, Address: "10.10.0.2"},
+							{Type: v1core.NodeInternalIP, Address: "2001:db8:42:a::2"},
+						},
+					},
+					Spec: v1core.NodeSpec{
+						PodCIDR:  "172.30.0.0/24",
+						PodCIDRs: []string{"172.30.0.0/24", "2001:db8:42:1e::/64"},
+					},
+				},
+			},
+			[]*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "default"},
+					Spec: v1core.ServiceSpec{
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.20.0.5",
+						ClusterIPs:            []string{"10.20.0.5", "2001:db8:42:14::5"},
+						ExternalIPs:           []string{"1.20.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			[]*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+						Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+					},
+					Endpoints: []discoveryv1.Endpoint{{Addresses: []string{testNodeIPv4}}},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "172.30.0.0/24", MaskLengthMin: 24, MaskLengthMax: 24},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "1.20.1.1/32", MaskLengthMin: 32, MaskLengthMax: 32},
+					{IpPrefix: "10.20.0.5/32", MaskLengthMin: 32, MaskLengthMax: 32},
+				},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSet,
+				List:        []string{"10.20.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSet,
+				List:        []string{"10.20.0.1/32"},
+			},
+			&gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "10.1.0.0/16", MaskLengthMin: 16, MaskLengthMax: ipv4MaskMinBits},
+					{IpPrefix: "192.168.11.0/24", MaskLengthMin: 24, MaskLengthMax: ipv4MaskMinBits},
+				},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_export_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: iBGPPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: podCIDRSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: iBGPPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt4",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+				{
+					Name: "kube_router_export_stmt5",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: externalPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_ACCEPT,
+					},
+				},
+			},
+			[]*gobgpapi.Statement{
+				{
+					Name: "kube_router_import_stmt0",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt1",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt2",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt3",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt4",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: customImportRejectSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt5",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: customImportRejectSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSet,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt6",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt7",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: serviceVIPsSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt8",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt9",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: defaultRouteSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt10",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: customImportRejectSet,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+				{
+					Name: "kube_router_import_stmt11",
+					Conditions: &gobgpapi.Conditions{
+						PrefixSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: customImportRejectSetV6,
+						},
+						NeighborSet: &gobgpapi.MatchSet{
+							Type: gobgpapi.MatchSet_TYPE_ANY,
+							Name: allPeerSetV6,
+						},
+						RpkiResult: -1,
+					},
+					Actions: &gobgpapi.Actions{
+						RouteAction: gobgpapi.RouteAction_ROUTE_ACTION_REJECT,
+					},
+				},
+			},
+			nil,
+		},
+		{
 			"has nodes, services with external peers",
 			&NetworkRoutingController{
 				clientset:         fake.NewSimpleClientset(),
@@ -3277,13 +3701,14 @@ type DefinedSetContentsTestCase struct {
 	existingEndpoints []*discoveryv1.EndpointSlice
 
 	// Prefix-typed defined sets
-	expectedPodCIDRSet            *gobgpapi.DefinedSet
-	expectedPodCIDRSetV6          *gobgpapi.DefinedSet
-	expectedServiceVIPsSet        *gobgpapi.DefinedSet
-	expectedServiceVIPsSetV6      *gobgpapi.DefinedSet
-	expectedDefaultRouteSet       *gobgpapi.DefinedSet
-	expectedDefaultRouteSetV6     *gobgpapi.DefinedSet
-	expectedCustomImportRejectSet *gobgpapi.DefinedSet
+	expectedPodCIDRSet              *gobgpapi.DefinedSet
+	expectedPodCIDRSetV6            *gobgpapi.DefinedSet
+	expectedServiceVIPsSet          *gobgpapi.DefinedSet
+	expectedServiceVIPsSetV6        *gobgpapi.DefinedSet
+	expectedDefaultRouteSet         *gobgpapi.DefinedSet
+	expectedDefaultRouteSetV6       *gobgpapi.DefinedSet
+	expectedCustomImportRejectSet   *gobgpapi.DefinedSet
+	expectedCustomImportRejectSetV6 *gobgpapi.DefinedSet
 
 	// Neighbor-typed defined sets
 	expectedExternalPeerSet   *gobgpapi.DefinedSet
@@ -3427,6 +3852,11 @@ func Test_AddDefinedSetContents(t *testing.T) {
 				Name:        customImportRejectSet,
 				Prefixes:    []*gobgpapi.Prefix{},
 			},
+			expectedCustomImportRejectSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSetV6,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
 			expectedExternalPeerSet: &gobgpapi.DefinedSet{
 				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
 				Name:        externalPeerSet,
@@ -3549,6 +3979,11 @@ func Test_AddDefinedSetContents(t *testing.T) {
 			expectedCustomImportRejectSet: &gobgpapi.DefinedSet{
 				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
 				Name:        customImportRejectSet,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
+			expectedCustomImportRejectSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSetV6,
 				Prefixes:    []*gobgpapi.Prefix{},
 			},
 			expectedExternalPeerSet: &gobgpapi.DefinedSet{
@@ -3690,6 +4125,11 @@ func Test_AddDefinedSetContents(t *testing.T) {
 				Name:        customImportRejectSet,
 				Prefixes:    []*gobgpapi.Prefix{},
 			},
+			expectedCustomImportRejectSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSetV6,
+				Prefixes:    []*gobgpapi.Prefix{},
+			},
 			expectedExternalPeerSet: &gobgpapi.DefinedSet{
 				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
 				Name:        externalPeerSet,
@@ -3709,6 +4149,166 @@ func Test_AddDefinedSetContents(t *testing.T) {
 				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
 				Name:        allPeerSetV6,
 				List:        []string{"2001:db8:42:141::1/128"},
+			},
+		},
+		{
+			name: "dual-stack with V4+V6 customImportReject annotation populates both sets",
+			nrc: &NetworkRoutingController{
+				clientset:         fake.NewSimpleClientset(),
+				hostnameOverride:  "node-1",
+				routerID:          "10.42.0.1",
+				localAddressList:  []string{"0.0.0.0", "::"},
+				bgpPort:           10000,
+				bgpFullMeshMode:   false,
+				bgpEnableInternal: true,
+				bgpServer:         gobgp.NewBgpServer(),
+				activeNodes:       make(map[string]bool),
+				nodeAsnNumber:     100,
+				podCidr:           "172.42.0.0/24",
+				krNode: &utils.LocalKRNode{
+					KRNode: utils.KRNode{
+						NodeName:      "node-1",
+						PrimaryIP:     net.ParseIP("10.42.0.2"),
+						NodeIPv4Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("10.42.0.2")}},
+						NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{v1core.NodeInternalIP: {net.ParseIP("2001:db8:42:42::2")}},
+					},
+				},
+				podIPv4CIDRs: []string{"172.42.0.0/24"},
+				podIPv6CIDRs: []string{"2001:db8:42:42::/64"},
+				globalPeerRouters: []*gobgpapi.Peer{
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "10.142.0.1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "10.42.0.2"},
+					},
+					{
+						Conf:      &gobgpapi.PeerConf{NeighborAddress: "2001:db8:42:142::1"},
+						Transport: &gobgpapi.Transport{LocalAddress: "2001:db8:42:42::2"},
+					},
+				},
+			},
+			existingNodes: []*v1core.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-1",
+						Annotations: map[string]string{
+							"kube-router.io/node.asn":                    "100",
+							"kube-router.io/node.bgp.customimportreject": "192.168.11.0/24,2001:db8:cafe::/48,10.1.0.0/16,2001:db8:dead::/48",
+						},
+					},
+					Status: v1core.NodeStatus{
+						Addresses: []v1core.NodeAddress{
+							{Type: v1core.NodeInternalIP, Address: "10.42.0.2"},
+							{Type: v1core.NodeInternalIP, Address: "2001:db8:42:42::2"},
+						},
+					},
+					Spec: v1core.NodeSpec{
+						PodCIDR:  "172.42.0.0/24",
+						PodCIDRs: []string{"172.42.0.0/24", "2001:db8:42:42::/64"},
+					},
+				},
+			},
+			existingServices: []*v1core.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "default"},
+					Spec: v1core.ServiceSpec{
+						Type:                  ClusterIPST,
+						ClusterIP:             "10.142.0.5",
+						ClusterIPs:            []string{"10.142.0.5", "2001:db8:42:142::5"},
+						ExternalIPs:           []string{"1.42.1.1"},
+						InternalTrafficPolicy: &testClusterIntTrafPol,
+						ExternalTrafficPolicy: testClusterExtTrafPol,
+					},
+				},
+			},
+			existingEndpoints: []*discoveryv1.EndpointSlice{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc-1",
+						Namespace: "default",
+						Labels:    map[string]string{"kubernetes.io/service-name": "svc-1"},
+					},
+					Endpoints: []discoveryv1.Endpoint{{Addresses: []string{testNodeIPv4}}},
+				},
+			},
+
+			expectedPodCIDRSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "172.42.0.0/24", MaskLengthMin: 24, MaskLengthMax: 24},
+				},
+			},
+			expectedPodCIDRSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        podCIDRSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "2001:db8:42:42::/64", MaskLengthMin: 64, MaskLengthMax: 64},
+				},
+			},
+			expectedServiceVIPsSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "1.42.1.1/32", MaskLengthMin: 32, MaskLengthMax: 32},
+					{IpPrefix: "10.142.0.5/32", MaskLengthMin: 32, MaskLengthMax: 32},
+				},
+			},
+			expectedServiceVIPsSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        serviceVIPsSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "2001:db8:42:142::5/128", MaskLengthMin: 128, MaskLengthMax: 128},
+				},
+			},
+			expectedDefaultRouteSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        defaultRouteSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "0.0.0.0/0", MaskLengthMin: 0, MaskLengthMax: 0},
+				},
+			},
+			expectedDefaultRouteSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        defaultRouteSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "::/0", MaskLengthMin: 0, MaskLengthMax: 0},
+				},
+			},
+			expectedCustomImportRejectSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSet,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "10.1.0.0/16", MaskLengthMin: 16, MaskLengthMax: 32},
+					{IpPrefix: "192.168.11.0/24", MaskLengthMin: 24, MaskLengthMax: 32},
+				},
+			},
+			expectedCustomImportRejectSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_PREFIX,
+				Name:        customImportRejectSetV6,
+				Prefixes: []*gobgpapi.Prefix{
+					{IpPrefix: "2001:db8:cafe::/48", MaskLengthMin: 48, MaskLengthMax: 128},
+					{IpPrefix: "2001:db8:dead::/48", MaskLengthMin: 48, MaskLengthMax: 128},
+				},
+			},
+			expectedExternalPeerSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSet,
+				List:        []string{"10.142.0.1/32"},
+			},
+			expectedExternalPeerSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        externalPeerSetV6,
+				List:        []string{"2001:db8:42:142::1/128"},
+			},
+			expectedAllPeerSet: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSet,
+				List:        []string{"10.142.0.1/32"},
+			},
+			expectedAllPeerSetV6: &gobgpapi.DefinedSet{
+				DefinedType: gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR,
+				Name:        allPeerSetV6,
+				List:        []string{"2001:db8:42:142::1/128"},
 			},
 		},
 	}
@@ -3755,6 +4355,7 @@ func Test_AddDefinedSetContents(t *testing.T) {
 			checkDefinedSet(t, tc.nrc, defaultRouteSet, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedDefaultRouteSet)
 			checkDefinedSet(t, tc.nrc, defaultRouteSetV6, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedDefaultRouteSetV6)
 			checkDefinedSet(t, tc.nrc, customImportRejectSet, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedCustomImportRejectSet)
+			checkDefinedSet(t, tc.nrc, customImportRejectSetV6, gobgpapi.DefinedType_DEFINED_TYPE_PREFIX, tc.expectedCustomImportRejectSetV6)
 			checkDefinedSet(t, tc.nrc, externalPeerSet, gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR, tc.expectedExternalPeerSet)
 			checkDefinedSet(t, tc.nrc, externalPeerSetV6, gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR, tc.expectedExternalPeerSetV6)
 			checkDefinedSet(t, tc.nrc, allPeerSet, gobgpapi.DefinedType_DEFINED_TYPE_NEIGHBOR, tc.expectedAllPeerSet)


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it:

Extends the existing IPv6 parity work in `addImportPolicies` (PR #2092) and closes related test-infrastructure gaps:

- **Adds IPv6 support to `customImportReject`** — the `kube-router.io/node.bgp.customimportreject` annotation can now
  contain a mix of V4 and V6 CIDRs. Previously GoBGP rejected the mixed defined set with "multiple families" and the
  import policy then failed referencing the never-created set. CIDRs are now split by family into
  `customImportRejectSet` and `customImportRejectSetV6` with the correct `MaskLengthMax` per family (32 vs 128), and
  matched in the import policy via the same V4/V6 loop pattern used by the default-route reject.
- **Fixes a silent-pass bug in the `checkPolicies` test helper** — the helper was calling GoBGP's `ListPolicy` with an
  exact name filter that never matched the actual policy name (missing the `"1"` version suffix appended by
  `incrementAndCreatePolicy`), so the per-statement validation loop was effectively skipped for every existing test
  case. Fixes the filter and introduces a `statementsEquivalent` helper using `proto.Equal` that tolerates two
  implementation-detail mismatches (statement `Name` and `RpkiResult`) that had drifted across many expected statements
  without anyone noticing.

To meaningfully exercise the now-validating runner, the PR also:

- Adds **dual-stack variants** for the existing external-peers, iBGP-disabled, AS-prepend, communities, and
  customImportReject scenarios in `Test_AddPolicies`.
- Adds a new **`Test_AddDefinedSetContents`** function that verifies the actual prefix/neighbor list contents of every
  relevant GoBGP defined set (so e.g. `defaultRouteSetV6` is now asserted to actually contain `::/0` rather than being
  trusted via a name reference alone).
- **Backfills five V4-only test cases** with the cross-family `defaultRouteSetV6 × allPeerSet` reject statement that
  the V6 default-route fix generates unconditionally for V4 peer sets.

#### Which issue(s) this PR is related to:

<!-- Builds on PR #2092 -->

#### Was AI used during the creation of this PR?

* What tool was used: Claude Code (Sonnet)
* To what extent was the tool used? Drafted most of the code and tests; human directed scope, reviewed each step, and
  made architectural decisions (separation of `Test_AddPolicies` vs `Test_AddDefinedSetContents`, commit splitting,
  whether to fix the runner bug now or later, etc.).
* If drafted, how detailed of a plan did you create for the AI? Iterative — short conversational prompts driving
  discovery, with an explicit TDD cycle requested for the customImportReject feature.
* Help us understand if a human was in the loop or not for this PR? Yes

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?

<!-- TODO: fill in -->

#### Does this PR introduce a breaking change?

```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

- Commits are ordered for narrative readability, not perfect bisectability: the runner-fix commit
  (`fix(NRC): correct exact-match policy name in checkPolicies test runner`) leaves V4-only tests failing until the
  next commit (`test(NRC): backfill expected V6 default-route cross-family statements`) lands. The first commit's
  message explicitly calls this out. Squash the two if strict bisectability is required.
- The only runtime behavior change is the V6 customImportReject support in `bgp_policies.go`. All other commits are
  test-internal.