### PR TITLE
Fix SLSA Provinance & Reduce Multi-Arch Build Times

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,5 +40,10 @@ archives:
       - CHANGELOG*
       - Documentation*
 
+# Pin the checksum filename to a stable, version-independent name so that the
+# SLSA provenance step in .github/workflows/ci-release.yml can reference it
+checksum:
+  name_template: 'checksums.txt'
+
 snapshot:
   version_template: SNAPSHOT-{{ .Commit }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV BUILD_IN_DOCKER=false \
     CGO_ENABLED=0 \
     GOOS=$TARGETOS \
     GOARCH=$TARGETARCH
+# GOARM can't be an ENV (no ${VAR#v} stripping); each ARM cross-compile RUN must export it.
 
 WORKDIR /build
 # Cache `go mod download` in its own layer; source-only changes won't invalidate it.
@@ -67,6 +68,41 @@ COPY --from=builder /build/cni-download /usr/libexec/cni
 # which version is used should be based on the host system as well as where rules that may have been added before
 # kube-router are being placed. For more information see: https://github.com/kubernetes-sigs/iptables-wrappers
 COPY --from=builder /iptables-wrappers/bin/iptables-wrapper /
+
+# Defense-in-depth: verify each copied binary's ELF e_machine (offset 18, 2 bytes) matches
+# TARGETPLATFORM. Catches wrong-arch binaries that QEMU's binfmt would otherwise silently
+# emulate at runtime. EM_ values from <elf.h>; s390x is big-endian, the rest little-endian.
+ARG TARGETPLATFORM
+RUN case "${TARGETPLATFORM}" in \
+        linux/amd64)   EXPECTED_EM="3e00" ;; \
+        linux/arm64)   EXPECTED_EM="b700" ;; \
+        linux/arm | linux/arm/*) EXPECTED_EM="2800" ;; \
+        linux/ppc64le) EXPECTED_EM="1500" ;; \
+        linux/s390x)   EXPECTED_EM="0016" ;; \
+        *) echo "ERROR: arch-check: unsupported TARGETPLATFORM=${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac && \
+    elf_checked=0 && \
+    for bin in /usr/local/bin/kube-router /usr/local/bin/gobgp /iptables-wrapper /usr/libexec/cni/*; do \
+        [ -f "$bin" ] || { echo "ERROR: arch-check: missing $bin" >&2; exit 1; }; \
+        magic=$(od -An -tx1 -N4 "$bin" | tr -d ' \n'); \
+        if [ "$magic" != "7f454c46" ]; then \
+            echo "arch-check skip: ${bin} is not ELF (magic=0x${magic:-empty})"; \
+            continue; \
+        fi; \
+        actual_em=$(od -An -tx1 -j18 -N2 "$bin" | tr -d ' \n'); \
+        if [ "$actual_em" != "$EXPECTED_EM" ]; then \
+            echo "ERROR: arch-check: ${bin} has ELF e_machine=0x${actual_em}, expected 0x${EXPECTED_EM} for ${TARGETPLATFORM}" >&2; \
+            exit 1; \
+        fi; \
+        echo "arch-check OK: ${bin} matches ${TARGETPLATFORM} (e_machine=0x${actual_em})"; \
+        elf_checked=$((elf_checked + 1)); \
+    done && \
+    if [ "$elf_checked" -lt 4 ]; then \
+        echo "ERROR: arch-check: only $elf_checked ELF binaries verified; expected at least 4 (kube-router, gobgp, iptables-wrapper, and >=1 CNI plugin)" >&2; \
+        exit 1; \
+    fi && \
+    echo "arch-check: verified $elf_checked ELF binaries against ${TARGETPLATFORM}"
+
 # This is necessary because of the bug reported here: https://github.com/flannel-io/flannel/pull/1340/files
 # Basically even under QEMU emulation, it still doesn't have an ARM kernel in-play which means that calls to
 # iptables-nft will fail in the build process. The sanity check here only makes sure that iptables-nft and iptables-legacy

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,27 @@ ARG BUILDTIME_BASE=golang:1-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2
 ARG RUNTIME_BASE=alpine:latest@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 ARG TARGETPLATFORM
 ARG CNI_VERSION
-FROM ${BUILDTIME_BASE} AS builder
-ENV BUILD_IN_DOCKER=false
+
+# Builder runs on BUILDPLATFORM (the runner's native arch) and cross-compiles Go for each
+# TARGETPLATFORM, avoiding QEMU-emulated `go build`. See:
+# https://docs.docker.com/build/building/multi-platform/#cross-compilation
+FROM --platform=$BUILDPLATFORM ${BUILDTIME_BASE} AS builder
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ENV BUILD_IN_DOCKER=false \
+    CGO_ENABLED=0 \
+    GOOS=$TARGETOS \
+    GOARCH=$TARGETARCH
 
 WORKDIR /build
-COPY . /build
+# Cache `go mod download` in its own layer; source-only changes won't invalidate it.
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+# GOARM is "v7" -> "7" (Dockerfile ENV can't do ${VAR#prefix}); empty on non-arm targets.
 RUN apk add --no-cache make git tar curl \
+    && export GOARM="${TARGETVARIANT#v}" \
     && make kube-router \
     && make gobgp \
     && make cni-download
@@ -15,11 +30,15 @@ RUN apk add --no-cache make git tar curl \
 WORKDIR /iptables-wrappers
 # This is the latest commit on the master branch.
 ENV IPTABLES_WRAPPERS_VERSION=bfef9e5087a198b50a4124bb9ce9d2c7c99025dd
-RUN git clone https://github.com/kubernetes-sigs/iptables-wrappers.git . \
+# Pure-Go CGO_ENABLED=0 build, cross-compiles via the env vars set above.
+RUN export GOARM="${TARGETVARIANT#v}" \
+    && git clone https://github.com/kubernetes-sigs/iptables-wrappers.git . \
     && git checkout "${IPTABLES_WRAPPERS_VERSION}" \
     && make build \
-    && test -x bin/iptables-wrapper 
+    && test -x bin/iptables-wrapper
 
+# Runtime stage runs on TARGETPLATFORM (QEMU for non-native), so apk pulls per-arch packages
+# and `iptables-wrapper install` runs target-arch scripts — both fast.
 FROM ${RUNTIME_BASE}
 
 RUN apk add --no-cache \

--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,6 @@ help:
 .PHONY: clean container run release goreleaser push gofmt gofmt-fix gomoqs scan
 .PHONY: test test-privileged test-pretty lint docker-login push-manifest push-manifest-release
 .PHONY: push-release github-release help multiarch-binverify markdownlint doctoc
-.PHONY: spellcheck update-deps update-deps-dry prep-release kube-router gobgp
+.PHONY: spellcheck update-deps update-deps-dry prep-release kube-router gobgp cni-download
 
 .DEFAULT: all


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?

<!--
Please choose one of the following kinds:
-->
bug
feature

#### What this PR does / why we need it:

This PR should fix the errors that we get during releases where the release doesn't fully complete because the SLSA provenance check isn't able to complete by pinning the checksum file.

Additionally, this consolidates all of the Go Binary building on the system's native architecture and the copies those binaries, based on the target architecture into the various container's that are based on that architecture.

The net result is that the build time is decreased by roughly 6 - 7x of what we usually see on a local development machine that has much more resources than the builders that GHA gives us. The lower estimation of the time savings is approx. going from 108 min build times down to 17 min build times for full releases.

This is relatively low hanging fruit considering the improvement expectations.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->
None

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->
None

#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

