### PR TITLE
Remove dead error checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - goconst
     - gocritic
     - gosec
+    - govet
     - lll
     - misspell
     - mnd
@@ -31,6 +32,11 @@ linters:
   settings:
     goconst:
       min-len: 20
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+        - shadow
   exclusions:
     generated: lax
     presets:

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -1150,14 +1150,6 @@ func (nrc *NetworkRoutingController) startBgpServer(grpcServer bool) error {
 			nrc.bgpHoldtime,
 			nrc.krNode.GetPrimaryNodeIP().String(),
 		)
-		if err != nil {
-			err2 := nrc.bgpServer.StopBgp(context.Background(), &gobgpapi.StopBgpRequest{})
-			if err2 != nil {
-				klog.Errorf("Failed to stop bgpServer: %s", err2)
-			}
-
-			return fmt.Errorf("failed to process Global Peer Router configs: %w", err)
-		}
 
 		nrc.nodePeerRouters = peerCfgs.RemoteIPStrings()
 	}
@@ -1456,9 +1448,6 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		nrc.bgpHoldtime,
 		nrc.krNode.GetPrimaryNodeIP().String(),
 	)
-	if err != nil {
-		return nil, fmt.Errorf("error processing Global Peer Router configs: %w", err)
-	}
 
 	bgpLocalAddressListAnnotation, ok := node.Annotations[bgpLocalAddressAnnotation]
 	if !ok {


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

The `newGlobalPeers` function is now infallible, but the err checks weren't removed. Enable the govet linter as a safeguard for this.

#### Which issue(s) this PR is related to:

#### Was AI used during the creation of this PR?

No.

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?

None.

#### Does this PR introduce a breaking change?

```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

