### PR TITLE
Handle kube-bridge setup failures safely

### DIFF
--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -38,6 +38,7 @@ import (
 )
 
 const (
+	// Deprecated: Use [netlink.LinkNotFoundError] instead.
 	IfaceNotFound = "Link not found"
 
 	podSubnetsIPSetName = "kube-router-pod-subnets"
@@ -436,7 +437,7 @@ func (nrc *NetworkRoutingController) initCNIConfig() (mtu int, _ *utils.CNINetwo
 
 func (*NetworkRoutingController) setupKubeBridge(ctx context.Context, mtu int, cniNetConf *utils.CNINetworkConfig) {
 	kubeBridgeIf, err := nlretry.LinkByName(ctx, "kube-bridge")
-	if err != nil && err.Error() == IfaceNotFound {
+	if _, notFound := errors.AsType[netlink.LinkNotFoundError](err); notFound {
 		linkAttrs := netlink.NewLinkAttrs()
 		linkAttrs.Name = "kube-bridge"
 		bridge := &netlink.Bridge{LinkAttrs: linkAttrs}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/goccy/go-yaml"
@@ -435,35 +436,37 @@ func (nrc *NetworkRoutingController) initCNIConfig() (mtu int, _ *utils.CNINetwo
 	return mtu, cniNetConf
 }
 
-func (*NetworkRoutingController) setupKubeBridge(ctx context.Context, mtu int, cniNetConf *utils.CNINetworkConfig) {
+func (nrc *NetworkRoutingController) setupKubeBridge(ctx context.Context, mtu int, cniNetConf *utils.CNINetworkConfig) {
+	skippedAction := "bring it up"
+	if nrc.autoMTU {
+		skippedAction = "bring it up and set the MTU"
+	}
+
 	kubeBridgeIf, err := nlretry.LinkByName(ctx, "kube-bridge")
 	if _, notFound := errors.AsType[netlink.LinkNotFoundError](err); notFound {
 		linkAttrs := netlink.NewLinkAttrs()
 		linkAttrs.Name = "kube-bridge"
 		bridge := &netlink.Bridge{LinkAttrs: linkAttrs}
-		if err = netlink.LinkAdd(bridge); err != nil {
+		if err := netlink.LinkAdd(bridge); err != nil && !errors.Is(err, syscall.EEXIST) {
 			klog.Errorf(
-				"Failed to create `kube-router` bridge due to %s. Will be created by CNI bridge "+
-					"plugin when pod is launched.",
-				err.Error(),
+				"Failed to create kube-bridge interface due to %v. Cannot %s. "+
+					"The CNI bridge plugin may create it when a pod starts.",
+				err, skippedAction,
 			)
+			return
 		}
 		kubeBridgeIf, err = nlretry.LinkByName(ctx, "kube-bridge")
-		if err != nil {
-			klog.Errorf(
-				"Failed to find created `kube-router` bridge due to %s. Will be created by CNI "+
-					"bridge plugin when pod is launched.",
-				err.Error(),
-			)
-		}
-		err = netlink.LinkSetUp(kubeBridgeIf)
-		if err != nil {
-			klog.Errorf(
-				"Failed to bring `kube-router` bridge up due to %s. Will be created by CNI bridge "+
-					"plugin at later point when pod is launched.",
-				err.Error(),
-			)
-		}
+	}
+	if err != nil {
+		klog.Errorf(
+			"Failed to get kube-bridge interface configuration due to %v. Cannot %s.",
+			err, skippedAction,
+		)
+		return
+	}
+
+	if err := netlink.LinkSetUp(kubeBridgeIf); err != nil {
+		klog.Errorf("Failed to bring kube-bridge interface up due to %v.", err)
 	}
 
 	if mtu > 0 {

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -255,57 +255,7 @@ func (nrc *NetworkRoutingController) Run(
 	}
 
 	// create 'kube-bridge' interface to which pods will be connected
-	ctx := context.Background()
-	kubeBridgeIf, err := nlretry.LinkByName(ctx, "kube-bridge")
-	if err != nil && err.Error() == IfaceNotFound {
-		linkAttrs := netlink.NewLinkAttrs()
-		linkAttrs.Name = "kube-bridge"
-		bridge := &netlink.Bridge{LinkAttrs: linkAttrs}
-		if err = netlink.LinkAdd(bridge); err != nil {
-			klog.Errorf(
-				"Failed to create `kube-router` bridge due to %s. Will be created by CNI bridge "+
-					"plugin when pod is launched.",
-				err.Error(),
-			)
-		}
-		kubeBridgeIf, err = nlretry.LinkByName(ctx, "kube-bridge")
-		if err != nil {
-			klog.Errorf(
-				"Failed to find created `kube-router` bridge due to %s. Will be created by CNI "+
-					"bridge plugin when pod is launched.",
-				err.Error(),
-			)
-		}
-		err = netlink.LinkSetUp(kubeBridgeIf)
-		if err != nil {
-			klog.Errorf(
-				"Failed to bring `kube-router` bridge up due to %s. Will be created by CNI bridge "+
-					"plugin at later point when pod is launched.",
-				err.Error(),
-			)
-		}
-	}
-
-	if mtu > 0 {
-		klog.Infof("Setting MTU of kube-bridge interface to: %d", mtu)
-		err = netlink.LinkSetMTU(kubeBridgeIf, mtu)
-		if err != nil {
-			klog.Errorf(
-				"Failed to set MTU for kube-bridge interface due to: %s (kubeBridgeIf: %#v, mtu: %v)",
-				err.Error(),
-				kubeBridgeIf,
-				mtu,
-			)
-			// Update the CNI config to include the effective MTU, if any.
-			if currentMTU := kubeBridgeIf.Attrs().MTU; currentMTU > 0 && cniNetConf != nil && currentMTU != mtu {
-				klog.Warningf(
-					"Updating CNI config with current MTU for kube-bridge: %d",
-					currentMTU,
-				)
-				cniNetConf.SetMTU(currentMTU)
-			}
-		}
-	}
+	nrc.setupKubeBridge(context.TODO(), mtu, cniNetConf)
 
 	if cniNetConf != nil {
 		if err := cniNetConf.WriteCNIConfig(); err != nil {
@@ -482,6 +432,59 @@ func (nrc *NetworkRoutingController) initCNIConfig() (mtu int, _ *utils.CNINetwo
 	}
 
 	return mtu, cniNetConf
+}
+
+func (*NetworkRoutingController) setupKubeBridge(ctx context.Context, mtu int, cniNetConf *utils.CNINetworkConfig) {
+	kubeBridgeIf, err := nlretry.LinkByName(ctx, "kube-bridge")
+	if err != nil && err.Error() == IfaceNotFound {
+		linkAttrs := netlink.NewLinkAttrs()
+		linkAttrs.Name = "kube-bridge"
+		bridge := &netlink.Bridge{LinkAttrs: linkAttrs}
+		if err = netlink.LinkAdd(bridge); err != nil {
+			klog.Errorf(
+				"Failed to create `kube-router` bridge due to %s. Will be created by CNI bridge "+
+					"plugin when pod is launched.",
+				err.Error(),
+			)
+		}
+		kubeBridgeIf, err = nlretry.LinkByName(ctx, "kube-bridge")
+		if err != nil {
+			klog.Errorf(
+				"Failed to find created `kube-router` bridge due to %s. Will be created by CNI "+
+					"bridge plugin when pod is launched.",
+				err.Error(),
+			)
+		}
+		err = netlink.LinkSetUp(kubeBridgeIf)
+		if err != nil {
+			klog.Errorf(
+				"Failed to bring `kube-router` bridge up due to %s. Will be created by CNI bridge "+
+					"plugin at later point when pod is launched.",
+				err.Error(),
+			)
+		}
+	}
+
+	if mtu > 0 {
+		klog.Infof("Setting MTU of kube-bridge interface to: %d", mtu)
+		err = netlink.LinkSetMTU(kubeBridgeIf, mtu)
+		if err != nil {
+			klog.Errorf(
+				"Failed to set MTU for kube-bridge interface due to: %s (kubeBridgeIf: %#v, mtu: %v)",
+				err.Error(),
+				kubeBridgeIf,
+				mtu,
+			)
+			// Update the CNI config to include the effective MTU, if any.
+			if currentMTU := kubeBridgeIf.Attrs().MTU; currentMTU > 0 && cniNetConf != nil && currentMTU != mtu {
+				klog.Warningf(
+					"Updating CNI config with current MTU for kube-bridge: %d",
+					currentMTU,
+				)
+				cniNetConf.SetMTU(currentMTU)
+			}
+		}
+	}
 }
 
 func (nrc *NetworkRoutingController) watchBgpUpdates() {


### PR DESCRIPTION
#### What type of PR is this?

bug
cleanup

#### What this PR does / why we need it:

Move the kube-bridge setup into its own method. It's all self-contained, so moving it makes it clear and easier to reason about.

Return early when the kube-bridge lookup fails, so that the link setup won't panic with a nil pointer access. Also return early when the bridge creation fails for any reason other than the bridge already existing. Use netlink's [LinkNotFoundError] for that, which is supposedly the idiomatic way to determine if a link was not found. Deprecate the public string constant. Clarify the error messages and describe which follow-up actions are skipped.

[LinkNotFoundError]: https://pkg.go.dev/github.com/vishvananda/netlink@v1.3.1#LinkNotFoundError

#### Was AI used during the creation of this PR?

Yes, for local code review.

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?

None.

#### Does this PR introduce a breaking change?

```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

