### PR TITLE
Move the go directive to the top of go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/cloudnativelabs/kube-router/v2
 
+go 1.26.0
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.26
@@ -137,8 +139,6 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
-
-go 1.26.0
 
 tool (
 	github.com/matryer/moq


### PR DESCRIPTION
#### What type of PR is this?

cleanup

#### What this PR does / why we need it:

Makes it easier for humans to spot the language baseline. Missed it at first glance, because I'm not used to have directives _after_ the (usually huge) require block for indirect dependencies.

#### Which issue(s) this PR is related to:

#### Was AI used during the creation of this PR?

No.

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?

None.

#### Does this PR introduce a breaking change?

No.

```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

Not sure about the tool directive. It's also buried at the end of the file, but not sure what'd be a better place for it.