### PR TITLE
Implement BFD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ DOCTOC_VERSION=2.4.1
 # See Versions: https://github.com/crate-ci/typos/releases
 TYPOS_VERSION=v1.46.3
 # See Versions: https://github.com/osrg/gobgp/releases
-GOBGP_VERSION=5f191066a78e2c1e929c54b5b75fe2c683c166e4  # v4.5.0
+GOBGP_VERSION=8b5edc2c55cbec9e7df33123a07811a119d44542  # v4.7.0
 QEMU_IMAGE?=multiarch/qemu-user-static:7.2.0-1@sha256:fe60359c92e86a43cc87b3d906006245f77bfc0565676b80004cc666e4feb9f0
 # See Versions: https://github.com/goreleaser/goreleaser/releases
 GORELEASER_VERSION=v2.16.0

--- a/docs/bgp.md
+++ b/docs/bgp.md
@@ -24,6 +24,9 @@ pod IPs, service IPs, etc.).
   - [Restoring pre-2.9.0 behavior](#restoring-pre-290-behavior)
 - [Overriding the next hop](#overriding-the-next-hop)
 - [Overriding the next hop and enable IPIP/tunnel](#overriding-the-next-hop-and-enable-ipiptunnel)
+- [BFD (Bidirectional Forwarding Detection)](#bfd-bidirectional-forwarding-detection)
+  - [Configuring BFD](#configuring-bfd)
+  - [BFD & Graceful Restart](#bfd--graceful-restart)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -358,3 +361,57 @@ Specifically, people need to take care when combining `--override-nexthop` and `
 they understand their network, the flows they desire, how the kube-router logic works, and the possible side effects
 that are created from their configuration. Please refer to [this PR](https://github.com/cloudnativelabs/kube-router/pull/1025)
 for the risk and impact discussion.
+
+## BFD (Bidirectional Forwarding Detection)
+
+kube-router integrates GoBGP's support for BFD for external peers. Please review GoBGP's
+[docs on BFD](https://github.com/osrg/gobgp/blob/master/docs/sources/bfd.md)
+for details on features and limitations, as GoBGP's implementation for BFD is new,
+and does not support all features.
+
+### Configuring BFD
+
+You can configure BFD settings either through CLI flags for global external BGP peers
+or configure them on a per-node basis. Ensure that detection multiplier,
+required min RX interval, and desired min TX interval to either match or
+are slower than the settings configured on the peer, as GoBGP does not currently
+handle timer negotiation. Note that required min RX interval and desired min TX
+interval are both in _microseconds_, as some implementations of BFD (such as FRR)
+handle timer values in milliseconds.
+
+**Global External BGP Peers:**
+
+You can enable BFD for global external BGP peers by specifying: `--enable-bfd=true`.
+BFD timer settings can be configured via `--bfd-detection-multiplier`,
+`--bfd-required-min-rx-interval`, and `--bfd-desired-min-tx-interval`. Each of these
+flags only accept one value to configure BFD settings for all peers. If different
+BFD configurations are required for external peers, please use the per-node BGP
+annotations.
+
+**Per-Node BFD Configuration:**
+
+Per-node BFD settings can be configured via the `kube-router.io/peers` annotation:
+
+```yaml
+- remoteip: 192.168.1.99
+  remoteasn: 65000
+  password: "<b64 encoded password here>"
+  bfd:
+    enabled: true
+    port: 3785
+    detection_multiplier: 2
+    required_min_rx_interval: 1000000
+    desired_min_tx_interval: 1000000
+```
+
+Per-node BFD settings are _not_ supported via the individual BGP node annotations,
+which have been deprecated since v2.7.0.
+
+### BFD & Graceful Restart
+
+kube-router will log warnings when BFD and graceful restart are both configured.
+Configuring both BFD and graceful restart is not recommended as they have contradictory
+effects and can cause inconsistent routing behavior depending on vendor implementation.
+In GoBGP, if BFD and graceful restart are both configured and a peer is
+detected as down, graceful restart seems to be bypassed and peer routes are
+immediately flushed.

--- a/docs/bgp.md
+++ b/docs/bgp.md
@@ -376,8 +376,7 @@ or configure them on a per-node basis. Ensure that detection multiplier,
 required min RX interval, and desired min TX interval to either match or
 are slower than the settings configured on the peer, as GoBGP does not currently
 handle timer negotiation. Note that required min RX interval and desired min TX
-interval are both in _microseconds_, as some implementations of BFD (such as FRR)
-handle timer values in milliseconds.
+interval are both in _milliseconds_, instead of microseconds, which GoBGP uses.
 
 **Global External BGP Peers:**
 
@@ -400,8 +399,8 @@ Per-node BFD settings can be configured via the `kube-router.io/peers` annotatio
     enabled: true
     port: 3785
     detection_multiplier: 2
-    required_min_rx_interval: 1000000
-    desired_min_tx_interval: 1000000
+    required_min_rx_interval: 1000
+    desired_min_tx_interval: 1000
 ```
 
 Per-node BFD settings are _not_ supported via the individual BGP node annotations,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -114,6 +114,10 @@ Usage of kube-router:
       --advertise-loadbalancer-ip                     Add LoadBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
       --advertise-pod-cidr                            Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
       --auto-mtu                                      Auto detect and set the largest possible MTU for kube-bridge and pod interfaces (also accounts for IPIP overlay network when enabled). (default true)
+      --bfd-desired-min-tx-interval uint32            The desired min interval in microseconds for GoBGP to transmit BFD control packets. (default 1000000)
+      --bfd-detection-multiplier uint32               BFD failure detection multiplier. Must be between 1-255. (default 3)
+      --bfd-port uint32                               UDP port for BFD control packets (default 3784)
+      --bfd-required-min-rx-interval uint32           Min interval in microseconds for GoBGP to receive BFD control packets. (default 1000000)
       --bgp-graceful-restart                          Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
       --bgp-graceful-restart-deferral-time duration   BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h. (default 6m0s)
       --bgp-graceful-restart-time duration            BGP Graceful restart time according to RFC4724 3, maximum 4095s. (default 1m30s)
@@ -123,6 +127,7 @@ Usage of kube-router:
       --cleanup-config                                Cleanup iptables rules, ipvs, ipset configuration and exit.
       --cluster-asn uint                              ASN number under which cluster nodes will run iBGP.
       --disable-source-dest-check                     Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be set some other way. (default true)
+      --enable-bfd                                    Enable BFD for GoBGP
       --enable-cni                                    Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin. (default true)
       --enable-ibgp                                   Enables peering with nodes with the same ASN, if disabled will only peer with external BGP peers (default true)
       --enable-ipv4                                   Enables IPv4 support (default true)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -114,10 +114,10 @@ Usage of kube-router:
       --advertise-loadbalancer-ip                     Add LoadBalancer IP of service status as set by the LB provider to the RIB so that it gets advertised to the BGP peers.
       --advertise-pod-cidr                            Add Node's POD cidr to the RIB so that it gets advertised to the BGP peers. (default true)
       --auto-mtu                                      Auto detect and set the largest possible MTU for kube-bridge and pod interfaces (also accounts for IPIP overlay network when enabled). (default true)
-      --bfd-desired-min-tx-interval uint32            The desired min interval in microseconds for GoBGP to transmit BFD control packets. (default 1000000)
+      --bfd-desired-min-tx-interval uint32            The desired min interval in milliseconds for GoBGP to transmit BFD control packets. (default 1000)
       --bfd-detection-multiplier uint32               BFD failure detection multiplier. Must be between 1-255. (default 3)
       --bfd-port uint32                               UDP port for BFD control packets (default 3784)
-      --bfd-required-min-rx-interval uint32           Min interval in microseconds for GoBGP to receive BFD control packets. (default 1000000)
+      --bfd-required-min-rx-interval uint32           Min interval in milliseconds for GoBGP to receive BFD control packets. (default 1000)
       --bgp-graceful-restart                          Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts
       --bgp-graceful-restart-deferral-time duration   BGP Graceful restart deferral time according to RFC4724 4.1, maximum 18h. (default 6m0s)
       --bgp-graceful-restart-time duration            BGP Graceful restart time according to RFC4724 3, maximum 4095s. (default 1m30s)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudnativelabs/kube-router/v2
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.0
@@ -16,7 +16,7 @@ require (
 	github.com/hashicorp/go-version v1.9.0
 	github.com/moby/ipvs v1.1.0
 	github.com/moby/moby/client v0.5.0
-	github.com/osrg/gobgp/v4 v4.5.0
+	github.com/osrg/gobgp/v4 v4.7.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudnativelabs/kube-router/v2
 
-go 1.26.0
+go 1.26.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1
@@ -18,7 +18,7 @@ require (
 	github.com/moby/moby/client v0.5.0
 	github.com/onsi/ginkgo/v2 v2.25.3
 	github.com/onsi/gomega v1.42.1
-	github.com/osrg/gobgp/v4 v4.5.0
+	github.com/osrg/gobgp/v4 v4.7.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -175,8 +175,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=
 github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
-github.com/osrg/gobgp/v4 v4.5.0 h1:1jS4cMxUYSo36UfDyigLOLYEg6Oh+9I2mrnjjgAGCFk=
-github.com/osrg/gobgp/v4 v4.5.0/go.mod h1:pgu8waqTvZUYl4eQuPrKNOaVwhHv7Zt9YymuzCaX7f8=
+github.com/osrg/gobgp/v4 v4.7.0 h1:KPnmJVDFx1AJ39ESNpzHukAzaQYa4kRR5c7BbuDJhuM=
+github.com/osrg/gobgp/v4 v4.7.0/go.mod h1:j1GLEuE20jm2YAoGmaHGb3y9lGH/KBgCBT4Ss5RY/wQ=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=
 github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
-github.com/osrg/gobgp/v4 v4.5.0 h1:1jS4cMxUYSo36UfDyigLOLYEg6Oh+9I2mrnjjgAGCFk=
-github.com/osrg/gobgp/v4 v4.5.0/go.mod h1:pgu8waqTvZUYl4eQuPrKNOaVwhHv7Zt9YymuzCaX7f8=
+github.com/osrg/gobgp/v4 v4.7.0 h1:KPnmJVDFx1AJ39ESNpzHukAzaQYa4kRR5c7BbuDJhuM=
+github.com/osrg/gobgp/v4 v4.7.0/go.mod h1:j1GLEuE20jm2YAoGmaHGb3y9lGH/KBgCBT4Ss5RY/wQ=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/bgp/bfd.go
+++ b/pkg/bgp/bfd.go
@@ -1,0 +1,52 @@
+package bgp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cloudnativelabs/kube-router/v2/pkg/options"
+	gobgpapi "github.com/osrg/gobgp/v4/api"
+	"k8s.io/utils/ptr"
+)
+
+type BFDConfig struct {
+	Enabled bool    `yaml:"enabled"`
+	Port    *uint32 `yaml:"port"`
+
+	DesiredMinTxInterval  *uint32 `yaml:"desired_min_tx_interval"`
+	DetectionMultiplier   *uint32 `yaml:"detection_multiplier"`
+	RequiredMinRxInterval *uint32 `yaml:"required_min_rx_interval"`
+}
+
+func (b BFDConfig) String() string {
+	fields := []string{fmt.Sprintf("Enabled: %t", b.Enabled)}
+	if b.Port != nil {
+		fields = append(fields, fmt.Sprintf("Port: %d", *b.Port))
+	}
+	if b.DesiredMinTxInterval != nil {
+		fields = append(fields, fmt.Sprintf("DesiredMinTxInterval: %d", *b.DesiredMinTxInterval))
+	}
+	if b.DetectionMultiplier != nil {
+		fields = append(fields, fmt.Sprintf("DetectionMultiplier: %d", *b.DetectionMultiplier))
+	}
+	if b.RequiredMinRxInterval != nil {
+		fields = append(fields, fmt.Sprintf("RequiredMinRxInterval: %d", *b.RequiredMinRxInterval))
+	}
+	return fmt.Sprintf("BFDConfig{%s}", strings.Join(fields, ", "))
+}
+
+// ToGoBGP builds the GoBGP API config for BFD settings. Returns nil
+// if BFDConfig is not enabled.
+func (b BFDConfig) ToGoBGP() *gobgpapi.BfdPeerConfig {
+	if !b.Enabled {
+		return nil
+	}
+
+	return &gobgpapi.BfdPeerConfig{
+		Enabled:                  true,
+		Port:                     ptr.Deref(b.Port, options.DefaultBFDPort),
+		DetectionMultiplier:      ptr.Deref(b.DetectionMultiplier, options.DefaultBFDDetectionMultiplier),
+		DesiredMinimumTxInterval: ptr.Deref(b.DesiredMinTxInterval, options.DefaultBFDDesiredMinTxInterval),
+		RequiredMinimumReceive:   ptr.Deref(b.RequiredMinRxInterval, options.DefaultBFDRequiredMinRxInterval),
+	}
+}

--- a/pkg/bgp/bfd.go
+++ b/pkg/bgp/bfd.go
@@ -2,11 +2,19 @@ package bgp
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/cloudnativelabs/kube-router/v2/pkg/options"
 	gobgpapi "github.com/osrg/gobgp/v4/api"
 	"k8s.io/utils/ptr"
+)
+
+const (
+	BFDDetectionMultiplierMax = 255 // RFC 5880 defines detect_mult as an 8-bit field
+	BFDPortMax                = 65535
+	BFDIntervalMax            = math.MaxUint32 / msToMicroseconds
+	msToMicroseconds          = 1000
 )
 
 type BFDConfig struct {
@@ -35,6 +43,33 @@ func (b BFDConfig) String() string {
 	return fmt.Sprintf("BFDConfig{%s}", strings.Join(fields, ", "))
 }
 
+func (b BFDConfig) Validate() error {
+	if b.Port != nil {
+		if *b.Port == 0 || *b.Port > BFDPortMax {
+			return fmt.Errorf("bfd port must be between 1 and %d, got %d", BFDPortMax, *b.Port)
+		}
+	}
+	if b.DetectionMultiplier != nil {
+		if *b.DetectionMultiplier == 0 || *b.DetectionMultiplier > BFDDetectionMultiplierMax {
+			return fmt.Errorf("bfd detection multiplier must be between 1 and %d, got %d",
+				BFDDetectionMultiplierMax, *b.DetectionMultiplier)
+		}
+	}
+	if b.DesiredMinTxInterval != nil {
+		if *b.DesiredMinTxInterval == 0 || *b.DesiredMinTxInterval > BFDIntervalMax {
+			return fmt.Errorf("bfd desired min tx interval must be between 1 and %d milliseconds, got %d",
+				BFDIntervalMax, *b.DesiredMinTxInterval)
+		}
+	}
+	if b.RequiredMinRxInterval != nil {
+		if *b.RequiredMinRxInterval == 0 || *b.RequiredMinRxInterval > BFDIntervalMax {
+			return fmt.Errorf("bfd required min rx interval must be between 1 and %d milliseconds, got %d",
+				BFDIntervalMax, *b.RequiredMinRxInterval)
+		}
+	}
+	return nil
+}
+
 // ToGoBGP builds the GoBGP API config for BFD settings. Returns nil
 // if BFDConfig is not enabled.
 func (b BFDConfig) ToGoBGP() *gobgpapi.BfdPeerConfig {
@@ -42,11 +77,13 @@ func (b BFDConfig) ToGoBGP() *gobgpapi.BfdPeerConfig {
 		return nil
 	}
 
+	txMs := ptr.Deref(b.DesiredMinTxInterval, options.DefaultBFDDesiredMinTxInterval)
+	rxMs := ptr.Deref(b.RequiredMinRxInterval, options.DefaultBFDRequiredMinRxInterval)
 	return &gobgpapi.BfdPeerConfig{
 		Enabled:                  true,
 		Port:                     ptr.Deref(b.Port, options.DefaultBFDPort),
 		DetectionMultiplier:      ptr.Deref(b.DetectionMultiplier, options.DefaultBFDDetectionMultiplier),
-		DesiredMinimumTxInterval: ptr.Deref(b.DesiredMinTxInterval, options.DefaultBFDDesiredMinTxInterval) * 1000,
-		RequiredMinimumReceive:   ptr.Deref(b.RequiredMinRxInterval, options.DefaultBFDRequiredMinRxInterval) * 1000,
+		DesiredMinimumTxInterval: txMs * msToMicroseconds,
+		RequiredMinimumReceive:   rxMs * msToMicroseconds,
 	}
 }

--- a/pkg/bgp/bfd.go
+++ b/pkg/bgp/bfd.go
@@ -46,7 +46,7 @@ func (b BFDConfig) ToGoBGP() *gobgpapi.BfdPeerConfig {
 		Enabled:                  true,
 		Port:                     ptr.Deref(b.Port, options.DefaultBFDPort),
 		DetectionMultiplier:      ptr.Deref(b.DetectionMultiplier, options.DefaultBFDDetectionMultiplier),
-		DesiredMinimumTxInterval: ptr.Deref(b.DesiredMinTxInterval, options.DefaultBFDDesiredMinTxInterval),
-		RequiredMinimumReceive:   ptr.Deref(b.RequiredMinRxInterval, options.DefaultBFDRequiredMinRxInterval),
+		DesiredMinimumTxInterval: ptr.Deref(b.DesiredMinTxInterval, options.DefaultBFDDesiredMinTxInterval) * 1000,
+		RequiredMinimumReceive:   ptr.Deref(b.RequiredMinRxInterval, options.DefaultBFDRequiredMinRxInterval) * 1000,
 	}
 }

--- a/pkg/bgp/bfd_test.go
+++ b/pkg/bgp/bfd_test.go
@@ -1,0 +1,129 @@
+package bgp
+
+import (
+	"testing"
+
+	"github.com/cloudnativelabs/kube-router/v2/pkg/options"
+	gobgpapi "github.com/osrg/gobgp/v4/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBFDConfig_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   BFDConfig
+		expected string
+	}{
+		{
+			name:     "empty config",
+			config:   BFDConfig{},
+			expected: "BFDConfig{Enabled: false}",
+		},
+		{
+			name: "Enabled",
+			config: BFDConfig{
+				Enabled: true,
+			},
+			expected: "BFDConfig{Enabled: true}",
+		},
+		{
+			name: "Port",
+			config: BFDConfig{
+				Port: new(uint32(3784)),
+			},
+			expected: "BFDConfig{Enabled: false, Port: 3784}",
+		},
+		{
+			name: "All fields set",
+			config: BFDConfig{
+				Enabled:               true,
+				Port:                  new(uint32(3785)),
+				DesiredMinTxInterval:  new(uint32(2000000)),
+				DetectionMultiplier:   new(uint32(5)),
+				RequiredMinRxInterval: new(uint32(1000000)),
+			},
+			expected: "BFDConfig{Enabled: true, Port: 3785, DesiredMinTxInterval: 2000000, DetectionMultiplier: 5, RequiredMinRxInterval: 1000000}",
+		},
+		{
+			name: "Some fields set",
+			config: BFDConfig{
+				Enabled:              true,
+				DetectionMultiplier:  new(uint32(3)),
+				DesiredMinTxInterval: new(uint32(1000000)),
+			},
+			expected: "BFDConfig{Enabled: true, DesiredMinTxInterval: 1000000, DetectionMultiplier: 3}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(st *testing.T) {
+			result := tt.config.String()
+			assert.Equal(st, tt.expected, result)
+		})
+	}
+}
+
+func TestBFDConfig_ToGoBGP(t *testing.T) {
+	tests := []struct {
+		name     string
+		peer     BFDConfig
+		expected *gobgpapi.BfdPeerConfig
+	}{
+		{
+			name: "bfd not enabled returns nil",
+			peer: BFDConfig{Port: new(uint32(5000))},
+		},
+		{
+			name: "no fields set, use defaults",
+			peer: BFDConfig{
+				Enabled: true,
+			},
+			expected: &gobgpapi.BfdPeerConfig{
+				Enabled:                  true,
+				Port:                     options.DefaultBFDPort,
+				DetectionMultiplier:      options.DefaultBFDDetectionMultiplier,
+				DesiredMinimumTxInterval: options.DefaultBFDDesiredMinTxInterval,
+				RequiredMinimumReceive:   options.DefaultBFDRequiredMinRxInterval,
+			},
+		},
+		{
+			name: "fields not set are set with defaults",
+			peer: BFDConfig{
+				Enabled:              true,
+				DetectionMultiplier:  new(uint32(5)),
+				DesiredMinTxInterval: new(uint32(2000000)),
+			},
+			expected: &gobgpapi.BfdPeerConfig{
+				Enabled:                  true,
+				Port:                     3784,
+				DetectionMultiplier:      5,
+				DesiredMinimumTxInterval: 2000000,
+				RequiredMinimumReceive:   options.DefaultBFDRequiredMinRxInterval,
+			},
+		},
+		{
+			name: "all fields set, not overridden by defaults",
+			peer: BFDConfig{
+				Enabled:               true,
+				Port:                  new(uint32(3785)),
+				DetectionMultiplier:   new(uint32(2)),
+				DesiredMinTxInterval:  new(uint32(2000000)),
+				RequiredMinRxInterval: new(uint32(2000000)),
+			},
+			expected: &gobgpapi.BfdPeerConfig{
+				Enabled:                  true,
+				Port:                     3785,
+				DetectionMultiplier:      2,
+				DesiredMinimumTxInterval: 2000000,
+				RequiredMinimumReceive:   2000000,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.peer.ToGoBGP()
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/bgp/bfd_test.go
+++ b/pkg/bgp/bfd_test.go
@@ -127,3 +127,81 @@ func TestBFDConfig_ToGoBGP(t *testing.T) {
 		})
 	}
 }
+
+func TestBFDConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        BFDConfig
+		errorContains string
+	}{
+		{
+			name: "valid config",
+			config: BFDConfig{
+				Enabled:               true,
+				Port:                  new(uint32(65535)),
+				DetectionMultiplier:   new(uint32(255)),
+				DesiredMinTxInterval:  new(uint32(BFDIntervalMax)),
+				RequiredMinRxInterval: new(uint32(BFDIntervalMax)),
+			},
+		},
+		{
+			name:   "empty config is valid",
+			config: BFDConfig{},
+		},
+		{
+			name:   "enabled with defaults is valid",
+			config: BFDConfig{Enabled: true},
+		},
+		{
+			name:          "port cannot be 0",
+			config:        BFDConfig{Port: new(uint32(0))},
+			errorContains: "bfd port must be between",
+		},
+		{
+			name:          "port cannot be above 65535",
+			config:        BFDConfig{Port: new(uint32(65536))},
+			errorContains: "bfd port must be between",
+		},
+		{
+			name:          "detection multiplier cannot be zero",
+			config:        BFDConfig{DetectionMultiplier: new(uint32(0))},
+			errorContains: "detection multiplier must be between",
+		},
+		{
+			name:          "detection multiplier cannot be above 255",
+			config:        BFDConfig{DetectionMultiplier: new(uint32(256))},
+			errorContains: "detection multiplier must be between",
+		},
+		{
+			name:          "desired min tx interval cannot be zero",
+			config:        BFDConfig{DesiredMinTxInterval: new(uint32(0))},
+			errorContains: "desired min tx interval must be between",
+		},
+		{
+			name:          "desired min tx interval cannot be greater than value that would cause uint32 overflow as microseconds",
+			config:        BFDConfig{DesiredMinTxInterval: new(uint32(BFDIntervalMax + 1))},
+			errorContains: "desired min tx interval must be between",
+		},
+		{
+			name:          "required rx interval cannot be zero",
+			config:        BFDConfig{RequiredMinRxInterval: new(uint32(0))},
+			errorContains: "required min rx interval must be between",
+		},
+		{
+			name:          "required rx interval cannot be greater than value that would cause uint32 overflow as microseconds",
+			config:        BFDConfig{RequiredMinRxInterval: new(uint32(BFDIntervalMax + 1))},
+			errorContains: "required min rx interval must be between",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.errorContains != "" {
+				assert.ErrorContains(t, err, tt.errorContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/bgp/bfd_test.go
+++ b/pkg/bgp/bfd_test.go
@@ -38,20 +38,20 @@ func TestBFDConfig_String(t *testing.T) {
 			config: BFDConfig{
 				Enabled:               true,
 				Port:                  new(uint32(3785)),
-				DesiredMinTxInterval:  new(uint32(2000000)),
+				DesiredMinTxInterval:  new(uint32(2000)),
 				DetectionMultiplier:   new(uint32(5)),
-				RequiredMinRxInterval: new(uint32(1000000)),
+				RequiredMinRxInterval: new(uint32(1000)),
 			},
-			expected: "BFDConfig{Enabled: true, Port: 3785, DesiredMinTxInterval: 2000000, DetectionMultiplier: 5, RequiredMinRxInterval: 1000000}",
+			expected: "BFDConfig{Enabled: true, Port: 3785, DesiredMinTxInterval: 2000, DetectionMultiplier: 5, RequiredMinRxInterval: 1000}",
 		},
 		{
 			name: "Some fields set",
 			config: BFDConfig{
 				Enabled:              true,
 				DetectionMultiplier:  new(uint32(3)),
-				DesiredMinTxInterval: new(uint32(1000000)),
+				DesiredMinTxInterval: new(uint32(1000)),
 			},
-			expected: "BFDConfig{Enabled: true, DesiredMinTxInterval: 1000000, DetectionMultiplier: 3}",
+			expected: "BFDConfig{Enabled: true, DesiredMinTxInterval: 1000, DetectionMultiplier: 3}",
 		},
 	}
 
@@ -82,8 +82,8 @@ func TestBFDConfig_ToGoBGP(t *testing.T) {
 				Enabled:                  true,
 				Port:                     options.DefaultBFDPort,
 				DetectionMultiplier:      options.DefaultBFDDetectionMultiplier,
-				DesiredMinimumTxInterval: options.DefaultBFDDesiredMinTxInterval,
-				RequiredMinimumReceive:   options.DefaultBFDRequiredMinRxInterval,
+				DesiredMinimumTxInterval: options.DefaultBFDDesiredMinTxInterval * 1000,
+				RequiredMinimumReceive:   options.DefaultBFDRequiredMinRxInterval * 1000,
 			},
 		},
 		{
@@ -91,14 +91,14 @@ func TestBFDConfig_ToGoBGP(t *testing.T) {
 			peer: BFDConfig{
 				Enabled:              true,
 				DetectionMultiplier:  new(uint32(5)),
-				DesiredMinTxInterval: new(uint32(2000000)),
+				DesiredMinTxInterval: new(uint32(2000)),
 			},
 			expected: &gobgpapi.BfdPeerConfig{
 				Enabled:                  true,
 				Port:                     3784,
 				DetectionMultiplier:      5,
 				DesiredMinimumTxInterval: 2000000,
-				RequiredMinimumReceive:   options.DefaultBFDRequiredMinRxInterval,
+				RequiredMinimumReceive:   options.DefaultBFDRequiredMinRxInterval * 1000,
 			},
 		},
 		{
@@ -107,8 +107,8 @@ func TestBFDConfig_ToGoBGP(t *testing.T) {
 				Enabled:               true,
 				Port:                  new(uint32(3785)),
 				DetectionMultiplier:   new(uint32(2)),
-				DesiredMinTxInterval:  new(uint32(2000000)),
-				RequiredMinRxInterval: new(uint32(2000000)),
+				DesiredMinTxInterval:  new(uint32(2000)),
+				RequiredMinRxInterval: new(uint32(2000)),
 			},
 			expected: &gobgpapi.BfdPeerConfig{
 				Enabled:                  true,

--- a/pkg/bgp/peer_config.go
+++ b/pkg/bgp/peer_config.go
@@ -18,10 +18,11 @@ type PeerConfig struct {
 	localIP   string             `yaml:"localip"`
 	password  utils.Base64String `yaml:"password"`
 	port      *uint32            `yaml:"port"`
+	bfd       BFDConfig          `yaml:"bfd"`
 }
 
 func NewPeerConfig(remoteIPStr string, remoteASN uint32, port *uint32, b64EncodedPassword utils.Base64String,
-	localIP string,
+	localIP string, bfd BFDConfig,
 ) (PeerConfig, error) {
 	remoteIP := net.ParseIP(remoteIPStr)
 	if remoteIP == nil {
@@ -37,6 +38,7 @@ func NewPeerConfig(remoteIPStr string, remoteASN uint32, port *uint32, b64Encode
 		localIP:   localIP,
 		password:  b64EncodedPassword,
 		port:      port,
+		bfd:       bfd,
 	}, nil
 }
 
@@ -60,6 +62,10 @@ func (p PeerConfig) Port() *uint32 {
 	return p.port
 }
 
+func (p PeerConfig) BFD() BFDConfig {
+	return p.bfd
+}
+
 // Custom Stringer to prevent leaking passwords when printed
 func (p PeerConfig) String() string {
 	var fields []string
@@ -75,6 +81,9 @@ func (p PeerConfig) String() string {
 	if p.remoteIP != nil {
 		fields = append(fields, fmt.Sprintf("RemoteIP: %v", p.remoteIP))
 	}
+	if p.bfd.Enabled {
+		fields = append(fields, fmt.Sprintf("BFD: %v", p.bfd))
+	}
 	return fmt.Sprintf("PeerConfig{%s}", strings.Join(fields, ", "))
 }
 
@@ -85,6 +94,7 @@ func (p *PeerConfig) UnmarshalYAML(raw []byte) error {
 		Port      *uint32             `yaml:"port"`
 		RemoteASN *uint32             `yaml:"remoteasn"`
 		RemoteIP  *string             `yaml:"remoteip"`
+		Bfd       BFDConfig           `yaml:"bfd"`
 	}{}
 
 	if err := yaml.Unmarshal(raw, &tmp); err != nil {
@@ -108,6 +118,7 @@ func (p *PeerConfig) UnmarshalYAML(raw []byte) error {
 	}
 	p.port = tmp.Port
 	p.remoteASN = *tmp.RemoteASN
+	p.bfd = tmp.Bfd
 	ip := net.ParseIP(*tmp.RemoteIP)
 	if ip == nil {
 		return fmt.Errorf("%s is not a valid IP address", *tmp.RemoteIP)
@@ -142,6 +153,7 @@ func NewPeerConfigs(
 	b64EncodedPasswords []string,
 	localIPs []string,
 	localAddress string,
+	globalBFDConfig BFDConfig,
 ) (PeerConfigs, error) {
 	if len(remoteIPs) != len(remoteASNs) {
 		return nil, errors.New("invalid peer router config, the number of IPs and ASN numbers must be equal")
@@ -175,7 +187,7 @@ func NewPeerConfigs(
 		if len(localIPs) != 0 {
 			localIP = localIPs[i]
 		}
-		peerCfg, err := NewPeerConfig(remoteIP, remoteASNs[i], port, pw, localIP)
+		peerCfg, err := NewPeerConfig(remoteIP, remoteASNs[i], port, pw, localIP, globalBFDConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/bgp/peer_config.go
+++ b/pkg/bgp/peer_config.go
@@ -31,6 +31,9 @@ func NewPeerConfig(remoteIPStr string, remoteASN uint32, port *uint32, b64Encode
 	if err := validateASN(remoteASN); err != nil {
 		return PeerConfig{}, err
 	}
+	if err := bfd.Validate(); err != nil {
+		return PeerConfig{}, err
+	}
 
 	return PeerConfig{
 		remoteIP:  remoteIP,
@@ -108,6 +111,9 @@ func (p *PeerConfig) UnmarshalYAML(raw []byte) error {
 		return errors.New("remoteasn cannot be empty")
 	}
 	if err := validateASN(*tmp.RemoteASN); err != nil {
+		return err
+	}
+	if err := tmp.Bfd.Validate(); err != nil {
 		return err
 	}
 	if tmp.LocalIP != nil {

--- a/pkg/bgp/peer_config_test.go
+++ b/pkg/bgp/peer_config_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestPeerConfig_String(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		config   PeerConfig
@@ -189,6 +190,30 @@ func TestPeerConfigs_String(t *testing.T) {
 			},
 			expected: "PeerConfigs[PeerConfig{LocalIP: 192.168.1.1, RemoteASN: 65000, RemoteIP: 10.0.0.1},PeerConfig{Port: 179, RemoteASN: 65001, RemoteIP: 10.0.0.2},PeerConfig{RemoteIP: 10.0.0.3}]",
 		},
+		{
+			name: "PeerConfigs - with BFD config",
+			configs: PeerConfigs{
+				{
+					localIP:   "192.168.1.1",
+					password:  utils.Base64String("secret"),
+					remoteASN: uint32(65000),
+					remoteIP:  net.ParseIP("10.0.0.1"),
+					bfd: BFDConfig{
+						Enabled: true,
+						Port:    new(uint32(13784)),
+					},
+				},
+				{
+					port:      new(uint32(179)),
+					remoteASN: uint32(65001),
+					remoteIP:  net.ParseIP("10.0.0.2"),
+				},
+				{
+					remoteIP: net.ParseIP("10.0.0.3"),
+				},
+			},
+			expected: "PeerConfigs[PeerConfig{LocalIP: 192.168.1.1, RemoteASN: 65000, RemoteIP: 10.0.0.1, BFD: BFDConfig{Enabled: true, Port: 13784}},PeerConfig{Port: 179, RemoteASN: 65001, RemoteIP: 10.0.0.2},PeerConfig{RemoteIP: 10.0.0.3}]",
+		},
 	}
 
 	for _, tt := range tests {
@@ -199,6 +224,7 @@ func TestPeerConfigs_String(t *testing.T) {
 }
 
 func Test_NewPeerConfigs(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                string
 		remoteIPs           []string
@@ -207,6 +233,7 @@ func Test_NewPeerConfigs(t *testing.T) {
 		b64EncodedPasswords []string
 		localIPs            []string
 		localAddress        string
+		bfdConfig           BFDConfig
 		errorContains       string
 	}{
 		{
@@ -245,15 +272,41 @@ func Test_NewPeerConfigs(t *testing.T) {
 			remoteASNs:    []uint32{0, 2345},
 			errorContains: "reserved ASN",
 		},
+		{
+			name:       "BFD config is propagated to all peers",
+			remoteIPs:  []string{"10.0.0.1", "10.0.0.2"},
+			remoteASNs: []uint32{1234, 2345},
+			bfdConfig: BFDConfig{
+				Enabled:               true,
+				Port:                  new(uint32(37850)),
+				DetectionMultiplier:   new(uint32(3)),
+				DesiredMinTxInterval:  new(uint32(100)),
+				RequiredMinRxInterval: new(uint32(100)),
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewPeerConfigs(tt.remoteIPs, tt.remoteASNs, tt.ports, tt.b64EncodedPasswords, tt.localIPs, tt.localAddress)
+			t.Parallel()
+			peerCfgs, err := NewPeerConfigs(tt.remoteIPs, tt.remoteASNs, tt.ports, tt.b64EncodedPasswords, tt.localIPs, tt.localAddress, tt.bfdConfig)
 			if tt.errorContains != "" {
 				assert.ErrorContains(t, err, tt.errorContains)
 			} else {
 				assert.NoError(t, err)
+				if len(peerCfgs) > 0 && tt.bfdConfig.Enabled {
+					for i, pc := range peerCfgs {
+						if !pc.BFD().Enabled {
+							t.Errorf("peer %d should have BFD enabled", i)
+						}
+						if pc.BFD().Port == nil || *pc.BFD().Port != *tt.bfdConfig.Port {
+							t.Errorf("peer %d BFD port mismatch: expected %d, got %v", i, *tt.bfdConfig.Port, pc.BFD().Port)
+						}
+						if pc.BFD().DetectionMultiplier == nil || *pc.BFD().DetectionMultiplier != *tt.bfdConfig.DetectionMultiplier {
+							t.Errorf("peer %d BFD detection multiplier mismatch", i)
+						}
+					}
+				}
 			}
 		})
 	}

--- a/pkg/bgp/peer_config_test.go
+++ b/pkg/bgp/peer_config_test.go
@@ -87,6 +87,18 @@ func TestPeerConfig_UnmarshalYAML(t *testing.T) {
 		errorContains string
 	}{
 		{
+			name: "Valid peer config YAML",
+			input: []byte(`remoteip: 1.1.1.1
+remoteasn: 1234
+password: aGVsbG8=
+`),
+			expected: PeerConfig{
+				password:  utils.Base64String("hello"),
+				remoteIP:  net.ParseIP("1.1.1.1"),
+				remoteASN: uint32(1234),
+			},
+		},
+		{
 			name:     "empty YAML",
 			expected: PeerConfig{},
 		},
@@ -119,16 +131,40 @@ remoteasn: 1234`),
 			errorContains: "is not a valid IP address",
 		},
 		{
-			name: "Valid peer config YAML",
+			name: "Invalid BFD port ",
 			input: []byte(`remoteip: 1.1.1.1
 remoteasn: 1234
-password: aGVsbG8=
-`),
-			expected: PeerConfig{
-				password:  utils.Base64String("hello"),
-				remoteIP:  net.ParseIP("1.1.1.1"),
-				remoteASN: uint32(1234),
-			},
+bfd:
+  enabled: true
+  port: 0`),
+			errorContains: "bfd port must be between",
+		},
+		{
+			name: "Invalid BFD detection multiplier",
+			input: []byte(`remoteip: 1.1.1.1
+remoteasn: 1234
+bfd:
+  enabled: true
+  detection_multiplier: 0`),
+			errorContains: "bfd detection multiplier must be between",
+		},
+		{
+			name: "Invalid BFD desired min tx interval",
+			input: []byte(`remoteip: 1.1.1.1
+remoteasn: 1234
+bfd:
+  enabled: true
+  desired_min_tx_interval: 0`),
+			errorContains: "bfd desired min tx interval must be between",
+		},
+		{
+			name: "Invalid BFD required min rx interval",
+			input: []byte(`remoteip: 1.1.1.1
+remoteasn: 1234
+bfd:
+  enabled: true
+  required_min_rx_interval: 0`),
+			errorContains: "bfd required min rx interval must be between",
 		},
 	}
 

--- a/pkg/bgp/peer_config_test.go
+++ b/pkg/bgp/peer_config_test.go
@@ -99,6 +99,27 @@ password: aGVsbG8=
 			},
 		},
 		{
+			name: "Valid peer config YAML with BFD enabled",
+			input: []byte(`remoteip: 1.1.1.1
+remoteasn: 1234
+password: aGVsbG8=
+bfd:
+  enabled: true
+  desired_min_tx_interval: 1000
+  required_min_rx_interval: 1000
+`),
+			expected: PeerConfig{
+				password:  utils.Base64String("hello"),
+				remoteIP:  net.ParseIP("1.1.1.1"),
+				remoteASN: uint32(1234),
+				bfd: BFDConfig{
+					Enabled:               true,
+					DesiredMinTxInterval:  new(uint32(1000)),
+					RequiredMinRxInterval: new(uint32(1000)),
+				},
+			},
+		},
+		{
 			name:     "empty YAML",
 			expected: PeerConfig{},
 		},

--- a/pkg/controllers/routing/bgp_peers.go
+++ b/pkg/controllers/routing/bgp_peers.go
@@ -240,6 +240,10 @@ func (nrc *NetworkRoutingController) connectToExternalBGPPeers(server *gobgp.Bgp
 		}
 
 		if bgpGracefulRestart {
+			if n.Bfd != nil && n.Bfd.Enabled {
+				klog.Warning("Both BFD and BGP Graceful Restart should not be enabled at the same time. " +
+					"See docs/bgp.md for details.")
+			}
 			n.GracefulRestart = &gobgpapi.GracefulRestart{
 				Enabled:         true,
 				RestartTime:     uint32(bgpGracefulRestartTime.Seconds()),
@@ -301,6 +305,8 @@ func newGlobalPeers(
 		if peerConfig.LocalIP() != "" {
 			peer.Transport.LocalAddress = peerConfig.LocalIP()
 		}
+
+		peer.Bfd = peerConfig.BFD().ToGoBGP()
 
 		peers[i] = peer
 	}

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -124,6 +124,11 @@ type NetworkRoutingController struct {
 	globalPeerRouters              []*gobgpapi.Peer
 	nodePeerRouters                []string
 	enableCNI                      bool
+	enableBFD                      bool
+	bfdDetectionMultiplier         uint32
+	bfdMinRxInt                    uint32
+	bfdMinTxInt                    uint32
+	bfdPort                        uint32
 	bgpFullMeshMode                bool
 	bgpEnableInternal              bool
 	bgpGracefulRestart             bool
@@ -1384,6 +1389,18 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		klog.Warning("--gobgp-admin-port is 0 but --gobgp-admin-address is non-empty, not binding GoBGP socket to an address")
 	}
 
+	nrc.enableBFD = kubeRouterConfig.EnableBFD
+	nrc.bfdPort = kubeRouterConfig.BFDPort
+	nrc.bfdDetectionMultiplier = kubeRouterConfig.BFDDetectionMultiplier
+	nrc.bfdMinRxInt = kubeRouterConfig.BFDRequiredMinRxInterval
+	nrc.bfdMinTxInt = kubeRouterConfig.BFDDesiredMinTxInterval
+
+	if nrc.enableBFD {
+		if nrc.bfdDetectionMultiplier == 0 || nrc.bfdDetectionMultiplier > options.BFDDetectionMultiplierMax {
+			return nil, fmt.Errorf("--bfd-detection-multiplier must be between 1-%d", options.BFDDetectionMultiplierMax)
+		}
+	}
+
 	// Convert ints to uint32s
 	peerASNs := make([]uint32, 0)
 	for _, i := range kubeRouterConfig.PeerASNs {
@@ -1438,6 +1455,13 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		peerPasswords,
 		nil,
 		nrc.krNode.GetPrimaryNodeIP().String(),
+		bgp.BFDConfig{
+			Enabled:               nrc.enableBFD,
+			Port:                  &nrc.bfdPort,
+			DetectionMultiplier:   &nrc.bfdDetectionMultiplier,
+			DesiredMinTxInterval:  &nrc.bfdMinTxInt,
+			RequiredMinRxInterval: &nrc.bfdMinRxInt,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -1590,7 +1614,9 @@ func bgpPeerConfigsFromIndividualAnnotations(
 		}
 	}
 
-	return bgp.NewPeerConfigs(ipStrings, peerASNs, ports, passwords, localIPs, localAddress)
+	// We intentionally pass in empty BFD configs here. Individual node annotations are deprecated.
+	// We do not plan on supporting new features like BFD using individual node annotations.
+	return bgp.NewPeerConfigs(ipStrings, peerASNs, ports, passwords, localIPs, localAddress, bgp.BFDConfig{})
 }
 
 func goBGPListenAddrs(adminAddress string, adminPort uint16) []string {

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -1402,9 +1402,6 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		DesiredMinTxInterval:  new(kubeRouterConfig.BFDDesiredMinTxInterval),
 		RequiredMinRxInterval: new(kubeRouterConfig.BFDRequiredMinRxInterval),
 	}
-	if err := nrc.bfdConfig.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid BFD configuration: %w", err)
-	}
 
 	// Convert ints to uint32s
 	peerASNs := make([]uint32, 0)

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -131,11 +131,7 @@ type NetworkRoutingController struct {
 	globalPeerRouters              []*gobgpapi.Peer
 	nodePeerRouters                []string
 	enableCNI                      bool
-	enableBFD                      bool
-	bfdDetectionMultiplier         uint32
-	bfdMinRxInt                    uint32
-	bfdMinTxInt                    uint32
-	bfdPort                        uint32
+	bfdConfig                      bgp.BFDConfig
 	bgpFullMeshMode                bool
 	bgpEnableInternal              bool
 	bgpGracefulRestart             bool
@@ -1399,16 +1395,15 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		klog.Warning("--gobgp-admin-port is 0 but --gobgp-admin-address is non-empty, not binding GoBGP socket to an address")
 	}
 
-	nrc.enableBFD = kubeRouterConfig.EnableBFD
-	nrc.bfdPort = kubeRouterConfig.BFDPort
-	nrc.bfdDetectionMultiplier = kubeRouterConfig.BFDDetectionMultiplier
-	nrc.bfdMinRxInt = kubeRouterConfig.BFDRequiredMinRxInterval
-	nrc.bfdMinTxInt = kubeRouterConfig.BFDDesiredMinTxInterval
-
-	if nrc.enableBFD {
-		if nrc.bfdDetectionMultiplier == 0 || nrc.bfdDetectionMultiplier > options.BFDDetectionMultiplierMax {
-			return nil, fmt.Errorf("--bfd-detection-multiplier must be between 1-%d", options.BFDDetectionMultiplierMax)
-		}
+	nrc.bfdConfig = bgp.BFDConfig{
+		Enabled:               kubeRouterConfig.EnableBFD,
+		Port:                  new(kubeRouterConfig.BFDPort),
+		DetectionMultiplier:   new(kubeRouterConfig.BFDDetectionMultiplier),
+		DesiredMinTxInterval:  new(kubeRouterConfig.BFDDesiredMinTxInterval),
+		RequiredMinRxInterval: new(kubeRouterConfig.BFDRequiredMinRxInterval),
+	}
+	if err := nrc.bfdConfig.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid BFD configuration: %w", err)
 	}
 
 	// Convert ints to uint32s
@@ -1465,13 +1460,7 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		peerPasswords,
 		nil,
 		nrc.krNode.GetPrimaryNodeIP().String(),
-		bgp.BFDConfig{
-			Enabled:               nrc.enableBFD,
-			Port:                  &nrc.bfdPort,
-			DetectionMultiplier:   &nrc.bfdDetectionMultiplier,
-			DesiredMinTxInterval:  &nrc.bfdMinTxInt,
-			RequiredMinRxInterval: &nrc.bfdMinRxInt,
-		},
+		nrc.bfdConfig,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -131,6 +131,11 @@ type NetworkRoutingController struct {
 	globalPeerRouters              []*gobgpapi.Peer
 	nodePeerRouters                []string
 	enableCNI                      bool
+	enableBFD                      bool
+	bfdDetectionMultiplier         uint32
+	bfdMinRxInt                    uint32
+	bfdMinTxInt                    uint32
+	bfdPort                        uint32
 	bgpFullMeshMode                bool
 	bgpEnableInternal              bool
 	bgpGracefulRestart             bool
@@ -1394,6 +1399,18 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		klog.Warning("--gobgp-admin-port is 0 but --gobgp-admin-address is non-empty, not binding GoBGP socket to an address")
 	}
 
+	nrc.enableBFD = kubeRouterConfig.EnableBFD
+	nrc.bfdPort = kubeRouterConfig.BFDPort
+	nrc.bfdDetectionMultiplier = kubeRouterConfig.BFDDetectionMultiplier
+	nrc.bfdMinRxInt = kubeRouterConfig.BFDRequiredMinRxInterval
+	nrc.bfdMinTxInt = kubeRouterConfig.BFDDesiredMinTxInterval
+
+	if nrc.enableBFD {
+		if nrc.bfdDetectionMultiplier == 0 || nrc.bfdDetectionMultiplier > options.BFDDetectionMultiplierMax {
+			return nil, fmt.Errorf("--bfd-detection-multiplier must be between 1-%d", options.BFDDetectionMultiplierMax)
+		}
+	}
+
 	// Convert ints to uint32s
 	peerASNs := make([]uint32, 0)
 	for _, i := range kubeRouterConfig.PeerASNs {
@@ -1448,6 +1465,13 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		peerPasswords,
 		nil,
 		nrc.krNode.GetPrimaryNodeIP().String(),
+		bgp.BFDConfig{
+			Enabled:               nrc.enableBFD,
+			Port:                  &nrc.bfdPort,
+			DetectionMultiplier:   &nrc.bfdDetectionMultiplier,
+			DesiredMinTxInterval:  &nrc.bfdMinTxInt,
+			RequiredMinRxInterval: &nrc.bfdMinRxInt,
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -1616,7 +1640,9 @@ func bgpPeerConfigsFromIndividualAnnotations(
 		}
 	}
 
-	return bgp.NewPeerConfigs(ipStrings, peerASNs, ports, passwords, localIPs, localAddress)
+	// We intentionally pass in empty BFD configs here. Individual node annotations are deprecated.
+	// We do not plan on supporting new features like BFD using individual node annotations.
+	return bgp.NewPeerConfigs(ipStrings, peerASNs, ports, passwords, localIPs, localAddress, bgp.BFDConfig{})
 }
 
 func goBGPListenAddrs(adminAddress string, adminPort uint16) []string {

--- a/pkg/controllers/routing/network_routes_controller_test.go
+++ b/pkg/controllers/routing/network_routes_controller_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cloudnativelabs/kube-router/v2/pkg/k8s/indexers"
 	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2599,8 +2598,45 @@ func Test_bgpPeerConfigsFromAnnotations(t *testing.T) {
   localip: 192.168.0.2`,
 			},
 			expected: func() bgp.PeerConfigs {
-				peer1, _ := bgp.NewPeerConfig("10.0.0.1", 64640, nil, "cGFzc3dvcmQ=", "192.168.0.1")
-				peer2, _ := bgp.NewPeerConfig("10.0.0.2", 64641, nil, "cGFzc3dvcmQ=", "192.168.0.2")
+				peer1, _ := bgp.NewPeerConfig("10.0.0.1", 64640, nil, "password", "192.168.0.1", bgp.BFDConfig{})
+				peer2, _ := bgp.NewPeerConfig("10.0.0.2", 64641, nil, "password", "192.168.0.2", bgp.BFDConfig{})
+				return bgp.PeerConfigs{peer1, peer2}
+			}(),
+		},
+		{
+			name: "bgp peers config annotation with bfd",
+			nodeAnnotations: map[string]string{
+				peersAnnotation: `- remoteip: 10.0.0.1
+  remoteasn: 64640
+  password: cGFzc3dvcmQ=
+  localip: 192.168.0.1
+  bfd:
+    enabled: true
+    port: 37850
+    detection_multiplier: 2
+    desired_min_tx_interval: 2
+    required_min_rx_interval: 2
+- remoteip: 10.0.0.2
+  remoteasn: 64641
+  password: cGFzc3dvcmQ=
+  localip: 192.168.0.2`,
+			},
+			expected: func() bgp.PeerConfigs {
+				peer1, _ := bgp.NewPeerConfig(
+					"10.0.0.1",
+					64640,
+					nil,
+					"password",
+					"192.168.0.1",
+					bgp.BFDConfig{
+						Enabled:               true,
+						Port:                  new(uint32(37850)),
+						DetectionMultiplier:   new(uint32(2)),
+						DesiredMinTxInterval:  new(uint32(2)),
+						RequiredMinRxInterval: new(uint32(2)),
+					},
+				)
+				peer2, _ := bgp.NewPeerConfig("10.0.0.2", 64641, nil, "password", "192.168.0.2", bgp.BFDConfig{})
 				return bgp.PeerConfigs{peer1, peer2}
 			}(),
 		},
@@ -2621,17 +2657,17 @@ func Test_bgpPeerConfigsFromAnnotations(t *testing.T) {
   port: 181`,
 			},
 			expected: func() bgp.PeerConfigs {
-				peer1, err := bgp.NewPeerConfig("10.0.0.1", 64640, nil, "cGFzc3dvcmQ=", "192.168.0.1")
+				peer1, err := bgp.NewPeerConfig("10.0.0.1", 64640, nil, "password", "192.168.0.1", bgp.BFDConfig{})
 				if err != nil {
 					t.Fatalf("should not have gotten error constructing PeerConfig but got one: %s", err)
 				}
 				port2 := uint32(180)
-				peer2, err := bgp.NewPeerConfig("10.0.0.2", 64641, &port2, "", "192.168.0.2")
+				peer2, err := bgp.NewPeerConfig("10.0.0.2", 64641, &port2, "", "192.168.0.2", bgp.BFDConfig{})
 				if err != nil {
 					t.Fatalf("should not have gotten error constructing PeerConfig but got one: %s", err)
 				}
 				port3 := uint32(181)
-				peer3, err := bgp.NewPeerConfig("10.0.0.3", 64642, &port3, "cGFzc3dvcmQ=", "")
+				peer3, err := bgp.NewPeerConfig("10.0.0.3", 64642, &port3, "password", "", bgp.BFDConfig{})
 				if err != nil {
 					t.Fatalf("should not have gotten error constructing PeerConfig but got one: %s", err)
 				}
@@ -2671,8 +2707,8 @@ func Test_bgpPeerConfigsFromAnnotations(t *testing.T) {
 				assert.ErrorContains(st, err, tc.errorContains)
 			} else {
 				require.NoError(t, err)
-				if !cmp.Equal(tc.expected, bgpPeerCfgs, cmpopts.IgnoreUnexported(bgp.PeerConfig{})) {
-					diff := cmp.Diff(tc.expected, bgpPeerCfgs, cmpopts.IgnoreUnexported(bgp.PeerConfig{}))
+				if !cmp.Equal(tc.expected, bgpPeerCfgs, cmp.AllowUnexported(bgp.PeerConfig{})) {
+					diff := cmp.Diff(tc.expected, bgpPeerCfgs, cmp.AllowUnexported(bgp.PeerConfig{}))
 					t.Errorf("BGP peer config mismatch:\n%s", diff)
 				}
 			}
@@ -2700,8 +2736,8 @@ func Test_bgpPeerConfigsFromIndividualAnnotations(t *testing.T) {
 			expected: func() bgp.PeerConfigs {
 				port1 := uint32(180)
 				port2 := uint32(181)
-				peer1, _ := bgp.NewPeerConfig("10.0.0.1", 64640, &port1, "cGFzc3dvcmQ=", "192.168.0.1")
-				peer2, _ := bgp.NewPeerConfig("10.0.0.2", 64641, &port2, "cGFzc3dvcmQ=", "192.168.0.2")
+				peer1, _ := bgp.NewPeerConfig("10.0.0.1", 64640, &port1, "password", "192.168.0.1", bgp.BFDConfig{})
+				peer2, _ := bgp.NewPeerConfig("10.0.0.2", 64641, &port2, "password", "192.168.0.2", bgp.BFDConfig{})
 				return bgp.PeerConfigs{peer1, peer2}
 			}(),
 		},
@@ -2717,8 +2753,8 @@ func Test_bgpPeerConfigsFromIndividualAnnotations(t *testing.T) {
 			expected: func() bgp.PeerConfigs {
 				port1 := uint32(180)
 				port2 := uint32(181)
-				peer1, _ := bgp.NewPeerConfig("10.0.0.1", 64640, &port1, "", "192.168.0.1")
-				peer2, _ := bgp.NewPeerConfig("10.0.0.2", 64641, &port2, "cGFzc3dvcmQ=", "192.168.0.2")
+				peer1, _ := bgp.NewPeerConfig("10.0.0.1", 64640, &port1, "", "192.168.0.1", bgp.BFDConfig{})
+				peer2, _ := bgp.NewPeerConfig("10.0.0.2", 64641, &port2, "password", "192.168.0.2", bgp.BFDConfig{})
 				return bgp.PeerConfigs{peer1, peer2}
 			}(),
 		},
@@ -2783,8 +2819,8 @@ func Test_bgpPeerConfigsFromIndividualAnnotations(t *testing.T) {
 				assert.ErrorContains(st, err, tc.errorContains)
 			} else {
 				require.NoError(t, err)
-				if !cmp.Equal(tc.expected, bgpPeerCfgs, cmpopts.IgnoreUnexported(bgp.PeerConfig{})) {
-					diff := cmp.Diff(tc.expected, bgpPeerCfgs, cmpopts.IgnoreUnexported(bgp.PeerConfig{}))
+				if !cmp.Equal(tc.expected, bgpPeerCfgs, cmp.AllowUnexported(bgp.PeerConfig{})) {
+					diff := cmp.Diff(tc.expected, bgpPeerCfgs, cmp.AllowUnexported(bgp.PeerConfig{}))
 					t.Errorf("BGP peer config mismatch:\n%s", diff)
 				}
 			}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -9,12 +9,17 @@ import (
 )
 
 const (
-	DefaultBgpPort                       = 179
-	DefaultBgpHoldTime                   = 90 * time.Second
-	defaultHealthCheckPort               = 20244
-	defaultOverlayTunnelEncapPort uint16 = 5555
-	defaultGoBGPAdminAddress             = "127.0.0.1"
-	defaultGoBGPAdminPort         uint16 = 50051
+	DefaultBFDPort                  uint32 = 3784
+	DefaultBFDDetectionMultiplier   uint32 = 3
+	DefaultBFDDesiredMinTxInterval  uint32 = 1000000 // 1s in microseconds
+	DefaultBFDRequiredMinRxInterval uint32 = 1000000 // 1s in microseconds
+	BFDDetectionMultiplierMax       uint32 = 255     // RFC 5880: detect_mult is an 8-bit field
+	DefaultBgpPort                         = 179
+	DefaultBgpHoldTime                     = 90 * time.Second
+	defaultHealthCheckPort                 = 20244
+	defaultOverlayTunnelEncapPort   uint16 = 5555
+	defaultGoBGPAdminAddress               = "127.0.0.1"
+	defaultGoBGPAdminPort           uint16 = 50051
 )
 
 type KubeRouterConfig struct {
@@ -23,6 +28,10 @@ type KubeRouterConfig struct {
 	AdvertiseLoadBalancerIP        bool
 	AdvertiseNodePodCidr           bool
 	AutoMTU                        bool
+	BFDDesiredMinTxInterval        uint32
+	BFDDetectionMultiplier         uint32
+	BFDPort                        uint32
+	BFDRequiredMinRxInterval       uint32
 	BGPGracefulRestart             bool
 	BGPGracefulRestartDeferralTime time.Duration
 	BGPGracefulRestartTime         time.Duration
@@ -33,6 +42,7 @@ type KubeRouterConfig struct {
 	ClusterAsn                     uint
 	ClusterIPCIDRs                 []string
 	DisableSrcDstCheck             bool
+	EnableBFD                      bool
 	EnableCNI                      bool
 	EnableiBGP                     bool
 	EnableIPv4                     bool
@@ -131,6 +141,13 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.AutoMTU, "auto-mtu", true,
 		"Auto detect and set the largest possible MTU for kube-bridge and pod interfaces (also accounts for "+
 			"IPIP overlay network when enabled).")
+	fs.Uint32Var(&s.BFDDesiredMinTxInterval, "bfd-desired-min-tx-interval", DefaultBFDDesiredMinTxInterval,
+		"The desired min interval in microseconds for GoBGP to transmit BFD control packets.")
+	fs.Uint32Var(&s.BFDDetectionMultiplier, "bfd-detection-multiplier", DefaultBFDDetectionMultiplier,
+		"BFD failure detection multiplier. Must be between 1-255.")
+	fs.Uint32Var(&s.BFDPort, "bfd-port", DefaultBFDPort, "UDP port for BFD control packets")
+	fs.Uint32Var(&s.BFDRequiredMinRxInterval, "bfd-required-min-rx-interval", DefaultBFDRequiredMinRxInterval,
+		"Min interval in microseconds for GoBGP to receive BFD control packets.")
 	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time",
@@ -153,6 +170,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.DisableSrcDstCheck, "disable-source-dest-check", true,
 		"Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be "+
 			"set some other way.")
+	fs.BoolVar(&s.EnableBFD, "enable-bfd", false, "Enable BFD for GoBGP")
 	fs.BoolVar(&s.EnableCNI, "enable-cni", true,
 		"Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin.")
 	fs.BoolVar(&s.EnableiBGP, "enable-ibgp", true,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -13,7 +13,6 @@ const (
 	DefaultBFDDetectionMultiplier   uint32 = 3
 	DefaultBFDDesiredMinTxInterval  uint32 = 1000 // 1s in milliseconds
 	DefaultBFDRequiredMinRxInterval uint32 = 1000 // 1s in milliseconds
-	BFDDetectionMultiplierMax       uint32 = 255     // RFC 5880: detect_mult is an 8-bit field
 	DefaultBgpPort                         = 179
 	DefaultBgpHoldTime                     = 90 * time.Second
 	defaultHealthCheckPort                 = 20244

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -9,12 +9,17 @@ import (
 )
 
 const (
-	DefaultBgpPort                       = 179
-	DefaultBgpHoldTime                   = 90 * time.Second
-	defaultHealthCheckPort               = 20244
-	defaultOverlayTunnelEncapPort uint16 = 5555
-	defaultGoBGPAdminAddress             = "127.0.0.1"
-	defaultGoBGPAdminPort         uint16 = 50051
+	DefaultBFDPort                  uint32 = 3784
+	DefaultBFDDetectionMultiplier   uint32 = 3
+	DefaultBFDDesiredMinTxInterval  uint32 = 1000000 // 1s in microseconds
+	DefaultBFDRequiredMinRxInterval uint32 = 1000000 // 1s in microseconds
+	BFDDetectionMultiplierMax       uint32 = 255     // RFC 5880: detect_mult is an 8-bit field
+	DefaultBgpPort                         = 179
+	DefaultBgpHoldTime                     = 90 * time.Second
+	defaultHealthCheckPort                 = 20244
+	defaultOverlayTunnelEncapPort   uint16 = 5555
+	defaultGoBGPAdminAddress               = "127.0.0.1"
+	defaultGoBGPAdminPort           uint16 = 50051
 )
 
 type KubeRouterConfig struct {
@@ -23,6 +28,10 @@ type KubeRouterConfig struct {
 	AdvertiseLoadBalancerIP        bool
 	AdvertiseNodePodCidr           bool
 	AutoMTU                        bool
+	BFDDesiredMinTxInterval        uint32
+	BFDDetectionMultiplier         uint32
+	BFDPort                        uint32
+	BFDRequiredMinRxInterval       uint32
 	BGPGracefulRestart             bool
 	BGPGracefulRestartDeferralTime time.Duration
 	BGPGracefulRestartTime         time.Duration
@@ -33,6 +42,7 @@ type KubeRouterConfig struct {
 	ClusterAsn                     uint
 	ClusterIPCIDRs                 []string
 	DisableSrcDstCheck             bool
+	EnableBFD                      bool
 	EnableCNI                      bool
 	EnableiBGP                     bool
 	EnableIPv4                     bool
@@ -132,6 +142,13 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.AutoMTU, "auto-mtu", true,
 		"Auto detect and set the largest possible MTU for kube-bridge and pod interfaces (also accounts for "+
 			"IPIP overlay network when enabled).")
+	fs.Uint32Var(&s.BFDDesiredMinTxInterval, "bfd-desired-min-tx-interval", DefaultBFDDesiredMinTxInterval,
+		"The desired min interval in microseconds for GoBGP to transmit BFD control packets.")
+	fs.Uint32Var(&s.BFDDetectionMultiplier, "bfd-detection-multiplier", DefaultBFDDetectionMultiplier,
+		"BFD failure detection multiplier. Must be between 1-255.")
+	fs.Uint32Var(&s.BFDPort, "bfd-port", DefaultBFDPort, "UDP port for BFD control packets")
+	fs.Uint32Var(&s.BFDRequiredMinRxInterval, "bfd-required-min-rx-interval", DefaultBFDRequiredMinRxInterval,
+		"Min interval in microseconds for GoBGP to receive BFD control packets.")
 	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time",
@@ -154,6 +171,7 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.DisableSrcDstCheck, "disable-source-dest-check", true,
 		"Disable the source-dest-check attribute for AWS EC2 instances. When this option is false, it must be "+
 			"set some other way.")
+	fs.BoolVar(&s.EnableBFD, "enable-bfd", false, "Enable BFD for GoBGP")
 	fs.BoolVar(&s.EnableCNI, "enable-cni", true,
 		"Enable CNI plugin. Disable if you want to use kube-router features alongside another CNI plugin.")
 	fs.BoolVar(&s.EnableiBGP, "enable-ibgp", true,

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -11,8 +11,8 @@ import (
 const (
 	DefaultBFDPort                  uint32 = 3784
 	DefaultBFDDetectionMultiplier   uint32 = 3
-	DefaultBFDDesiredMinTxInterval  uint32 = 1000000 // 1s in microseconds
-	DefaultBFDRequiredMinRxInterval uint32 = 1000000 // 1s in microseconds
+	DefaultBFDDesiredMinTxInterval  uint32 = 1000 // 1s in milliseconds
+	DefaultBFDRequiredMinRxInterval uint32 = 1000 // 1s in milliseconds
 	BFDDetectionMultiplierMax       uint32 = 255     // RFC 5880: detect_mult is an 8-bit field
 	DefaultBgpPort                         = 179
 	DefaultBgpHoldTime                     = 90 * time.Second
@@ -143,12 +143,12 @@ func (s *KubeRouterConfig) AddFlags(fs *pflag.FlagSet) {
 		"Auto detect and set the largest possible MTU for kube-bridge and pod interfaces (also accounts for "+
 			"IPIP overlay network when enabled).")
 	fs.Uint32Var(&s.BFDDesiredMinTxInterval, "bfd-desired-min-tx-interval", DefaultBFDDesiredMinTxInterval,
-		"The desired min interval in microseconds for GoBGP to transmit BFD control packets.")
+		"The desired min interval in milliseconds for GoBGP to transmit BFD control packets.")
 	fs.Uint32Var(&s.BFDDetectionMultiplier, "bfd-detection-multiplier", DefaultBFDDetectionMultiplier,
 		"BFD failure detection multiplier. Must be between 1-255.")
 	fs.Uint32Var(&s.BFDPort, "bfd-port", DefaultBFDPort, "UDP port for BFD control packets")
 	fs.Uint32Var(&s.BFDRequiredMinRxInterval, "bfd-required-min-rx-interval", DefaultBFDRequiredMinRxInterval,
-		"Min interval in microseconds for GoBGP to receive BFD control packets.")
+		"Min interval in milliseconds for GoBGP to receive BFD control packets.")
 	fs.BoolVar(&s.BGPGracefulRestart, "bgp-graceful-restart", false,
 		"Enables the BGP Graceful Restart capability so that routes are preserved on unexpected restarts")
 	fs.DurationVar(&s.BGPGracefulRestartDeferralTime, "bgp-graceful-restart-deferral-time",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?

feature

#### What this PR does / why we need it:

Implement basic BFD support into kube-router for external BGP peers

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->

Fixes https://github.com/cloudnativelabs/kube-router/issues/1117

#### Was AI used during the creation of this PR?
<!--
We are not against AI, but in the current era of tech AI is being used more and more to help upstream projects and it is
useful for the maintainers of this project to understand if AI was used and to what extent it was used. Please see our
AI policy: https://github.com/cloudnativelabs/kube-router/blob/master/AI_POLICY.md

If no AI was used during the generation of this PR, please remove the following content and simply put "No" for this
section.
-->

* What tool was used: <!-- One of Claude, Codex, Copilot, etc. --> Claude Code (with GLM 5.2 & Deepseek V4 Flash)
* To what extent was the tool used? <!-- Anything from line autofill to it drafted the entire PR or anything imbetween --> Used it to author a quick first draft so I could get to testing. Don't have a ton of exposure to BFD either, so I used it as a jumping off point for research into understanding how it's implemented and the various config options since the various docs I was reading from hardware providers/networking guides weren't clear about how it behaves. (Was mostly trying to figure out how it behaves if graceful restart is also enabled.) I also used it during testing for `vtysh` commands for FRR (since I'm not familiar with it) and to construct the `iptables` rule to drop BFD traffic. 
* If drafted, how detailed of a plan did you create for the AI? <!-- Very detailed (multiple paragraphs) to not at all detailed (I gave it a single line prompt) --> Pretty detailed about what I wanted the configs to look like and the actual entrypoints in the config to write.
* Help us understand if a human was in the loop or not for this PR? Yes 

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->

I did some testing prior to cleanliness refactors and I'll do additional rounds of integration tests after feedback. 

Tested it a few times with kube-router-automation, which spins up a controller, a worker, and an external BGP peer (with FRR). I updated the FRR configs with BFD configs. I also added routes on the FRR node that were exported to kube-router.

To simulate failure, I tried a few combos: 

* `systemctl kill frr` to kill FRR after peering
* `iptables -A INPUT -p udp --dport 3784 -s <FRR_IP> -j DROP` - In the kube-router pods to drop external BFD traffic to see what happened

To validate behavior, I would exec into the kube-router pod and run `watch -n 1 ip route show` and `watch -n 1 gobgp global rib` to see how quickly routes got yanked & how quickly GoBGP would mark a peer state from Established -> Idle -> Active. 

I would then restore the peer session by either doing `systemctl start frr` or dropping the iptables rule I added 

I then tested behavior with a few scenarios:

**BFD + GR both enabled in external peer + kube-router nodes** 
As expected, BFD seems to supersede GR. 

**Node Annotation Implemention/Asymmetric Setup Per Node**

The other test cases were done with the cluster wide `--enable-bfd` flag.

I tested the per-node annotations as well. I set up the controller with the legacy single BGP config annotations (which should not get any BFD configs because the legacy annotations do not support BFD as they're deprecated) and the worker with the consolidated node BGP annotation (with the BFD config). 

I verified on the FRR side that the controller was a BGP peer, but BFD was not configured and that the worker was a BGP peer with BFD configured. 

Sorry for the novel - I also took more detailed notes with test configs that I'm happy to share. 

#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

There a few implementation choices I made that I'd like feedback on:

* kube-router exposes the timer intervals as microseconds, because that's what GoBGP uses. However, FRR uses milliseconds - and after doing the integration testing, I think the milliseconds are a lot easier to deal with. Wanted to get feedback on this
* The cluster-wide BFD flags all only take 1 set of configs for the global external peers for ease of implementation. However, I can see how it might be desirable to provide the flexibility to configure separate values per peer. I'm totally open to changing it. 
* The single BGP annotations are deprecated, so I didn't feel like we should support new features with them to continue encouraging their use. I'm okay with changing the implementation to support them though, it's not very difficult to.