### PR TITLE
Misc Touch Ups and Fixes

### DIFF
--- a/.github/workflows/ci-e2e-netpol.yml
+++ b/.github/workflows/ci-e2e-netpol.yml
@@ -62,10 +62,6 @@ jobs:
       BACKEND: ${{ matrix.backend }}
       DEFAULT_DENY: ${{ matrix.default-deny }}
       KIND_CLUSTER_NAME: e2e
-      KIND_NODE_IMAGE: ${{ env.KIND_NODE_IMAGE }}
-      KUBE_ROUTER_IMAGE: ${{ env.KUBE_ROUTER_IMAGE }}
-      BUILDTIME_BASE: ${{ env.BUILDTIME_BASE }}
-      RUNTIME_BASE: ${{ env.RUNTIME_BASE }}
     strategy:
       fail-fast: false
       matrix:

--- a/cmd/kube-router/kube-router.go
+++ b/cmd/kube-router/kube-router.go
@@ -48,6 +48,10 @@ func Main() error {
 		return fmt.Errorf("failed to set flag: %w", err)
 	}
 
+	if args := pflag.Args(); len(args) > 0 {
+		return fmt.Errorf("unrecognized positional argument(s): %v", args)
+	}
+
 	if config.HelpRequested {
 		pflag.Usage()
 		return nil

--- a/cmd/kube-router/kube-router.go
+++ b/cmd/kube-router/kube-router.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -27,25 +26,15 @@ func main() {
 }
 
 func Main() error {
-	klog.InitFlags(nil)
-
 	config := options.NewKubeRouterConfig()
 	config.AddFlags(pflag.CommandLine)
 	pflag.Parse()
 
-	// Workaround for this issue:
-	// https://github.com/kubernetes/kubernetes/issues/17162
-	err := flag.CommandLine.Parse([]string{})
-	if err != nil {
-		return fmt.Errorf("failed to parse flags: %w", err)
-	}
-	err = flag.Set("logtostderr", "true")
-	if err != nil {
-		return fmt.Errorf("failed to set flag: %w", err)
-	}
-	err = flag.Set("v", config.VLevel)
-	if err != nil {
-		return fmt.Errorf("failed to set flag: %w", err)
+	// Level.Set() mutates klog's package-global verbosity rather than the receiver, so we can discard
+	// vLevel afterwards. Everything else we need, logging to stderr included, is already klog's default.
+	var vLevel klog.Level
+	if err := vLevel.Set(config.VLevel); err != nil {
+		return fmt.Errorf("failed to set log level to %q: %w", config.VLevel, err)
 	}
 
 	if args := pflag.Args(); len(args) > 0 {

--- a/pkg/cmd/kube-router.go
+++ b/pkg/cmd/kube-router.go
@@ -42,6 +42,25 @@ type KubeRouter struct {
 	Config *options.KubeRouterConfig
 }
 
+// sharedInformers bundles every informer we start so that we can hand a single value to each controller.
+// Each controller declares its own narrow interface over this (routing.Informers, proxy.Informers, and so on)
+// and therefore only ever sees the informers it actually watches.
+type sharedInformers struct {
+	services        cache.SharedIndexInformer
+	endpointSlices  cache.SharedIndexInformer
+	pods            cache.SharedIndexInformer
+	nodes           cache.SharedIndexInformer
+	namespaces      cache.SharedIndexInformer
+	networkPolicies cache.SharedIndexInformer
+}
+
+func (s *sharedInformers) Services() cache.SharedIndexInformer        { return s.services }
+func (s *sharedInformers) EndpointSlices() cache.SharedIndexInformer  { return s.endpointSlices }
+func (s *sharedInformers) Pods() cache.SharedIndexInformer            { return s.pods }
+func (s *sharedInformers) Nodes() cache.SharedIndexInformer           { return s.nodes }
+func (s *sharedInformers) Namespaces() cache.SharedIndexInformer      { return s.namespaces }
+func (s *sharedInformers) NetworkPolicies() cache.SharedIndexInformer { return s.networkPolicies }
+
 // NewKubeRouterDefault returns a KubeRouter object
 func NewKubeRouterDefault(config *options.KubeRouterConfig) (*KubeRouter, error) {
 
@@ -134,15 +153,17 @@ func (kr *KubeRouter) Run() error {
 
 	// Setup factory and informers
 	informerFactory := informers.NewSharedInformerFactory(kr.Client, 0)
-	svcInformer := informerFactory.Core().V1().Services().Informer()
-	epSliceInformer := informerFactory.Discovery().V1().EndpointSlices().Informer()
-	podInformer := informerFactory.Core().V1().Pods().Informer()
-	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
-	nsInformer := informerFactory.Core().V1().Namespaces().Informer()
-	npInformer := informerFactory.Networking().V1().NetworkPolicies().Informer()
+	krInformers := &sharedInformers{
+		services:        informerFactory.Core().V1().Services().Informer(),
+		endpointSlices:  informerFactory.Discovery().V1().EndpointSlices().Informer(),
+		pods:            informerFactory.Core().V1().Pods().Informer(),
+		nodes:           informerFactory.Core().V1().Nodes().Informer(),
+		namespaces:      informerFactory.Core().V1().Namespaces().Informer(),
+		networkPolicies: informerFactory.Networking().V1().NetworkPolicies().Informer(),
+	}
 
 	// Add custom indexers
-	err = epSliceInformer.AddIndexers(map[string]cache.IndexFunc{
+	err = krInformers.EndpointSlices().AddIndexers(map[string]cache.IndexFunc{
 		indexers.ServiceNameIndex: indexers.ServiceNameIndexFunc,
 	})
 	if err != nil {
@@ -216,22 +237,9 @@ func (kr *KubeRouter) Run() error {
 
 	if kr.Config.RunRouter {
 		nrc, err := routing.NewNetworkRoutingController(kr.Client, kr.Config,
-			nodeInformer, svcInformer, epSliceInformer, &ipsetMutex, ipValidator)
+			krInformers, &ipsetMutex, ipValidator)
 		if err != nil {
 			return fmt.Errorf("failed to create network routing controller: %w", err)
-		}
-
-		_, err = nodeInformer.AddEventHandler(nrc.NodeEventHandler)
-		if err != nil {
-			return fmt.Errorf("failed to add NodeEventHandler: %w", err)
-		}
-		_, err = svcInformer.AddEventHandler(nrc.ServiceEventHandler)
-		if err != nil {
-			return fmt.Errorf("failed to add ServiceEventHandler: %w", err)
-		}
-		_, err = epSliceInformer.AddEventHandler(nrc.EndpointSliceEventHandler)
-		if err != nil {
-			return fmt.Errorf("failed to add EndpointsEventHandler: %w", err)
 		}
 
 		wg.Add(1)
@@ -247,18 +255,9 @@ func (kr *KubeRouter) Run() error {
 
 	if kr.Config.RunServiceProxy {
 		nsc, err := proxy.NewNetworkServicesController(kr.Client, kr.Config,
-			svcInformer, epSliceInformer, podInformer, &ipsetMutex, ipValidator)
+			krInformers, &ipsetMutex, ipValidator)
 		if err != nil {
 			return fmt.Errorf("failed to create network services controller: %w", err)
-		}
-
-		_, err = svcInformer.AddEventHandler(nsc.ServiceEventHandler)
-		if err != nil {
-			return fmt.Errorf("failed to add ServiceEventHandler: %w", err)
-		}
-		_, err = epSliceInformer.AddEventHandler(nsc.EndpointSliceEventHandler)
-		if err != nil {
-			return fmt.Errorf("failed to add EndpointsEventHandler: %w", err)
 		}
 
 		wg.Add(1)
@@ -289,23 +288,10 @@ func (kr *KubeRouter) Run() error {
 			return fmt.Errorf("failed to create nftables interfaces: %v", err)
 		}
 		npc, err := netpol.NewNetworkPolicyController(kr.Client,
-			kr.Config, podInformer, npInformer, nsInformer, &ipsetMutex, nil,
+			kr.Config, krInformers, &ipsetMutex, nil,
 			iptablesCmdHandlers, ipSetHandlers, ipValidator, knftablesInterfaces)
 		if err != nil {
 			return fmt.Errorf("failed to create network policy controller: %w", err)
-		}
-
-		_, err = podInformer.AddEventHandler(npc.PodEventHandler())
-		if err != nil {
-			return fmt.Errorf("failed to add PodEventHandler: %w", err)
-		}
-		_, err = nsInformer.AddEventHandler(npc.NamespaceEventHandler())
-		if err != nil {
-			return fmt.Errorf("failed to add NamespaceEventHandler: %w", err)
-		}
-		_, err = npInformer.AddEventHandler(npc.NetworkPolicyEventHandler())
-		if err != nil {
-			return fmt.Errorf("failed to add NetworkPolicyEventHandler: %w", err)
 		}
 
 		wg.Add(1)
@@ -314,14 +300,9 @@ func (kr *KubeRouter) Run() error {
 
 	if kr.Config.RunLoadBalancer {
 		klog.V(0).Info("running load balancer allocator controller")
-		lbc, err := lballoc.NewLoadBalancerController(kr.Client, kr.Config, svcInformer, ipValidator)
+		lbc, err := lballoc.NewLoadBalancerController(kr.Client, kr.Config, krInformers, ipValidator)
 		if err != nil {
 			return fmt.Errorf("failed to create load balancer allocator: %w", err)
-		}
-
-		_, err = svcInformer.AddEventHandler(lbc)
-		if err != nil {
-			return fmt.Errorf("failed to add ServiceEventHandler: %w", err)
 		}
 
 		wg.Add(1)

--- a/pkg/controllers/lballoc/lballoc.go
+++ b/pkg/controllers/lballoc/lballoc.go
@@ -32,6 +32,12 @@ type ipRanges struct {
 	currentIP  net.IP
 }
 
+// Informers is the set of shared informers the LBC reads from. We declare it here rather than accepting a
+// full informer factory so that the controller can only reach the resources it actually watches.
+type Informers interface {
+	Services() cache.SharedIndexInformer
+}
+
 type LoadBalancerController struct {
 	ipv4Ranges   *ipRanges
 	ipv6Ranges   *ipRanges
@@ -478,7 +484,7 @@ func (lbc *LoadBalancerController) Run(healthChan chan<- *healthcheck.Controller
 }
 
 func NewLoadBalancerController(clientset kubernetes.Interface,
-	config *options.KubeRouterConfig, svcInformer cache.SharedIndexInformer,
+	config *options.KubeRouterConfig, informers Informers,
 	ipRanges svcip.RangeQuerier,
 ) (*LoadBalancerController, error) {
 	lbc := &LoadBalancerController{
@@ -491,7 +497,14 @@ func NewLoadBalancerController(clientset kubernetes.Interface,
 		syncPeriod:   config.LoadBalancerSyncPeriod,
 	}
 
+	svcInformer := informers.Services()
 	lbc.svcLister = svcInformer.GetIndexer()
+
+	// The controller is its own ResourceEventHandler, see OnAdd/OnUpdate/OnDelete below. We register here so
+	// that the wiring lives next to the handler methods themselves.
+	if _, err := svcInformer.AddEventHandler(lbc); err != nil {
+		return nil, fmt.Errorf("failed to add ServiceEventHandler: %w", err)
+	}
 
 	namespace, err := getNamespace()
 	if err != nil {

--- a/pkg/controllers/lballoc/lballoc_test.go
+++ b/pkg/controllers/lballoc/lballoc_test.go
@@ -653,6 +653,13 @@ func TestAllocateServiceAlreadyAllocated(t *testing.T) {
 	}
 }
 
+// testInformers satisfies the package's Informers interface for tests that drive the constructor directly.
+type testInformers struct {
+	services cache.SharedIndexInformer
+}
+
+func (t testInformers) Services() cache.SharedIndexInformer { return t.services }
+
 type mockInformer struct {
 }
 
@@ -762,7 +769,7 @@ func TestNewLoadBalancerController(t *testing.T) {
 		t.Fatalf("expected validator to succeed, got %s", validatorErr)
 	}
 
-	_, err := NewLoadBalancerController(fs, config, mf, validator)
+	_, err := NewLoadBalancerController(fs, config, testInformers{services: mf}, validator)
 	if err != nil {
 		t.Fatalf("expected %v, got %s", nil, err)
 	}

--- a/pkg/controllers/netpol/ipset_fixture_test.go
+++ b/pkg/controllers/netpol/ipset_fixture_test.go
@@ -72,9 +72,7 @@ func TestNetworkPolicyFixtureIPSets(t *testing.T) {
 	controller, err := NewNetworkPolicyController(
 		client,
 		config,
-		podInformer,
-		npInformer,
-		nsInformer,
+		testInformers{pods: podInformer, namespaces: nsInformer, networkPolicies: npInformer},
 		&sync.Mutex{},
 		linkQ,
 		map[v1.IPFamily]utils.IPTablesHandler{

--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -76,6 +76,14 @@ type NetworkPolicyController interface {
 	NetworkPolicyEventHandler() cache.ResourceEventHandler
 }
 
+// Informers is the set of shared informers the NPC reads from. We declare it here rather than accepting a
+// full informer factory so that the controller can only reach the resources it actually watches.
+type Informers interface {
+	Pods() cache.SharedIndexInformer
+	Namespaces() cache.SharedIndexInformer
+	NetworkPolicies() cache.SharedIndexInformer
+}
+
 // NetworkPolicyController struct to hold information required by NetworkPolicyController
 type NetworkPolicyControllerBase struct {
 	krNode               utils.NodeIPAndFamilyAware
@@ -188,8 +196,7 @@ func (npc *NetworkPolicyControllerBase) RequestFullSync() {
 
 // NewNetworkPolicyController returns new NetworkPolicyController object
 func NewNetworkPolicyController(clientset kubernetes.Interface,
-	config *options.KubeRouterConfig, podInformer cache.SharedIndexInformer,
-	npInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer,
+	config *options.KubeRouterConfig, informers Informers,
 	ipsetMutex *sync.Mutex, linkQ utils.LocalLinkQuerier,
 	iptablesCmdHandlers map[v1core.IPFamily]utils.IPTablesHandler,
 	ipSetHandlers map[v1core.IPFamily]utils.IPSetHandler,
@@ -255,22 +262,38 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 	}
 
 	npcBase.filterTableRules = make(map[v1core.IPFamily]*bytes.Buffer, 2)
+
+	podInformer := informers.Pods()
 	npcBase.podLister = podInformer.GetIndexer()
 	npcBase.podEventHandler = npcBase.newPodEventHandler()
 
+	nsInformer := informers.Namespaces()
 	npcBase.nsLister = nsInformer.GetIndexer()
 	npcBase.namespaceEventHandler = npcBase.newNamespaceEventHandler()
 
+	npInformer := informers.NetworkPolicies()
 	npcBase.npLister = npInformer.GetIndexer()
 	npcBase.networkPolicyEventHandler = npcBase.newNetworkPolicyEventHandler()
+
+	// We register our own handlers here so that the wiring lives next to the handlers themselves. The informer
+	// factory has already been started by this point, which is fine, a SharedIndexInformer replays existing
+	// objects as synthetic adds to handlers that join late.
+	if _, err := podInformer.AddEventHandler(npcBase.podEventHandler); err != nil {
+		return nil, fmt.Errorf("failed to add PodEventHandler: %w", err)
+	}
+	if _, err := nsInformer.AddEventHandler(npcBase.namespaceEventHandler); err != nil {
+		return nil, fmt.Errorf("failed to add NamespaceEventHandler: %w", err)
+	}
+	if _, err := npInformer.AddEventHandler(npcBase.networkPolicyEventHandler); err != nil {
+		return nil, fmt.Errorf("failed to add NetworkPolicyEventHandler: %w", err)
+	}
 
 	if config.UseNftablesForNetpol {
 		// Cleanup any existing iptables rules before starting nftables controller to avoid conflicts
 		// in case of a restart with a different configuration
 		npc := NetworkPolicyControllerIptables{NetworkPolicyControllerBase: &NetworkPolicyControllerBase{}}
 		npc.Cleanup()
-		return NewNetworkPolicyControllerNftables(&npcBase, clientset, config,
-			podInformer, npInformer, nsInformer, linkQ, knftInterfaces)
+		return NewNetworkPolicyControllerNftables(&npcBase, config, knftInterfaces)
 	} else {
 		// Cleanup any existing nftables rules before starting iptables controller to avoid conflicts
 		// in case of a restart with a different configuration. Cleanup() self-initializes nftables
@@ -278,7 +301,6 @@ func NewNetworkPolicyController(clientset kubernetes.Interface,
 		// On hosts that lack nftables entirely, Cleanup() logs the error and returns without panic.
 		npc := NetworkPolicyControllerNftables{NetworkPolicyControllerBase: &NetworkPolicyControllerBase{}}
 		npc.Cleanup()
-		return NewNetworkPolicyControllerIptables(&npcBase, clientset, config,
-			podInformer, npInformer, nsInformer, linkQ, iptablesCmdHandlers, ipSetHandlers)
+		return NewNetworkPolicyControllerIptables(&npcBase, config, iptablesCmdHandlers, ipSetHandlers)
 	}
 }

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -31,6 +31,17 @@ import (
 	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 )
 
+// testInformers satisfies the package's Informers interface for tests that drive the constructor directly.
+type testInformers struct {
+	pods            cache.SharedIndexInformer
+	namespaces      cache.SharedIndexInformer
+	networkPolicies cache.SharedIndexInformer
+}
+
+func (t testInformers) Pods() cache.SharedIndexInformer            { return t.pods }
+func (t testInformers) Namespaces() cache.SharedIndexInformer      { return t.namespaces }
+func (t testInformers) NetworkPolicies() cache.SharedIndexInformer { return t.networkPolicies }
+
 // newFakeInformersFromClient creates the different informers used in the uneventful network policy controller
 func newFakeInformersFromClient(kubeClient clientset.Interface) (informers.SharedInformerFactory, cache.SharedIndexInformer, cache.SharedIndexInformer, cache.SharedIndexInformer) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
@@ -1420,7 +1431,8 @@ func TestNetworkPolicyController(t *testing.T) {
 					return
 				}
 				test.config.UseNftablesForNetpol = useNfTables
-				_, err := NewNetworkPolicyController(client, test.config, podInformer, netpolInformer, nsInformer,
+				_, err := NewNetworkPolicyController(client, test.config,
+					testInformers{pods: podInformer, namespaces: nsInformer, networkPolicies: netpolInformer},
 					&sync.Mutex{}, fakeLinkQuerier, iptablesHandlers, ipSetHandlers, validator, knftInterfaces)
 				if err == nil && test.expectError {
 					t.Error("This config should have failed, but it was successful instead")

--- a/pkg/controllers/netpol/npc_iptables.go
+++ b/pkg/controllers/netpol/npc_iptables.go
@@ -18,8 +18,6 @@ import (
 	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	"github.com/coreos/go-iptables/iptables"
 	v1core "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 )
@@ -1048,10 +1046,7 @@ func NewIPTablesHandlers(config *options.KubeRouterConfig) (
 
 // NewNetworkPolicyControllerIptables returns new NetworkPolicyControllerIptables object
 func NewNetworkPolicyControllerIptables(
-	npcBase *NetworkPolicyControllerBase, clientset kubernetes.Interface,
-	config *options.KubeRouterConfig, podInformer cache.SharedIndexInformer,
-	npInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer,
-	linkQ utils.LocalLinkQuerier,
+	npcBase *NetworkPolicyControllerBase, config *options.KubeRouterConfig,
 	iptablesCmdHandlers map[v1core.IPFamily]utils.IPTablesHandler,
 	ipSetHandlers map[v1core.IPFamily]utils.IPSetHandler) (*NetworkPolicyControllerIptables, error) {
 

--- a/pkg/controllers/netpol/npc_nftables.go
+++ b/pkg/controllers/netpol/npc_nftables.go
@@ -17,8 +17,6 @@ import (
 	"github.com/cloudnativelabs/kube-router/v2/pkg/options"
 	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	v1core "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 	"sigs.k8s.io/knftables"
@@ -376,10 +374,7 @@ func (npc *NetworkPolicyControllerNftables) ensureCommonPolicyChain() {
 }
 
 func NewNetworkPolicyControllerNftables(
-	npcBase *NetworkPolicyControllerBase, clientset kubernetes.Interface,
-	config *options.KubeRouterConfig, podInformer cache.SharedIndexInformer,
-	npInformer cache.SharedIndexInformer, nsInformer cache.SharedIndexInformer,
-	linkQ utils.LocalLinkQuerier,
+	npcBase *NetworkPolicyControllerBase, config *options.KubeRouterConfig,
 	knftInterfaces map[v1core.IPFamily]knftables.Interface) (*NetworkPolicyControllerNftables, error) {
 
 	npc := NetworkPolicyControllerNftables{NetworkPolicyControllerBase: npcBase, knftInterfaces: knftInterfaces}

--- a/pkg/controllers/netpol/npc_nftables_test.go
+++ b/pkg/controllers/netpol/npc_nftables_test.go
@@ -398,9 +398,7 @@ func TestFullPolicySync(t *testing.T) {
 	npc, err := NewNetworkPolicyController(
 		client,
 		config,
-		podInformer,
-		npInformer,
-		nsInformer,
+		testInformers{pods: podInformer, namespaces: nsInformer, networkPolicies: npInformer},
 		&sync.Mutex{},
 		linkQ,
 		nil,
@@ -885,7 +883,7 @@ func TestNftablesStalePolicyCleanup(t *testing.T) {
 	require.NoError(t, err)
 	npc, err := NewNetworkPolicyController(
 		client, config,
-		podInformer, npInformer, nsInformer,
+		testInformers{pods: podInformer, namespaces: nsInformer, networkPolicies: npInformer},
 		&sync.Mutex{}, linkQ, nil, nil,
 		ipRanges,
 		map[v1core.IPFamily]knftables.Interface{v1core.IPv4Protocol: ipv4KNft},
@@ -1032,7 +1030,7 @@ func TestNftablesNodePortRange(t *testing.T) {
 			require.NoError(t, err)
 			npc, err := NewNetworkPolicyController(
 				client, config,
-				podInformer, npInformer, nsInformer,
+				testInformers{pods: podInformer, namespaces: nsInformer, networkPolicies: npInformer},
 				&sync.Mutex{}, linkQ, nil, nil,
 				ipRanges,
 				map[v1core.IPFamily]knftables.Interface{v1core.IPv4Protocol: ipv4KNft},

--- a/pkg/controllers/proxy/linux_networking.go
+++ b/pkg/controllers/proxy/linux_networking.go
@@ -863,7 +863,7 @@ func (ln *linuxNetworking) configureContainerForDSR(
 	ctx := context.Background()
 	tunIf, err := nlretry.LinkByName(ctx, ipTunLink.Attrs().Name)
 	if err != nil {
-		if err.Error() != IfaceNotFound {
+		if _, notFound := errors.AsType[netlink.LinkNotFoundError](err); !notFound {
 			attemptNamespaceResetAfterError(hostNetworkNamespaceHandle)
 			return fmt.Errorf("failed to verify if ipip tunnel interface exists in endpoint %s namespace due "+
 				"to %v", endpointIP, err)
@@ -884,7 +884,7 @@ func (ln *linuxNetworking) configureContainerForDSR(
 			if err == nil {
 				break
 			}
-			if err.Error() == IfaceNotFound {
+			if _, notFound := errors.AsType[netlink.LinkNotFoundError](err); notFound {
 				klog.V(3).Infof("Waiting for tunnel interface %s to come up in the pod, retrying",
 					ipTunLink.Attrs().Name)
 				continue
@@ -957,7 +957,7 @@ func (ln *linuxNetworking) getKubeDummyInterface() (netlink.Link, error) {
 	ctx := context.Background()
 	var dummyVipInterface netlink.Link
 	dummyVipInterface, err := nlretry.LinkByName(ctx, KubeDummyIf)
-	if err != nil && err.Error() == IfaceNotFound {
+	if _, notFound := errors.AsType[netlink.LinkNotFoundError](err); err != nil && notFound {
 		klog.V(1).Infof("Could not find dummy interface: %s to assign cluster ip's, creating one",
 			KubeDummyIf)
 		err = netlink.LinkAdd(&netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: KubeDummyIf}})
@@ -972,6 +972,9 @@ func (ln *linuxNetworking) getKubeDummyInterface() (netlink.Link, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to bring dummy interface up: %w", err)
 		}
+	} else if err != nil {
+		// Without this we'd return (nil, nil) and callers would deref a nil link
+		return nil, fmt.Errorf("failed to look up dummy interface %s: %w", KubeDummyIf, err)
 	}
 	return dummyVipInterface, nil
 }

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -41,7 +41,6 @@ const (
 	KubeTunnelIfv4    = "kube-tunnel-if"
 	KubeTunnelIfv6    = "kube-tunnel-v6"
 	KubeBridgeIf      = "kube-bridge"
-	IfaceNotFound     = "Link not found"
 	IfaceHasNoAddr    = "cannot assign requested address"
 	IpvsMaglevHashing = "mh"
 	IpvsSvcFSched1    = "flag-1"
@@ -1850,13 +1849,13 @@ func (nsc *NetworkServicesController) Cleanup() {
 	// delete dummy interface used to assign cluster IP's
 	dummyVipInterface, err := nlretry.LinkByName(context.Background(), KubeDummyIf)
 	if err != nil {
-		if err.Error() != IfaceNotFound {
-			klog.Infof("Dummy interface: " + KubeDummyIf + " does not exist")
+		if _, notFound := errors.AsType[netlink.LinkNotFoundError](err); notFound {
+			klog.Infof("Dummy interface: %s does not exist", KubeDummyIf)
 		}
 	} else {
 		err = netlink.LinkDel(dummyVipInterface)
 		if err != nil {
-			klog.Errorf("could not delete dummy interface %s due to: %v", KubeDummyIf, err.Error())
+			klog.Errorf("could not delete dummy interface %s due to: %v", KubeDummyIf, err)
 			return
 		}
 	}

--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -165,6 +165,14 @@ type NetworkServicesController struct {
 	nphc *nodePortHealthCheckController
 }
 
+// Informers is the set of shared informers the NSC reads from. We declare it here rather than accepting a
+// full informer factory so that the controller can only reach the resources it actually watches.
+type Informers interface {
+	Services() cache.SharedIndexInformer
+	EndpointSlices() cache.SharedIndexInformer
+	Pods() cache.SharedIndexInformer
+}
+
 type ipvsCalls interface {
 	ipvsNewService(ipvsSvc *ipvs.Service) error
 	ipvsAddService(svcs []*ipvs.Service, vip net.IP, protocol, port uint16, persistent bool,
@@ -2017,8 +2025,7 @@ func (nsc *NetworkServicesController) setupHandlers(node *v1.Node) error {
 
 // NewNetworkServicesController returns NetworkServicesController object
 func NewNetworkServicesController(clientset kubernetes.Interface,
-	config *options.KubeRouterConfig, svcInformer cache.SharedIndexInformer,
-	epSliceInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer,
+	config *options.KubeRouterConfig, informers Informers,
 	ipsetMutex *sync.Mutex, ipFilter svcip.Filter) (*NetworkServicesController, error) {
 
 	var err error
@@ -2115,15 +2122,27 @@ func NewNetworkServicesController(clientset kubernetes.Interface,
 	// Store MTU only. Code setting MSS will handle address family, and calculate correct MSS.
 	nsc.mtu = automtu
 
-	nsc.podLister = podInformer.GetIndexer()
+	nsc.podLister = informers.Pods().GetIndexer()
 
+	svcInformer := informers.Services()
 	nsc.svcLister = svcInformer.GetIndexer()
 	nsc.ServiceEventHandler = nsc.newSvcEventHandler()
 
 	nsc.ipvsPermitAll = config.IpvsPermitAll
 
+	epSliceInformer := informers.EndpointSlices()
 	nsc.epSliceLister = epSliceInformer.GetIndexer()
 	nsc.EndpointSliceEventHandler = nsc.newEndpointSliceEventHandler()
+
+	// We register our own handlers here so that the wiring lives next to the handlers themselves. The informer
+	// factory has already been started by this point, which is fine, a SharedIndexInformer replays existing
+	// objects as synthetic adds to handlers that join late.
+	if _, err := svcInformer.AddEventHandler(nsc.ServiceEventHandler); err != nil {
+		return nil, fmt.Errorf("failed to add ServiceEventHandler: %w", err)
+	}
+	if _, err := epSliceInformer.AddEventHandler(nsc.EndpointSliceEventHandler); err != nil {
+		return nil, fmt.Errorf("failed to add EndpointSliceEventHandler: %w", err)
+	}
 
 	// Not creating the hairpin controller for now because this should be handled at the CNI level. The CNI bridge
 	// plugin ensures that hairpin mode is set much more reliably than we do. However, as a lot of work was put into

--- a/pkg/controllers/proxy/network_services_controller_test.go
+++ b/pkg/controllers/proxy/network_services_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cloudnativelabs/kube-router/v2/pkg/controllers/testhelpers"
 	"github.com/cloudnativelabs/kube-router/v2/pkg/svcip"
 	"github.com/cloudnativelabs/kube-router/v2/pkg/utils"
 	"github.com/moby/ipvs"
@@ -2183,6 +2184,214 @@ func TestShuffleDoesNotPanicOnEmptySlice(t *testing.T) {
 			result := shuffle(tt.input)
 			assert.Equal(t, len(tt.input), len(result), "shuffle should preserve slice length")
 		})
+	}
+}
+
+// setupDualStackNodeController creates a controller backed by a dual-stack node (v4 primary + v6 internal).
+// It returns the ipvsState (for inspecting services), the mock, and the controller.
+//
+//nolint:unparam // mockIPVSState returned for API consistency with setupTestController
+func setupDualStackNodeController(t *testing.T, service *v1core.Service) (
+	*mockIPVSState, *LinuxNetworkingMock, *NetworkServicesController) {
+	t.Helper()
+
+	ipvsState := newMockIPVSState()
+	netlinkState := newMockNetlinkState()
+
+	mock := &LinuxNetworkingMock{
+		getKubeDummyInterfaceFunc:          createMockGetKubeDummyInterface(netlinkState),
+		ipAddrAddFunc:                      createMockIPAddrAdd(netlinkState),
+		ipAddrDelFunc:                      createMockIPAddrDel(netlinkState),
+		setupPolicyRoutingForDSRFunc:       createMockSetupPolicyRoutingForDSR(netlinkState),
+		setupRoutesForExternalIPForDSRFunc: createMockSetupRoutesForExternalIPForDSR(netlinkState),
+		configureContainerForDSRFunc:       createMockConfigureContainerForDSR(netlinkState),
+		getContainerPidWithDockerFunc:      createMockGetContainerPidWithDocker(netlinkState),
+		getContainerPidWithCRIFunc:         createMockGetContainerPidWithCRI(netlinkState),
+		findIfaceLinkForPidFunc:            createMockFindIfaceLinkForPid(netlinkState),
+		ipvsAddServerFunc: func(ipvsSvc *ipvs.Service, ipvsDst *ipvs.Destination) error {
+			return nil
+		},
+		ipvsAddServiceFunc: func(svcs []*ipvs.Service, vip net.IP, protocol uint16, port uint16,
+			persistent bool, persistentTimeout int32, scheduler string,
+			flags schedFlags) ([]*ipvs.Service, *ipvs.Service, error) {
+			svc := &ipvs.Service{Address: vip, Protocol: protocol, Port: port}
+			ipvsState.services = append(ipvsState.services, svc)
+			return svcs, svc, nil
+		},
+		ipvsDelServiceFunc: func(ipvsSvc *ipvs.Service) error { return nil },
+		ipvsGetDestinationsFunc: func(ipvsSvc *ipvs.Service) ([]*ipvs.Destination, error) {
+			return []*ipvs.Destination{}, nil
+		},
+		ipvsGetServicesFunc: func() ([]*ipvs.Service, error) {
+			svcsCopy := make([]*ipvs.Service, len(ipvsState.services))
+			copy(svcsCopy, ipvsState.services)
+			return svcsCopy, nil
+		},
+	}
+
+	routeVIPTrafficToDirector = createMockRouteVIPTrafficToDirector(netlinkState)
+
+	clientset := fake.NewSimpleClientset()
+	_, err := clientset.CoreV1().Services("default").Create(
+		context.Background(), service, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	// Dual-stack node: IPv4 primary + IPv6 internal address.
+	krNode := &utils.LocalKRNode{
+		KRNode: utils.KRNode{
+			NodeName:  "node-1",
+			PrimaryIP: net.ParseIP("10.0.0.1"),
+			NodeIPv6Addrs: map[v1core.NodeAddressType][]net.IP{
+				v1core.NodeInternalIP: {net.ParseIP("2001:db8::1")},
+			},
+		},
+	}
+
+	ipt4 := &utils.IPTablesHandlerMock{
+		AppendUniqueFunc: func(table string, chain string, rulespec ...string) error { return nil },
+		ExistsFunc:       func(table string, chain string, rulespec ...string) (bool, error) { return false, nil },
+		DeleteFunc:       func(table string, chain string, rulespec ...string) error { return nil },
+	}
+	ipt6 := &utils.IPTablesHandlerMock{
+		AppendUniqueFunc: func(table string, chain string, rulespec ...string) error { return nil },
+		ExistsFunc:       func(table string, chain string, rulespec ...string) (bool, error) { return false, nil },
+		DeleteFunc:       func(table string, chain string, rulespec ...string) error { return nil },
+	}
+
+	nsc := &NetworkServicesController{
+		krNode:     krNode,
+		ln:         mock,
+		nphc:       NewNodePortHealthCheck(),
+		ipsetMutex: &sync.Mutex{},
+		client:     clientset,
+		fwMarkMap:  make(map[uint32]string),
+		iptablesCmdHandlers: map[v1core.IPFamily]utils.IPTablesHandler{
+			v1core.IPv4Protocol: ipt4,
+			v1core.IPv6Protocol: ipt6,
+		},
+		ipSetHandlers: map[v1core.IPFamily]utils.IPSetHandler{
+			v1core.IPv4Protocol: testhelpers.NewFakeIPSetHandler(false),
+			v1core.IPv6Protocol: testhelpers.NewFakeIPSetHandler(true),
+		},
+	}
+
+	startInformersForServiceProxy(t, nsc, clientset)
+	waitForListerWithTimeout(t, nsc.svcLister, time.Second*10)
+
+	nsc.setServiceMap(nsc.buildServicesInfo())
+	nsc.endpointsMap = nsc.buildEndpointSliceInfo()
+
+	return ipvsState, mock, nsc
+}
+
+// TestDualStackNodePort_BothFamiliesGetIPVSService verifies that on a dual-stack node,
+// a dual-stack NodePort service produces IPVS NodePort services on both the v4 and v6 node IPs.
+// This is the regression test for the bug where only the primary (v4) family got a NodePort service
+// and traffic to [nodeV6IP]:nodePort was black-holed.
+func TestDualStackNodePort_BothFamiliesGetIPVSService(t *testing.T) {
+	intPolicyCluster := v1core.ServiceInternalTrafficPolicyCluster
+	extPolicyCluster := v1core.ServiceExternalTrafficPolicyCluster
+
+	service := &v1core.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-ds-np", Namespace: "default"},
+		Spec: v1core.ServiceSpec{
+			Type:                  v1core.ServiceTypeNodePort,
+			ClusterIP:             "10.100.5.1",
+			ClusterIPs:            []string{"10.100.5.1", "2001:db8:42::1"},
+			IPFamilies:            []v1core.IPFamily{v1core.IPv4Protocol, v1core.IPv6Protocol},
+			InternalTrafficPolicy: &intPolicyCluster,
+			ExternalTrafficPolicy: extPolicyCluster,
+			Ports: []v1core.ServicePort{
+				{Name: "http", Port: 8080, NodePort: 30500, Protocol: v1core.ProtocolTCP},
+			},
+		},
+	}
+
+	_, mock, nsc := setupDualStackNodeController(t, service)
+
+	err := nsc.syncIpvsServices(nsc.getServiceMap(), nsc.endpointsMap)
+	assert.NoError(t, err)
+
+	actualServices := getServicesFromAddServiceCalls(mock)
+
+	assert.Contains(t, actualServices, "10.0.0.1:6:30500:false:rr",
+		"v4 NodePort IPVS service should be created on the IPv4 node IP")
+	assert.Contains(t, actualServices, "2001:db8::1:6:30500:false:rr",
+		"v6 NodePort IPVS service should be created on the IPv6 node IP")
+}
+
+// TestSingleStackNodePort_OnlyOwnFamilyGetsIPVSService verifies that a single-stack (IPv4-only)
+// NodePort service on a dual-stack node only creates a NodePort IPVS service for IPv4, not IPv6.
+func TestSingleStackNodePort_OnlyOwnFamilyGetsIPVSService(t *testing.T) {
+	intPolicyCluster := v1core.ServiceInternalTrafficPolicyCluster
+	extPolicyCluster := v1core.ServiceExternalTrafficPolicyCluster
+
+	service := &v1core.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-v4-np", Namespace: "default"},
+		Spec: v1core.ServiceSpec{
+			Type:                  v1core.ServiceTypeNodePort,
+			ClusterIP:             "10.100.6.1",
+			ClusterIPs:            []string{"10.100.6.1"},
+			IPFamilies:            []v1core.IPFamily{v1core.IPv4Protocol},
+			InternalTrafficPolicy: &intPolicyCluster,
+			ExternalTrafficPolicy: extPolicyCluster,
+			Ports: []v1core.ServicePort{
+				{Name: "http", Port: 8080, NodePort: 30501, Protocol: v1core.ProtocolTCP},
+			},
+		},
+	}
+
+	_, mock, nsc := setupDualStackNodeController(t, service)
+
+	err := nsc.syncIpvsServices(nsc.getServiceMap(), nsc.endpointsMap)
+	assert.NoError(t, err)
+
+	actualServices := getServicesFromAddServiceCalls(mock)
+
+	assert.Contains(t, actualServices, "10.0.0.1:6:30501:false:rr",
+		"v4 NodePort IPVS service should be created on the IPv4 node IP")
+	for _, svc := range actualServices {
+		assert.NotContains(t, svc, "2001:db8::1",
+			"no v6 NodePort IPVS service should be created for an IPv4-only service")
+	}
+}
+
+// TestSingleStackV6NodePort_OnlyOwnFamilyGetsIPVSService verifies that a single-stack (IPv6-only)
+// NodePort service on a dual-stack node creates its NodePort IPVS service on the v6 node IP rather
+// than the primary (v4) node IP, which is the corner that black-holed v6-only NodePort traffic.
+func TestSingleStackV6NodePort_OnlyOwnFamilyGetsIPVSService(t *testing.T) {
+	intPolicyCluster := v1core.ServiceInternalTrafficPolicyCluster
+	extPolicyCluster := v1core.ServiceExternalTrafficPolicyCluster
+
+	service := &v1core.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-v6-np", Namespace: "default"},
+		Spec: v1core.ServiceSpec{
+			Type:                  v1core.ServiceTypeNodePort,
+			ClusterIP:             "2001:db8:42::2",
+			ClusterIPs:            []string{"2001:db8:42::2"},
+			IPFamilies:            []v1core.IPFamily{v1core.IPv6Protocol},
+			InternalTrafficPolicy: &intPolicyCluster,
+			ExternalTrafficPolicy: extPolicyCluster,
+			Ports: []v1core.ServicePort{
+				{Name: "http", Port: 8080, NodePort: 30502, Protocol: v1core.ProtocolTCP},
+			},
+		},
+	}
+
+	_, mock, nsc := setupDualStackNodeController(t, service)
+
+	err := nsc.syncIpvsServices(nsc.getServiceMap(), nsc.endpointsMap)
+	assert.NoError(t, err)
+
+	actualServices := getServicesFromAddServiceCalls(mock)
+
+	assert.Contains(t, actualServices, "2001:db8::1:6:30502:false:rr",
+		"v6 NodePort IPVS service should be created on the IPv6 node IP")
+	for _, svc := range actualServices {
+		assert.NotContains(t, svc, "10.0.0.1",
+			"no v4 IPVS service should be created for an IPv6-only service")
 	}
 }
 

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -336,14 +336,36 @@ func (nsc *NetworkServicesController) setupNodePortServices(serviceInfoMap servi
 				}
 			}
 		} else {
-			ipvsSvcs, svcID, ipvsSvc = nsc.addIPVSService(ipvsSvcs, activeServiceEndpointMap, svc,
-				nsc.krNode.GetPrimaryNodeIP(), protocol, nPort)
-			// We weren't able to create the IPVS service, so we won't be able to add endpoints to it
-			if svcID == "" {
-				continue
+			// A NodePort is one port shared across every family the Service exposes, but each family has to
+			// be programmed on that family's node IP, otherwise the secondary family NodePort never gets an
+			// IPVS service and traffic to [nodeV6IP]:nodePort is black-holed.
+			for family, famClusIPs := range getAllClusterIPs(svc) {
+				// Skip families the Service doesn't actually expose (getAllClusterIPs always returns both
+				// family keys, but the slice will be empty for families the Service doesn't use).
+				if len(famClusIPs) == 0 {
+					continue
+				}
+				var nodeIP net.IP
+				//nolint:exhaustive // only two IP families exist
+				switch family {
+				case v1.IPv4Protocol:
+					nodeIP = nsc.krNode.FindBestIPv4NodeAddress()
+				case v1.IPv6Protocol:
+					nodeIP = nsc.krNode.FindBestIPv6NodeAddress()
+				}
+				if nodeIP == nil {
+					// node doesn't have an address in this family (single-stack node with a dual-stack service)
+					continue
+				}
+				ipvsSvcs, svcID, ipvsSvc = nsc.addIPVSService(ipvsSvcs, activeServiceEndpointMap, svc,
+					nodeIP, protocol, nPort)
+				// We weren't able to create the IPVS service, so we won't be able to add endpoints to it
+				if svcID == "" {
+					continue
+				}
+				nsc.addEndpointsToIPVSService(endpoints, activeServiceEndpointMap, svc, svcID, ipvsSvc,
+					nodeIP, false)
 			}
-			nsc.addEndpointsToIPVSService(endpoints, activeServiceEndpointMap, svc, svcID, ipvsSvc,
-				nsc.krNode.GetPrimaryNodeIP(), false)
 		}
 	}
 

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -421,7 +421,7 @@ func (nrc *NetworkRoutingController) initCNIConfig() (mtu int, _ *utils.CNINetwo
 		}
 	}
 
-	// Insert any IPv4 CIDRs that are missing from the IPAM configuration in the CNI
+	// Insert any IPv6 CIDRs that are missing from the IPAM configuration in the CNI
 	for _, ipv6CIDR := range nrc.podIPv6CIDRs {
 		err = cniNetConf.InsertPodCIDRIntoIPAM(ipv6CIDR)
 		if err != nil {
@@ -465,28 +465,32 @@ func (nrc *NetworkRoutingController) setupKubeBridge(ctx context.Context, mtu in
 		return
 	}
 
+	// We call LinkSetUp unconditionally so that bridges that already existed (and were returned
+	// by the first LinkByName above) are also brought up - idempotent and safe to repeat.
 	if err := netlink.LinkSetUp(kubeBridgeIf); err != nil {
 		klog.Errorf("Failed to bring kube-bridge interface up due to %v.", err)
 	}
 
 	if mtu > 0 {
-		klog.Infof("Setting MTU of kube-bridge interface to: %d", mtu)
-		err = netlink.LinkSetMTU(kubeBridgeIf, mtu)
-		if err != nil {
-			klog.Errorf(
-				"Failed to set MTU for kube-bridge interface due to: %s (kubeBridgeIf: %#v, mtu: %v)",
-				err.Error(),
-				kubeBridgeIf,
-				mtu,
-			)
-			// Update the CNI config to include the effective MTU, if any.
-			if currentMTU := kubeBridgeIf.Attrs().MTU; currentMTU > 0 && cniNetConf != nil && currentMTU != mtu {
-				klog.Warningf(
-					"Updating CNI config with current MTU for kube-bridge: %d",
-					currentMTU,
-				)
-				cniNetConf.SetMTU(currentMTU)
-			}
+		nrc.setKubeBridgeMTU(kubeBridgeIf, mtu, cniNetConf)
+	}
+}
+
+func (nrc *NetworkRoutingController) setKubeBridgeMTU(
+	kubeBridgeIf netlink.Link, mtu int, cniNetConf *utils.CNINetworkConfig,
+) {
+	klog.Infof("Setting MTU of kube-bridge interface to: %d", mtu)
+	if err := netlink.LinkSetMTU(kubeBridgeIf, mtu); err != nil {
+		klog.Errorf(
+			"Failed to set MTU for kube-bridge interface due to: %v (kubeBridgeIf: %#v, mtu: %v)",
+			err,
+			kubeBridgeIf,
+			mtu,
+		)
+		// Fall back to the bridge's current MTU so the CNI config stays consistent.
+		if currentMTU := kubeBridgeIf.Attrs().MTU; currentMTU > 0 && cniNetConf != nil && currentMTU != mtu {
+			klog.Warningf("Updating CNI config with current MTU for kube-bridge: %d", currentMTU)
+			cniNetConf.SetMTU(currentMTU)
 		}
 	}
 }

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -99,6 +99,14 @@ type PolicyBasedRouter interface {
 	Disable() error
 }
 
+// Informers is the set of shared informers the NRC reads from. We declare it here rather than accepting a
+// full informer factory so that the controller can only reach the resources it actually watches.
+type Informers interface {
+	Nodes() cache.SharedIndexInformer
+	Services() cache.SharedIndexInformer
+	EndpointSlices() cache.SharedIndexInformer
+}
+
 // NetworkRoutingController is struct to hold necessary information required by controller
 type NetworkRoutingController struct {
 	krNode                         utils.NodeAware
@@ -1238,8 +1246,7 @@ func (nrc *NetworkRoutingController) setupHandlers(node *v1core.Node) error {
 // NewNetworkRoutingController returns new NetworkRoutingController object
 func NewNetworkRoutingController(clientset kubernetes.Interface,
 	kubeRouterConfig *options.KubeRouterConfig,
-	nodeInformer cache.SharedIndexInformer, svcInformer cache.SharedIndexInformer,
-	epSliceInformer cache.SharedIndexInformer, ipsetMutex *sync.Mutex,
+	informers Informers, ipsetMutex *sync.Mutex,
 	ipFilter svcip.Filter,
 ) (*NetworkRoutingController, error) {
 	var err error
@@ -1483,14 +1490,30 @@ func NewNetworkRoutingController(clientset kubernetes.Interface,
 		}
 		nrc.localAddressList = append(nrc.localAddressList, localAddresses...)
 	}
+	svcInformer := informers.Services()
 	nrc.svcLister = svcInformer.GetIndexer()
 	nrc.ServiceEventHandler = nrc.newServiceEventHandler()
 
+	epSliceInformer := informers.EndpointSlices()
 	nrc.epSliceLister = epSliceInformer.GetIndexer()
 	nrc.EndpointSliceEventHandler = nrc.newEndpointSliceEventHandler()
 
+	nodeInformer := informers.Nodes()
 	nrc.nodeLister = nodeInformer.GetIndexer()
 	nrc.NodeEventHandler = nrc.newNodeEventHandler()
+
+	// We register our own handlers here so that the wiring lives next to the handlers themselves. The informer
+	// factory has already been started by this point, which is fine, a SharedIndexInformer replays existing
+	// objects as synthetic adds to handlers that join late.
+	if _, err := nodeInformer.AddEventHandler(nrc.NodeEventHandler); err != nil {
+		return nil, fmt.Errorf("failed to add NodeEventHandler: %w", err)
+	}
+	if _, err := svcInformer.AddEventHandler(nrc.ServiceEventHandler); err != nil {
+		return nil, fmt.Errorf("failed to add ServiceEventHandler: %w", err)
+	}
+	if _, err := epSliceInformer.AddEventHandler(nrc.EndpointSliceEventHandler); err != nil {
+		return nil, fmt.Errorf("failed to add EndpointSliceEventHandler: %w", err)
+	}
 
 	return &nrc, nil
 }

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -39,9 +39,6 @@ import (
 )
 
 const (
-	// Deprecated: Use [netlink.LinkNotFoundError] instead.
-	IfaceNotFound = "Link not found"
-
 	podSubnetsIPSetName = "kube-router-pod-subnets"
 	nodeAddrsIPSetName  = "kube-router-node-ips"
 

--- a/pkg/controllers/routing/network_routes_controller.go
+++ b/pkg/controllers/routing/network_routes_controller.go
@@ -176,6 +176,16 @@ func (nrc *NetworkRoutingController) Run(
 	stopCh <-chan struct{},
 	wg *sync.WaitGroup,
 ) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
 	mtu, cniNetConf := nrc.initCNIConfig()
 
 	klog.V(1).Info("Populating ipsets.")
@@ -254,7 +264,7 @@ func (nrc *NetworkRoutingController) Run(
 	}
 
 	// create 'kube-bridge' interface to which pods will be connected
-	nrc.setupKubeBridge(context.TODO(), mtu, cniNetConf)
+	nrc.setupKubeBridge(ctx, mtu, cniNetConf)
 
 	if cniNetConf != nil {
 		if err := cniNetConf.WriteCNIConfig(); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?

<!--
Please choose one of the following kinds:
-->
bug
cleanup
feature
regression

#### What this PR does / why we need it:

This PR does a few things:

* Fixes a regression in the e2e-netpol action flow that I accidentally introduced
* kube-router now fails if people accidentally introduce positional args instead of silently swallowing them
* Refactors `setupKubeBridge()` to be less complex and fixes an IPv6 comment
* Replaces string error checking with `errors.AsType` available since 1.25 for netlink error type checking also add more complete error handling
* Add proper context handling to `NRC.Run()` to `setupKubeBridge()` to ensure that it doesn't get stuck during termination
* Add dual-stack handling for `NodePort` binding (similar to what was done for ClusterIP) to ensure that even if the primary interface is one family or another, that in dual-stack handling it at least binds to both families. This was causing several conformance tests to fail previously and had never been properly handled before
  * Also adds tests to ensure regressions don't happen in the future
* Add a structured way of passing k8s informers into the various kube-router controllers
  * This reduces the complexity of controller signatures and moves handler adding into the controllers which is a bit more idiomatic and self-contained

The dual-stack NodePort handling fixes the following k8s conformance regressions:

```
  [FAIL] [sig-network] [Feature:IPv6DualStack] Granular Checks: Services Secondary IP Family [LinuxOnly] [It] should function for endpoint-Service: http [sig-network, Feature:IPv6DualStack]
  [FAIL] [sig-network] [Feature:IPv6DualStack] Granular Checks: Services Secondary IP Family [LinuxOnly] [It] should function for endpoint-Service: udp [sig-network, Feature:IPv6DualStack]
  [FAIL] [sig-network] [Feature:IPv6DualStack] Granular Checks: Services Secondary IP Family [LinuxOnly] [It] should function for node-Service: http [sig-network, Feature:IPv6DualStack]
  [FAIL] [sig-network] [Feature:IPv6DualStack] Granular Checks: Services Secondary IP Family [LinuxOnly] [It] should function for node-Service: udp [sig-network, Feature:IPv6DualStack]
  [FAIL] [sig-network] [Feature:IPv6DualStack] Granular Checks: Services Secondary IP Family [LinuxOnly] [It] should function for pod-Service: http [sig-network, Feature:IPv6DualStack]
  [FAIL] [sig-network] [Feature:IPv6DualStack] Granular Checks: Services Secondary IP Family [LinuxOnly] [It] should function for pod-Service: sctp [Feature:SCTPConnectivity] [sig-network, Feature:IPv6DualStack, Feature:SCTPConnectivity]
  [FAIL] [sig-network] [Feature:IPv6DualStack] Granular Checks: Services Secondary IP Family [LinuxOnly] [It] should function for pod-Service: udp [sig-network, Feature:IPv6DualStack]
  [FAIL] [sig-network] [Feature:IPv6DualStack] Granular Checks: Services Secondary IP Family [LinuxOnly] [It] should function for service endpoints using hostNetwork [sig-network, Feature:IPv6DualStack]
  [FAIL] [sig-network] Services [It] should be able to create a functioning NodePort service [Conformance] [sig-network, Conformance]
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->
None

#### Was AI used during the creation of this PR?
<!--
We are not against AI, but in the current era of tech AI is being used more and more to help upstream projects and it is
useful for the maintainers of this project to understand if AI was used and to what extent it was used. Please see our
AI policy: https://github.com/cloudnativelabs/kube-router/blob/master/AI_POLICY.md

If no AI was used during the generation of this PR, please remove the following content and simply put "No" for this
section.
-->

* What tool was used: Claude
* To what extent was the tool used? Most coding, with supervision / review by human
* If drafted, how detailed of a plan did you create for the AI? Very Detailed
* Help us understand if a human was in the loop or not for this PR? Yes

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->

Fully k8s conformance testing, this resolves 9 conformance test failures. Plus it was deployed to a working k8s cluster.

#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Replacement of individual structured k8s informers does introduce pkg instability in the current v2 version for downstreams
```

#### Anything else the reviewer should know that wasn't already covered?

This is a semi-large PR with a lot of clubbed changes, I would recommend reviewing it commit-by-commit as it is easier to understand that way.