### PR TITLE
Fix scorecard findings

### DIFF
--- a/.github/workflows/ci-e2e-netpol.yml
+++ b/.github/workflows/ci-e2e-netpol.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
       with:
         go-version: ${{ env.GO_VERSION }}
       id: go

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,12 +21,15 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 
 jobs:
   CodeQL-Build:
     # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout repository

--- a/pkg/controllers/routing/utils.go
+++ b/pkg/controllers/routing/utils.go
@@ -2,6 +2,7 @@ package routing
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -74,8 +75,7 @@ func stringSliceB64Decode(s []string) ([]string, error) {
 	for _, b64String := range s {
 		decoded, err := base64.StdEncoding.DecodeString(b64String)
 		if err != nil {
-			return nil, fmt.Errorf("could not parse \"%s\" as a base64 encoded string",
-				b64String)
+			return nil, errors.New("could not parse value as a base64 encoded string")
 		}
 		ss = append(ss, string(decoded))
 	}

--- a/pkg/controllers/routing/utils_test.go
+++ b/pkg/controllers/routing/utils_test.go
@@ -50,3 +50,37 @@ func Test_stringSliceToIPNets(t *testing.T) {
 		assert.Nil(t, ips)
 	})
 }
+
+func Test_stringSliceB64Decode(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		expected  []string
+		errorText string
+	}{
+		{
+			name:     "valid values",
+			input:    []string{"cGFzc3dvcmQ=", "c2VjcmV0"},
+			expected: []string{"password", "secret"},
+		},
+		{
+			name:      "invalid value is not returned in error",
+			input:     []string{"sensitive-value"},
+			errorText: "could not parse value as a base64 encoded string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := stringSliceB64Decode(tt.input)
+			if tt.errorText != "" {
+				assert.EqualError(t, err, tt.errorText)
+				assert.Nil(t, actual)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?

<!--
Please choose one of the following kinds:
-->
bug

#### What this PR does / why we need it:

Cleans up open findings from the OSS Scorecard job.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->
None

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->
None

#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

This does make troubleshooting failed BGP MD5 sums harder to triage if the user's cluster has more than one.