### PR TITLE
fact(NSC): reuse caller's local IP map in isValidKubeRouterServiceArt…

### DIFF
--- a/pkg/controllers/proxy/network_services_controller.go
+++ b/pkg/controllers/proxy/network_services_controller.go
@@ -680,7 +680,7 @@ func (nsc *NetworkServicesController) syncIpvsFirewall() error {
 			address = ipvsService.Address
 			port = int(ipvsService.Port)
 
-			isValid, err := nsc.isValidKubeRouterServiceArtifact(address, port)
+			isValid, err := nsc.isValidKubeRouterServiceArtifact(address, port, addrsMap)
 			if err != nil {
 				klog.Infof("failed to lookup service by address %s: %v - this does not appear to be a kube-router "+
 					"controlled service, skipping...", address, err)

--- a/pkg/controllers/proxy/service_endpoints_sync.go
+++ b/pkg/controllers/proxy/service_endpoints_sync.go
@@ -274,6 +274,18 @@ func (nsc *NetworkServicesController) setupNodePortServices(serviceInfoMap servi
 		return fmt.Errorf("failed get list of IPVS services due to: %w", err)
 	}
 
+	// Enumerate once per sync because doing it in the loop below is a netlink sweep per NodePort service
+	var addrMap map[v1.IPFamily][]net.IP
+	if nsc.nodeportBindOnAllIP {
+		addrMap, err = getAllLocalIPs()
+		if err != nil {
+			return fmt.Errorf("could not get list of system addresses for ipvs services: %w", err)
+		}
+		if !hasAnyIPs(addrMap) {
+			return errors.New("no IP addresses returned for nodeport service creation")
+		}
+	}
+
 	// For each Service in our service map
 	for k, svc := range serviceInfoMap {
 		protocol := convertSvcProtoToSysCallProto(svc.protocol)
@@ -301,31 +313,8 @@ func (nsc *NetworkServicesController) setupNodePortServices(serviceInfoMap servi
 		var ipvsSvc *ipvs.Service
 		if nsc.nodeportBindOnAllIP {
 			// Bind on all interfaces instead of just the primary interface
-			addrMap, err := getAllLocalIPs()
-			if err != nil {
-				klog.Errorf("Could not get list of system addresses for ipvs services: %s", err.Error())
-				continue
-			}
-
-			// Check that any addrs were actually found
-			addrsFound := false
-			for _, addrs := range addrMap {
-				if len(addrs) > 0 {
-					addrsFound = true
-				}
-				if addrsFound {
-					break
-				}
-			}
-			if !addrsFound {
-				klog.Errorf("No IP addresses returned for nodeport service creation!")
-				continue
-			}
-
-			// Create the services
 			for _, addrs := range addrMap {
 				for _, addr := range addrs {
-
 					ipvsSvcs, svcID, ipvsSvc = nsc.addIPVSService(ipvsSvcs, activeServiceEndpointMap, svc, addr,
 						protocol, nPort)
 					// We weren't able to create the IPVS service, so we won't be able to add endpoints to it
@@ -385,17 +374,7 @@ func (nsc *NetworkServicesController) setupExternalIPServices(serviceInfoMap ser
 		}
 
 		extIPs := getAllExternalIPs(svc, !svc.skipLbIps)
-		// Check that any addrs were actually found
-		addrsFound := false
-		for _, addrs := range extIPs {
-			if len(addrs) > 0 {
-				addrsFound = true
-			}
-			if addrsFound {
-				break
-			}
-		}
-		if !addrsFound {
+		if !hasAnyIPs(extIPs) {
 			klog.V(1).Infof("no external IP addresses returned for service %s:%s skipping...",
 				svc.namespace, svc.name)
 			continue

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -581,6 +581,16 @@ func getAllLocalIPs() (map[v1.IPFamily][]net.IP, error) {
 	return convertIPMapsToFamilyMap(v4Map, v6Map), nil
 }
 
+// hasAnyIPs reports whether a family separated IP map holds at least one address in any family
+func hasAnyIPs(ipMap map[v1.IPFamily][]net.IP) bool {
+	for _, ips := range ipMap {
+		if len(ips) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // getIPSetName formulates an IP Family specific ipset name based upon the prefix and IPFamily passed
 func getIPSetName(nameBase string, family v1.IPFamily) string {
 	var sb strings.Builder

--- a/pkg/controllers/proxy/utils.go
+++ b/pkg/controllers/proxy/utils.go
@@ -123,8 +123,9 @@ func (nsc *NetworkServicesController) lookupServiceByFWMark(fwMark uint32) (stri
 }
 
 // isValidKubeRouterServiceArtifact looks up a service by its clusterIP, externalIP, or loadBalancerIP. It returns
-// truthy
-func (nsc *NetworkServicesController) isValidKubeRouterServiceArtifact(address net.IP, nodePort int) (bool, error) {
+// truthy. localIPs is the node's local address map, supplied by the caller.
+func (nsc *NetworkServicesController) isValidKubeRouterServiceArtifact(address net.IP, nodePort int,
+	localIPs map[v1.IPFamily][]net.IP) (bool, error) {
 	for _, svc := range nsc.getServiceMap() {
 		for _, clIP := range svc.clusterIPs {
 			if net.ParseIP(clIP).Equal(address) {
@@ -143,15 +144,11 @@ func (nsc *NetworkServicesController) isValidKubeRouterServiceArtifact(address n
 		}
 		if nodePort != 0 && svc.nodePort == nodePort {
 			if nsc.nodeportBindOnAllIP {
-				addrMap, err := getAllLocalIPs()
-				if err != nil {
-					return false, fmt.Errorf("failed to get all local IPs: %w", err)
-				}
 				var addresses []net.IP
 				if address.To4() != nil {
-					addresses = addrMap[v1.IPv4Protocol]
+					addresses = localIPs[v1.IPv4Protocol]
 				} else {
-					addresses = addrMap[v1.IPv6Protocol]
+					addresses = localIPs[v1.IPv6Protocol]
 				}
 				for _, addr := range addresses {
 					if addr.Equal(address) {

--- a/pkg/controllers/proxy/utils_test.go
+++ b/pkg/controllers/proxy/utils_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/moby/ipvs"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
+	v1 "k8s.io/api/core/v1"
 )
 
 func getMoqNSC() *NetworkServicesController {
@@ -251,9 +252,42 @@ func TestIsValidKubeRouterServiceArtifact(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result, err := nsc.isValidKubeRouterServiceArtifact(test.address, test.port)
+		result, err := nsc.isValidKubeRouterServiceArtifact(test.address, test.port, nil)
 		if result != test.expected || (err != nil && err.Error() != test.err.Error()) {
 			t.Errorf("lookupServiceByAddress(%v) = %v, %v; want %v, %v", test.address, result, err, test.expected, test.err)
 		}
+	}
+}
+
+// TestIsValidKubeRouterServiceArtifactBindOnAllIP verifies that with nodeportBindOnAllIP set, a NodePort service is
+// validated against the caller-supplied local IP map (rather than re-enumerating interfaces).
+func TestIsValidKubeRouterServiceArtifactBindOnAllIP(t *testing.T) {
+	nsc := &NetworkServicesController{nodeportBindOnAllIP: true}
+	nsc.setServiceMap(map[string]*serviceInfo{
+		"service1": {clusterIPs: []string{"10.0.0.1"}, nodePort: 30000},
+	})
+
+	localIPs := map[v1.IPFamily][]net.IP{
+		v1.IPv4Protocol: {net.ParseIP("192.168.1.10")},
+	}
+
+	tests := []struct {
+		name     string
+		address  net.IP
+		port     int
+		expected bool
+	}{
+		{"nodeport on a local IP is valid", net.ParseIP("192.168.1.10"), 30000, true},
+		{"nodeport on a non-local IP is not valid", net.ParseIP("192.168.1.99"), 30000, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, _ := nsc.isValidKubeRouterServiceArtifact(test.address, test.port, localIPs)
+			if result != test.expected {
+				t.Errorf("isValidKubeRouterServiceArtifact(%v, %d) = %v; want %v",
+					test.address, test.port, result, test.expected)
+			}
+		})
 	}
 }

--- a/pkg/controllers/proxy/utils_test.go
+++ b/pkg/controllers/proxy/utils_test.go
@@ -259,35 +259,84 @@ func TestIsValidKubeRouterServiceArtifact(t *testing.T) {
 	}
 }
 
-// TestIsValidKubeRouterServiceArtifactBindOnAllIP verifies that with nodeportBindOnAllIP set, a NodePort service is
-// validated against the caller-supplied local IP map (rather than re-enumerating interfaces).
+// TestIsValidKubeRouterServiceArtifactBindOnAllIP checks NodePorts against the caller supplied local IP map
 func TestIsValidKubeRouterServiceArtifactBindOnAllIP(t *testing.T) {
-	nsc := &NetworkServicesController{nodeportBindOnAllIP: true}
+	// krNode is unused here, but set so that a bind-on-primary-IP case added later doesn't nil panic
+	krNode := &utils.LocalKRNode{
+		KRNode: utils.KRNode{
+			NodeName:  "node-1",
+			PrimaryIP: net.ParseIP("192.168.1.10"),
+		},
+	}
+	nsc := &NetworkServicesController{
+		krNode:              krNode,
+		nodeportBindOnAllIP: true,
+	}
 	nsc.setServiceMap(map[string]*serviceInfo{
 		"service1": {clusterIPs: []string{"10.0.0.1"}, nodePort: 30000},
 	})
 
+	// same shape that syncIpvsFirewall hands us
 	localIPs := map[v1.IPFamily][]net.IP{
 		v1.IPv4Protocol: {net.ParseIP("192.168.1.10")},
+		v1.IPv6Protocol: {net.ParseIP("2001:db8::1")},
 	}
 
 	tests := []struct {
 		name     string
 		address  net.IP
 		port     int
+		localIPs map[v1.IPFamily][]net.IP
 		expected bool
 	}{
-		{"nodeport on a local IP is valid", net.ParseIP("192.168.1.10"), 30000, true},
-		{"nodeport on a non-local IP is not valid", net.ParseIP("192.168.1.99"), 30000, false},
+		{"IPv4 nodeport on a local IP is valid", net.ParseIP("192.168.1.10"), 30000, localIPs, true},
+		{"IPv4 nodeport on a non-local IP is not valid", net.ParseIP("192.168.1.99"), 30000, localIPs, false},
+		{"IPv6 nodeport on a local IP is valid", net.ParseIP("2001:db8::1"), 30000, localIPs, true},
+		{"IPv6 nodeport on a non-local IP is not valid", net.ParseIP("2001:db8::99"), 30000, localIPs, false},
+		{"a nil local IP map matches nothing", net.ParseIP("192.168.1.10"), 30000, nil, false},
+		{"an empty local IP map matches nothing", net.ParseIP("2001:db8::1"), 30000,
+			map[v1.IPFamily][]net.IP{}, false},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, _ := nsc.isValidKubeRouterServiceArtifact(test.address, test.port, localIPs)
-			if result != test.expected {
-				t.Errorf("isValidKubeRouterServiceArtifact(%v, %d) = %v; want %v",
-					test.address, test.port, result, test.expected)
+			result, err := nsc.isValidKubeRouterServiceArtifact(test.address, test.port, test.localIPs)
+			assert.Equal(t, test.expected, result,
+				"unexpected validity for address %s on port %d", test.address, test.port)
+			if test.expected {
+				assert.NoError(t, err, "a service that was matched shouldn't also return an error")
+			} else {
+				assert.EqualError(t, err, fmt.Sprintf("service not found for address %s", test.address),
+					"an unmatched address should return a service not found error")
 			}
+		})
+	}
+}
+
+func TestHasAnyIPs(t *testing.T) {
+	tests := []struct {
+		name     string
+		ipMap    map[v1.IPFamily][]net.IP
+		expected bool
+	}{
+		{"nil map", nil, false},
+		{"empty map", map[v1.IPFamily][]net.IP{}, false},
+		{"both families present but empty",
+			map[v1.IPFamily][]net.IP{v1.IPv4Protocol: {}, v1.IPv6Protocol: {}}, false},
+		{"IPv4 only",
+			map[v1.IPFamily][]net.IP{v1.IPv4Protocol: {net.ParseIP("10.0.0.1")}, v1.IPv6Protocol: {}}, true},
+		{"IPv6 only",
+			map[v1.IPFamily][]net.IP{v1.IPv4Protocol: {}, v1.IPv6Protocol: {net.ParseIP("2001:db8::1")}}, true},
+		{"dual-stack",
+			map[v1.IPFamily][]net.IP{
+				v1.IPv4Protocol: {net.ParseIP("10.0.0.1")},
+				v1.IPv6Protocol: {net.ParseIP("2001:db8::1")},
+			}, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, hasAnyIPs(test.ipMap), "unexpected result for %v", test.ipMap)
 		})
 	}
 }


### PR DESCRIPTION
…ifact

syncIpvsFirewall already enumerates local addresses, so re-enumerating them per NodePort service inside the loop is redundant work leading to very long ipvs update time (measured up to 30 seconds). Pass the map in instead.


#### What type of PR is this?

bug

#### What this PR does / why we need it:

It seems syncIpvsFirewall (network_services_controller.go) calls getAllLocalIPs once, then calls `isValidKubeRouterServiceArtifact` for each ipvs service. `isValidKubeRouterServiceArtifact` itself calls getAllLocalIPs again.

In tests we found that this can lead to an increased failover time for our Kubernetes services. Each service is processed quickly, but a large number of services make the failover time unpredictable based on its spot in the queue.

This PR introduces passing down the addrsMap to avoid calling getAllLocalIPs per iteration.

#### Which issue(s) this PR is related to:
There is no related issue ticket. 

#### Was AI used during the creation of this PR?

* What tool was used: Claude
* To what extent was the tool used? It wrote the actual Golang code
* If drafted, how detailed of a plan did you create for the AI? Very detailed, including verification tests before and after. This was not an auto-accepted change. 
* Help us understand if a human was in the loop or not for this PR? Yes at all times.

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?

Yes, this is the before and after in a v1.32.0 Kubernetes environment. This test shows a postgresql database failover and its respective ipvs add timing. The delayed IPVS entry update/creation (depending on the externalTrafficPolicy) increases a sub second failover to up to 30 seconds.

>>> Before
` while true;do sleep 0.5;date;sudo ipvsadm -L -n | grep 10.20.149.16 -A1;done`

Source node (pod deleted at 17:55:28)
```
Tue Aug 11 17:55:27 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.0.96:5432             Masq    1      0          0         
Tue Aug 11 17:55:27 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.0.96:5432             Masq    1      0          0         
Tue Aug 11 17:55:28 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.0.96:5432             Masq    1      0          0         
Tue Aug 11 17:55:28 UTC 2026
Tue Aug 11 17:55:29 UTC 2026
Tue Aug 11 17:55:29 UTC 2026
Tue Aug 11 17:55:30 UTC 2026
Tue Aug 11 17:55:31 UTC 2026
Tue Aug 11 17:55:31 UTC 2026
```

Target node (service/endpointslice failover already happened sub second)
```
Tue Aug 11 17:55:53 UTC 2026
Tue Aug 11 17:55:54 UTC 2026
Tue Aug 11 17:55:55 UTC 2026
Tue Aug 11 17:55:55 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.2.248:5432            Masq    1      0          0         
Tue Aug 11 17:55:56 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.2.248:5432            Masq    1      0          0         
Tue Aug 11 17:55:56 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.2.248:5432            Masq    1      0          0    
```

Failover took 27 seconds.

>>>> After

source node
```
Tue Aug 11 18:07:38 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.2.248:5432            Masq    1      0          0         
Tue Aug 11 18:07:38 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.2.248:5432            Masq    1      0          0         
Tue Aug 11 18:07:39 UTC 2026
Tue Aug 11 18:07:39 UTC 2026
Tue Aug 11 18:07:40 UTC 2026
```

target node
```
Tue Aug 11 18:07:38 UTC 2026
Tue Aug 11 18:07:38 UTC 2026
Tue Aug 11 18:07:39 UTC 2026
Tue Aug 11 18:07:39 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.0.134:5432            Masq    1      0          0         
Tue Aug 11 18:07:40 UTC 2026
TCP  10.20.149.16:5432 rr
  -> 10.244.0.134:5432            Masq    1      0          0         
Tue Aug 11 18:07:40 UTC 2026
TCP  10.20.149.16:5432 rr
```

If there is more testing required, please let me know and I can reproduce this any time. I am running this fix in 4 Kubernetes clusters without any issues.

#### Does this PR introduce a breaking change?
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?
