### PR TITLE
Added monitor network policy

### DIFF
--- a/pkg/controllers/netpol/network_policy_controller.go
+++ b/pkg/controllers/netpol/network_policy_controller.go
@@ -126,6 +126,7 @@ type networkPolicyInfo struct {
 	name        string
 	namespace   string
 	podSelector labels.Selector
+	annotations map[string]string
 
 	// set of pods matching network policy spec podselector label selector
 	targetPods map[string]podInfo

--- a/pkg/controllers/netpol/network_policy_controller_test.go
+++ b/pkg/controllers/netpol/network_policy_controller_test.go
@@ -474,7 +474,7 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-C23KD7UE4TAT3Y5M -m comment --comment \"nsA/simple-egress egress any\" --dport 30000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+			expectedRule: "-A KUBE-NWPLCY-C23KD7UE4TAT3Y5M -m comment --comment \"nsA/simple-egress egress any\" --dport 30000 -j MARK --set-xmark 0x10000/0x50000 \n" +
 				"-A KUBE-NWPLCY-C23KD7UE4TAT3Y5M -m comment --comment \"nsA/simple-egress egress any\" --dport 30000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 		{
@@ -508,9 +508,9 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"nsA/simple-ingress-egress egress any\" --dport 30000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+			expectedRule: "-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"nsA/simple-ingress-egress egress any\" --dport 30000 -j MARK --set-xmark 0x10000/0x50000 \n" +
 				"-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"nsA/simple-ingress-egress egress any\" --dport 30000 -m mark --mark 0x10000/0x10000 -j RETURN \n" +
-				"-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"nsA/simple-ingress-egress ingress any\" --dport 37000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+				"-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"nsA/simple-ingress-egress ingress any\" --dport 37000 -j MARK --set-xmark 0x10000/0x50000 \n" +
 				"-A KUBE-NWPLCY-IDIX352DRLNY3D23 -m comment --comment \"nsA/simple-ingress-egress ingress any\" --dport 37000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 		{
@@ -540,9 +540,9 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"nsA/simple-egress-pr egress any\" --dport 30000:31000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+			expectedRule: "-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"nsA/simple-egress-pr egress any\" --dport 30000:31000 -j MARK --set-xmark 0x10000/0x50000 \n" +
 				"-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"nsA/simple-egress-pr egress any\" --dport 30000:31000 -m mark --mark 0x10000/0x10000 -j RETURN \n" +
-				"-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"nsA/simple-egress-pr egress any\" --dport 34000:35000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+				"-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"nsA/simple-egress-pr egress any\" --dport 34000:35000 -j MARK --set-xmark 0x10000/0x50000 \n" +
 				"-A KUBE-NWPLCY-2UTXQIFBI5TAPUCL -m comment --comment \"nsA/simple-egress-pr egress any\" --dport 34000:35000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 		{
@@ -568,7 +568,7 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-HHGHJNRMJN6UUDNA -m comment --comment \"nsA/sctp-egress egress any\" -p SCTP --dport 36000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+			expectedRule: "-A KUBE-NWPLCY-HHGHJNRMJN6UUDNA -m comment --comment \"nsA/sctp-egress egress any\" -p SCTP --dport 36000 -j MARK --set-xmark 0x10000/0x50000 \n" +
 				"-A KUBE-NWPLCY-HHGHJNRMJN6UUDNA -m comment --comment \"nsA/sctp-egress egress any\" -p SCTP --dport 36000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 		{
@@ -594,7 +594,7 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-BHQGYKZ6X5RBPUOB -m comment --comment \"nsA/sctp-ingress ingress any\" -p SCTP --dport 36000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+			expectedRule: "-A KUBE-NWPLCY-BHQGYKZ6X5RBPUOB -m comment --comment \"nsA/sctp-ingress ingress any\" -p SCTP --dport 36000 -j MARK --set-xmark 0x10000/0x50000 \n" +
 				"-A KUBE-NWPLCY-BHQGYKZ6X5RBPUOB -m comment --comment \"nsA/sctp-ingress ingress any\" -p SCTP --dport 36000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 		{
@@ -620,7 +620,7 @@ func TestNetworkPolicyBuilder(t *testing.T) {
 					},
 				},
 			},
-			expectedRule: "-A KUBE-NWPLCY-N5DQE4SCQ56JEMH7 -m comment --comment \"nsA/invalid-endport egress any\" --dport 34000 -j MARK --set-xmark 0x10000/0x10000 \n" +
+			expectedRule: "-A KUBE-NWPLCY-N5DQE4SCQ56JEMH7 -m comment --comment \"nsA/invalid-endport egress any\" --dport 34000 -j MARK --set-xmark 0x10000/0x50000 \n" +
 				"-A KUBE-NWPLCY-N5DQE4SCQ56JEMH7 -m comment --comment \"nsA/invalid-endport egress any\" --dport 34000 -m mark --mark 0x10000/0x10000 -j RETURN \n",
 		},
 	}

--- a/pkg/controllers/netpol/pod.go
+++ b/pkg/controllers/netpol/pod.go
@@ -109,7 +109,7 @@ func (npc *NetworkPolicyControllerBase) syncPodFirewallChains(networkPoliciesInf
 			// add rule to log the packets that will be dropped due to network policy enforcement
 			comment := "\"" + idComment(pod.namespace, pod.name, cmtLogDrop) + "\""
 			args := []string{"-A", podFwChainName, "-m", "comment", "--comment", comment,
-				"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "NFLOG",
+				"-m", "mark", "!", "--mark", "0x10000/0x50000", "-j", "NFLOG",
 				"--nflog-group", "100", "-m", "limit", "--limit", "10/minute", "--limit-burst", "10", "\n"}
 			// This used to be AppendUnique when we were using iptables directly, this checks to make sure we didn't drop
 			// unmarked for this chain already
@@ -125,7 +125,7 @@ func (npc *NetworkPolicyControllerBase) syncPodFirewallChains(networkPoliciesInf
 			filterTableRules.WriteString(strings.Join(args, " "))
 
 			// reset mark to let traffic pass through rest of the chains
-			args = []string{"-A", podFwChainName, "-j", "MARK", "--set-mark", "0/0x10000", "\n"}
+			args = []string{"-A", podFwChainName, "-j", "MARK", "--set-mark", "0/0x50000", "\n"}
 			filterTableRules.WriteString(strings.Join(args, " "))
 		}
 	}

--- a/pkg/controllers/netpol/policy.go
+++ b/pkg/controllers/netpol/policy.go
@@ -149,6 +149,11 @@ func (npc *NetworkPolicyControllerIptables) syncNetworkPolicyChains(networkPolic
 				}
 				activePolicyIPSets[targetSourcePodIPSetName] = true
 			}
+			if isMonitorPolicy(policy) {
+				monitorRule := []string{"-A", policyChainName, "-m", "comment", "--comment", "\"rule to mark to monitor traffic\"",
+					"-m", "mark", "!", "--mark", "0x10000/0x10000", "-j", "MARK", "--set-xmark", "0x50000/0x50000", "\n"}
+				npc.filterTableRules[ipFamily].WriteString(strings.Join(monitorRule, " "))
+			}
 		}
 	}
 
@@ -482,7 +487,7 @@ func (npc *NetworkPolicyControllerIptables) appendRuleToPolicyChain(
 	}
 
 	//nolint:gocritic // we want to append to a separate array here so that we can re-use args below
-	markArgs := append(args, "-j", "MARK", "--set-xmark", "0x10000/0x10000", "\n")
+	markArgs := append(args, "-j", "MARK", "--set-xmark", "0x10000/0x50000", "\n")
 	npc.filterTableRules[ipFamily].WriteString(strings.Join(markArgs, " "))
 
 	args = append(args, "-m", "mark", "--mark", "0x10000/0x10000", "-j", "RETURN", "\n")
@@ -509,6 +514,7 @@ func (npc *NetworkPolicyControllerBase) buildNetworkPoliciesInfo() ([]networkPol
 			namespace:   policy.Namespace,
 			podSelector: podSelector,
 			policyType:  kubeIngressPolicyType,
+			annotations: policy.Annotations,
 		}
 
 		ingressType, egressType := false, false
@@ -959,4 +965,8 @@ func policyRulePortsHasNamedPort(npPorts []networking.NetworkPolicyPort) bool {
 		}
 	}
 	return false
+}
+
+func isMonitorPolicy(policy networkPolicyInfo) bool {
+	return policy.annotations["kube-router.io/network-policy.monitor"] == "true"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

#### What type of PR is this?
<!--
Please choose one of the following kinds:
-->
feature


#### What this PR does / why we need it:
This PR is an initial implementation of #2123 in case a policy is defined with the annotation `kube-router.io/network-policy.monitor: "true"` the packet is marked with an additional mark `0x40000` and logged as it was dropped but even if the mark `0x10000` is set. Right now it works for iptables.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->
#2123 
#### Was AI used during the creation of this PR?
<!--
We are not against AI, but in the current era of tech AI is being used more and more to help upstream projects and it is
useful for the maintainers of this project to understand if AI was used and to what extent it was used. Please see our
AI policy: https://github.com/cloudnativelabs/kube-router/blob/master/AI_POLICY.md

If no AI was used during the generation of this PR, please remove the following content and simply put "No" for this
section.
-->

* What tool was used: Copilot <!-- One of Claude, Codex, Copilot, etc. -->
* To what extent was the tool used? To draft some part of the code<!-- Anything from line autofill to it drafted the entire PR or anything imbetween -->
* If drafted, how detailed of a plan did you create for the AI? Part of the code human written and used AI to help <!-- Very detailed (multiple paragraphs) to not at all detailed (I gave it a single line prompt) -->
* Help us understand if a human was in the loop or not for this PR? Yes

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->
Tested with different policies with and without the annotation
#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

