### PR TITLE
Modernize daemonset manifests

### DIFF
--- a/cni/10-kuberouter.conf
+++ b/cni/10-kuberouter.conf
@@ -1,5 +1,5 @@
 {
-    "cniVersion": "0.3.0",
+    "cniVersion": "1.0.0",
     "name":"mynet",
     "type":"bridge",
     "bridge":"kube-bridge",

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -157,6 +157,10 @@ spec:
           mountPath: /opt
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -197,7 +197,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -206,7 +205,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - list
       - get
@@ -218,14 +216,6 @@ rules:
     verbs:
       - list
       - get
-      - watch
-  - apiGroups:
-    - extensions
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - "coordination.k8s.io"

--- a/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-all-features-advertise-routes.yaml
@@ -91,12 +91,19 @@ spec:
               fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -153,6 +153,10 @@ spec:
           mountPath: /opt
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -87,12 +87,19 @@ spec:
               fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/generic-kuberouter-all-features.yaml
+++ b/daemonset/generic-kuberouter-all-features.yaml
@@ -193,7 +193,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -202,7 +201,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - list
       - get
@@ -214,14 +212,6 @@ rules:
     verbs:
       - list
       - get
-      - watch
-  - apiGroups:
-    - extensions
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - "coordination.k8s.io"

--- a/daemonset/generic-kuberouter-only-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-only-advertise-routes.yaml
@@ -96,7 +96,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -105,7 +104,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - list
       - get
@@ -117,14 +115,6 @@ rules:
     verbs:
       - list
       - get
-      - watch
-  - apiGroups:
-    - extensions
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - "coordination.k8s.io"

--- a/daemonset/generic-kuberouter-only-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-only-advertise-routes.yaml
@@ -72,6 +72,10 @@ spec:
           readOnly: false
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/generic-kuberouter-only-advertise-routes.yaml
+++ b/daemonset/generic-kuberouter-only-advertise-routes.yaml
@@ -47,12 +47,19 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -66,12 +66,19 @@ spec:
               fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -122,6 +122,10 @@ spec:
           mountPath: /opt
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/generic-kuberouter.yaml
+++ b/daemonset/generic-kuberouter.yaml
@@ -159,7 +159,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -168,7 +167,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - list
       - get
@@ -180,14 +178,6 @@ rules:
     verbs:
       - list
       - get
-      - watch
-  - apiGroups:
-    - extensions
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - "coordination.k8s.io"

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -137,6 +137,8 @@ spec:
       - name: kubeconfig
         hostPath:
           path: /var/lib/kube-router/kubeconfig
+          # Without an explicit type, kubelet creates a directory here when the kubeconfig is missing
+          type: File
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -41,6 +41,7 @@ spec:
         k8s-app: kube-router
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: kube-router
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
@@ -49,7 +50,6 @@ spec:
           - "--run-firewall=true"
           - "--run-service-proxy=true"
           - "--bgp-graceful-restart=true"
-          - "--kubeconfig=/var/lib/kube-router/kubeconfig"
           - "--advertise-cluster-ip=true"
           - "--cluster-asn=64512"
           - "--peer-router-ips=192.168.1.99"
@@ -62,6 +62,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
         # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
@@ -83,9 +87,6 @@ spec:
           readOnly: true
         - name: cni-conf-dir
           mountPath: /etc/cni/net.d
-        - name: kubeconfig
-          mountPath: /var/lib/kube-router/kubeconfig
-          readOnly: true
         - name: xtables-lock
           mountPath: /run/xtables.lock
           readOnly: false
@@ -134,11 +135,6 @@ spec:
       - name: kube-router-cfg
         configMap:
           name: kube-router-cfg
-      - name: kubeconfig
-        hostPath:
-          path: /var/lib/kube-router/kubeconfig
-          # Without an explicit type, kubelet creates a directory here when the kubeconfig is missing
-          type: File
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
@@ -146,3 +142,72 @@ spec:
       - name: host-opt
         hostPath:
           path: /opt
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - namespaces
+      - pods
+      - services
+      - nodes
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+    - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router
+subjects:
+- kind: ServiceAccount
+  name: kube-router
+  namespace: kube-system

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -81,6 +81,10 @@ spec:
             port: 20244
           periodSeconds: 3
           failureThreshold: 3
+        resources:
+          requests:
+            cpu: 250m
+            memory: 250Mi
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules
@@ -118,6 +122,10 @@ spec:
           mountPath: /opt
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
+++ b/daemonset/kube-router-all-service-daemonset-advertise-routes.yaml
@@ -64,12 +64,19 @@ spec:
               fieldPath: spec.nodeName
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -133,6 +133,8 @@ spec:
       - name: kubeconfig
         hostPath:
           path: /var/lib/kube-router/kubeconfig
+          # Without an explicit type, kubelet creates a directory here when the kubeconfig is missing
+          type: File
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -77,6 +77,10 @@ spec:
             port: 20244
           periodSeconds: 3
           failureThreshold: 3
+        resources:
+          requests:
+            cpu: 250m
+            memory: 250Mi
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules
@@ -114,6 +118,10 @@ spec:
           mountPath: /opt
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -60,12 +60,19 @@ spec:
               fieldPath: spec.nodeName
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules

--- a/daemonset/kube-router-all-service-daemonset.yaml
+++ b/daemonset/kube-router-all-service-daemonset.yaml
@@ -41,6 +41,7 @@ spec:
         k8s-app: kube-router
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: kube-router
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
@@ -49,7 +50,6 @@ spec:
           - "--run-firewall=true"
           - "--run-service-proxy=true"
           - "--bgp-graceful-restart=true"
-          - "--kubeconfig=/var/lib/kube-router/kubeconfig"
         securityContext:
           privileged: true
         imagePullPolicy: Always
@@ -58,6 +58,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
         # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
@@ -79,9 +83,6 @@ spec:
           readOnly: true
         - name: cni-conf-dir
           mountPath: /etc/cni/net.d
-        - name: kubeconfig
-          mountPath: /var/lib/kube-router/kubeconfig
-          readOnly: true
         - name: xtables-lock
           mountPath: /run/xtables.lock
           readOnly: false
@@ -130,11 +131,6 @@ spec:
       - name: kube-router-cfg
         configMap:
           name: kube-router-cfg
-      - name: kubeconfig
-        hostPath:
-          path: /var/lib/kube-router/kubeconfig
-          # Without an explicit type, kubelet creates a directory here when the kubeconfig is missing
-          type: File
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
@@ -142,3 +138,72 @@ spec:
       - name: host-opt
         hostPath:
           path: /opt
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - namespaces
+      - pods
+      - services
+      - nodes
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+    - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router
+subjects:
+- kind: ServiceAccount
+  name: kube-router
+  namespace: kube-system

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -1,29 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kube-router-cfg
-  namespace: kube-system
-  labels:
-    tier: node
-    k8s-app: kube-router
-data:
-  cni-conf.json: |
-    {
-       "cniVersion":"0.3.0",
-       "name":"mynet",
-       "plugins":[
-          {
-             "name":"kubernetes",
-             "type":"bridge",
-             "bridge":"kube-bridge",
-             "isDefaultGateway":true,
-             "ipam":{
-                "type":"host-local"
-             }
-          }
-       ]
-    }
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -41,6 +15,7 @@ spec:
         k8s-app: kube-router
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: kube-router
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
@@ -48,7 +23,8 @@ spec:
           - "--run-router=false"
           - "--run-firewall=true"
           - "--run-service-proxy=false"
-          - "--kubeconfig=/var/lib/kube-router/kubeconfig"
+          # This runs alongside another CNI, so kube-router must never write a CNI config
+          - "--enable-cni=false"
         securityContext:
           privileged: true
         imagePullPolicy: Always
@@ -57,8 +33,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: KUBE_ROUTER_CNI_CONF_FILE
-          value: /etc/cni/net.d/10-kuberouter.conflist
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
         startupProbe:
           httpGet:
@@ -76,40 +54,9 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
           readOnly: true
-        - name: cni-conf-dir
-          mountPath: /etc/cni/net.d
-        - name: kubeconfig
-          mountPath: /var/lib/kube-router/kubeconfig
-          readOnly: true
         - name: xtables-lock
           mountPath: /run/xtables.lock
           readOnly: false
-      initContainers:
-      - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router
-        imagePullPolicy: Always
-        command:
-        - /bin/sh
-        - -c
-        - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
-            if [ -f /etc/cni/net.d/*.conf ]; then
-              rm -f /etc/cni/net.d/*.conf;
-            fi;
-            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
-            cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
-          fi;
-          if [ -x /usr/local/bin/cni-install ]; then
-            /usr/local/bin/cni-install;
-          fi;
-        volumeMounts:
-        - name: cni-conf-dir
-          mountPath: /etc/cni/net.d
-        - name: kube-router-cfg
-          mountPath: /etc/kube-router
-        - name: host-opt
-          mountPath: /opt
       hostNetwork: true
       hostPID: true
       tolerations:
@@ -123,21 +70,76 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
-      - name: cni-conf-dir
-        hostPath:
-          path: /etc/cni/net.d
-      - name: kube-router-cfg
-        configMap:
-          name: kube-router-cfg
-      - name: kubeconfig
-        hostPath:
-          path: /var/lib/kube-router/kubeconfig
-          # Without an explicit type, kubelet creates a directory here when the kubeconfig is missing
-          type: File
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
-      - name: host-opt
-        hostPath:
-          path: /opt
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - namespaces
+      - pods
+      - services
+      - nodes
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+    - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router
+subjects:
+- kind: ServiceAccount
+  name: kube-router
+  namespace: kube-system

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -132,6 +132,8 @@ spec:
       - name: kubeconfig
         hostPath:
           path: /var/lib/kube-router/kubeconfig
+          # Without an explicit type, kubelet creates a directory here when the kubeconfig is missing
+          type: File
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -59,12 +59,19 @@ spec:
               fieldPath: spec.nodeName
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules

--- a/daemonset/kube-router-firewall-daemonset.yaml
+++ b/daemonset/kube-router-firewall-daemonset.yaml
@@ -50,6 +50,10 @@ spec:
             port: 20244
           periodSeconds: 3
           failureThreshold: 3
+        resources:
+          requests:
+            cpu: 250m
+            memory: 250Mi
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules
@@ -59,6 +63,10 @@ spec:
           readOnly: false
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -132,6 +132,8 @@ spec:
       - name: kubeconfig
         hostPath:
           path: /var/lib/kube-router/kubeconfig
+          # Without an explicit type, kubelet creates a directory here when the kubeconfig is missing
+          type: File
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -59,12 +59,19 @@ spec:
               fieldPath: spec.nodeName
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -1,29 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: kube-router-cfg
-  namespace: kube-system
-  labels:
-    tier: node
-    k8s-app: kube-router
-data:
-  cni-conf.json: |
-    {
-       "cniVersion":"0.3.0",
-       "name":"mynet",
-       "plugins":[
-          {
-             "name":"kubernetes",
-             "type":"bridge",
-             "bridge":"kube-bridge",
-             "isDefaultGateway":true,
-             "ipam":{
-                "type":"host-local"
-             }
-          }
-       ]
-    }
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -41,6 +15,7 @@ spec:
         k8s-app: kube-router
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: kube-router
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
@@ -48,7 +23,8 @@ spec:
           - "--run-router=false"
           - "--run-firewall=false"
           - "--run-service-proxy=true"
-          - "--kubeconfig=/var/lib/kube-router/kubeconfig"
+          # This runs alongside another CNI, so kube-router must never write a CNI config
+          - "--enable-cni=false"
         securityContext:
           privileged: true
         imagePullPolicy: Always
@@ -57,8 +33,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: KUBE_ROUTER_CNI_CONF_FILE
-          value: /etc/cni/net.d/10-kuberouter.conflist
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
         startupProbe:
           httpGet:
@@ -76,40 +54,9 @@ spec:
         - name: lib-modules
           mountPath: /lib/modules
           readOnly: true
-        - name: cni-conf-dir
-          mountPath: /etc/cni/net.d
-        - name: kubeconfig
-          mountPath: /var/lib/kube-router/kubeconfig
-          readOnly: true
         - name: xtables-lock
           mountPath: /run/xtables.lock
           readOnly: false
-      initContainers:
-      - name: install-cni
-        image: docker.io/cloudnativelabs/kube-router
-        imagePullPolicy: Always
-        command:
-        - /bin/sh
-        - -c
-        - set -e -x;
-          if [ ! -f /etc/cni/net.d/10-kuberouter.conflist ]; then
-            if [ -f /etc/cni/net.d/*.conf ]; then
-              rm -f /etc/cni/net.d/*.conf;
-            fi;
-            TMP=/etc/cni/net.d/.tmp-kuberouter-cfg;
-            cp /etc/kube-router/cni-conf.json ${TMP};
-            mv ${TMP} /etc/cni/net.d/10-kuberouter.conflist;
-          fi;
-          if [ -x /usr/local/bin/cni-install ]; then
-            /usr/local/bin/cni-install;
-          fi;
-        volumeMounts:
-        - name: cni-conf-dir
-          mountPath: /etc/cni/net.d
-        - name: kube-router-cfg
-          mountPath: /etc/kube-router
-        - name: host-opt
-          mountPath: /opt
       hostNetwork: true
       hostPID: true
       tolerations:
@@ -123,21 +70,76 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
-      - name: cni-conf-dir
-        hostPath:
-          path: /etc/cni/net.d
-      - name: kube-router-cfg
-        configMap:
-          name: kube-router-cfg
-      - name: kubeconfig
-        hostPath:
-          path: /var/lib/kube-router/kubeconfig
-          # Without an explicit type, kubelet creates a directory here when the kubeconfig is missing
-          type: File
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
-      - name: host-opt
-        hostPath:
-          path: /opt
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-router
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - namespaces
+      - pods
+      - services
+      - nodes
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+    - "networking.k8s.io"
+    resources:
+      - networkpolicies
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - update
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kube-router
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-router
+subjects:
+- kind: ServiceAccount
+  name: kube-router
+  namespace: kube-system

--- a/daemonset/kube-router-proxy-daemonset.yaml
+++ b/daemonset/kube-router-proxy-daemonset.yaml
@@ -50,6 +50,10 @@ spec:
             port: 20244
           periodSeconds: 3
           failureThreshold: 3
+        resources:
+          requests:
+            cpu: 250m
+            memory: 250Mi
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules
@@ -59,6 +63,10 @@ spec:
           readOnly: false
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -185,7 +185,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -194,7 +193,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - list
       - get
@@ -206,14 +204,6 @@ rules:
     verbs:
       - list
       - get
-      - watch
-  - apiGroups:
-    - extensions
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - "coordination.k8s.io"

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -69,12 +69,19 @@ spec:
               fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-dsr.yaml
@@ -46,7 +46,6 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
-      serviceAccount: kube-router
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
@@ -135,6 +134,10 @@ spec:
       hostNetwork: true
       hostIPC: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -53,7 +53,6 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
-      serviceAccount: kube-router
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
@@ -134,6 +133,10 @@ spec:
           mountPath: /opt
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -75,12 +75,19 @@ spec:
               fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features-hostport.yaml
@@ -175,7 +175,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -184,7 +183,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - list
       - get
@@ -196,14 +194,6 @@ rules:
     verbs:
       - list
       - get
-      - watch
-  - apiGroups:
-    - extensions
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - "coordination.k8s.io"

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -46,7 +46,6 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
-      serviceAccount: kube-router
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
@@ -127,6 +126,10 @@ spec:
           mountPath: /opt
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -68,12 +68,19 @@ spec:
               fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/kubeadm-kuberouter-all-features.yaml
+++ b/daemonset/kubeadm-kuberouter-all-features.yaml
@@ -168,7 +168,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -177,7 +176,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - list
       - get
@@ -189,14 +187,6 @@ rules:
     verbs:
       - list
       - get
-      - watch
-  - apiGroups:
-    - extensions
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - "coordination.k8s.io"

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -9,7 +9,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -157,7 +157,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kube-router
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -166,7 +165,6 @@ rules:
       - pods
       - services
       - nodes
-      - endpoints
     verbs:
       - list
       - get
@@ -178,14 +176,6 @@ rules:
     verbs:
       - list
       - get
-      - watch
-  - apiGroups:
-    - extensions
-    resources:
-      - networkpolicies
-    verbs:
-      - get
-      - list
       - watch
   - apiGroups:
       - "coordination.k8s.io"

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -66,12 +66,19 @@ spec:
               fieldPath: metadata.name
         - name: KUBE_ROUTER_CNI_CONF_FILE
           value: /etc/cni/net.d/10-kuberouter.conflist
+        # Cache sync can take up to --cache-sync-timeout (default 1m), so gate liveness behind a startup probe
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 20244
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: /healthz
             port: 20244
-          initialDelaySeconds: 10
           periodSeconds: 3
+          failureThreshold: 3
         resources:
           requests:
             cpu: 250m

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -45,7 +45,6 @@ spec:
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: kube-router
-      serviceAccount: kube-router
       containers:
       - name: kube-router
         image: docker.io/cloudnativelabs/kube-router
@@ -122,6 +121,10 @@ spec:
           mountPath: /opt
       hostNetwork: true
       hostPID: true
+      # Inherit the host resolver: we resolve no hostnames, and cluster DNS would depend on our own service proxy
+      dnsPolicy: Default
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/daemonset/kubeadm-kuberouter.yaml
+++ b/daemonset/kubeadm-kuberouter.yaml
@@ -91,9 +91,6 @@ spec:
           readOnly: true
         - name: cni-conf-dir
           mountPath: /etc/cni/net.d
-        - name: kubeconfig
-          mountPath: /var/lib/kube-router/kubeconfig
-          readOnly: true
         - name: xtables-lock
           mountPath: /run/xtables.lock
           readOnly: false
@@ -142,9 +139,6 @@ spec:
       - name: kube-router-cfg
         configMap:
           name: kube-router-cfg
-      - name: kubeconfig
-        hostPath:
-          path: /var/lib/kube-router/kubeconfig
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock

--- a/docs/ipv6.md
+++ b/docs/ipv6.md
@@ -141,7 +141,7 @@ A CNI configuration with multiple ranges will typically look something like the 
 
 ```json
 {
-  "cniVersion": "0.3.0",
+  "cniVersion": "1.0.0",
   "name": "mynet",
   "plugins": [
     {

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -594,7 +594,7 @@ If you would like to use `HostPort` functionality below changes are required in 
 
 ```json
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {
@@ -645,7 +645,7 @@ attempt to configure MTU. However you can choose the right MTU and set in the `c
 ```json
   cni-conf.json: |
     {
-       "cniVersion":"0.3.0",
+       "cniVersion":"1.0.0",
        "name":"mynet",
        "plugins":[
           {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/cloudnativelabs/kube-router/blob/master/CONTRIBUTING.md and developer guide https://github.com/cloudnativelabs/kube-router/blob/master/docs/developing.md
2. Ensure you have added or ran the appropriate tests for your PR: `make test` & `make lint`
3. If the PR is unfinished, please mark it as a "Draft" when opening it
-->

FYI @catherinetcai / @mrueg 

#### What type of PR is this?

<!--
Please choose one of the following kinds:
-->
bug
cleanup

#### What this PR does / why we need it:

Modernizes kube-router's manifests and corrects some issues that have been around for a bit:

* Upgrades CNI version from 0.3.0 -> 1.0.0
* Adds a ServiceAccount with RBAC to legacy manifests instead of relying on users to mount in their kube-config
* Differentiate the liveness probe from the startup probe to give more time for kube-router to cache from the API server
* Add a File to specification to the hostPath so that kubelet doesn't incorrectly create a directory when the file doesn't exist
* Drops RBAC to APIs that are deprecated or no longer used (endpoints / networkpolicies as extension instead of the networking api group)

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
-->
None

#### Was AI used during the creation of this PR?
<!--
We are not against AI, but in the current era of tech AI is being used more and more to help upstream projects and it is
useful for the maintainers of this project to understand if AI was used and to what extent it was used. Please see our
AI policy: https://github.com/cloudnativelabs/kube-router/blob/master/AI_POLICY.md

If no AI was used during the generation of this PR, please remove the following content and simply put "No" for this
section.
-->

* What tool was used: Claude
* To what extent was the tool used? To discover unused / old declarations
* If drafted, how detailed of a plan did you create for the AI? N/A
* Help us understand if a human was in the loop or not for this PR? Yes

#### What, if any, amount of integration testing was done with this change in a Kubernetes environment?
<!--
It is helpful for us to understand how much integration testing was done for this work. kube-router has extensive unit
tests, but those only go so far for catching bugs that might turn up in an environment.

Please let us know if you have done any tests beyond the unit tests that are required for validating your PR before
submission. Responses for this section can range from: "I haven't done any integration tests" to "I deployed it in my
environment of X number of nodes and exercised the functionality Y ways" to "I ran the entire Kubernetes Network
validation suite against this change"
-->
None

#### Does this PR introduce a breaking change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Anything else the reviewer should know that wasn't already covered?

